### PR TITLE
suppress org and vdc fields if provider has the same values already

### DIFF
--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -85,9 +85,15 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_vm_internal_disk":   resourceVmInternalDisk(),      // 2.7
 }
 
+var (
+	// providerOrg is populated with global org value (set in provider) during authentication
+	providerOrg string
+	// providerVdc is populated with global org value (set in provider) during authentication
+	providerVdc string
+)
+
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {
-
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"user": &schema.Schema{
@@ -204,6 +210,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetryTimeout: maxRetryTimeout,
 		InsecureFlag:    d.Get("allow_unverified_ssl").(bool),
 	}
+
+	// Store default org and vdc in global scope
+	providerOrg = d.Get("org").(string)
+	providerVdc = d.Get("vdc").(string)
+
 	// If the provider includes logging directives,
 	// it will activate logging from upstream go-vcloud-director
 	logging := d.Get("logging").(bool)

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -25,12 +25,6 @@ func resourceVcdVApp() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "A name for the vApp, unique withing the VDC",
-			},
 			"org": {
 				Type:     schema.TypeString,
 				Required: false,
@@ -38,12 +32,20 @@ func resourceVcdVApp() *schema.Resource {
 				ForceNew: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
+				DiffSuppressFunc: suppressProviderFieldValue("org"),
 			},
 			"vdc": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Description:      "The name of VDC to use, optional if defined at provider level",
+				DiffSuppressFunc: suppressProviderFieldValue("vdc"),
+			},
+			"name": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				ForceNew:    true,
-				Description: "The name of VDC to use, optional if defined at provider level",
+				Description: "A name for the vApp, unique withing the VDC",
 			},
 			"template_name": {
 				Type:        schema.TypeString,

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -3,12 +3,13 @@ package vcd
 import (
 	"bytes"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"net"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -28,6 +29,21 @@ func resourceVcdVAppVm() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+				DiffSuppressFunc: suppressProviderFieldValue("org"),
+			},
+			"vdc": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         true,
+				Description:      "The name of VDC to use, optional if defined at provider level",
+				DiffSuppressFunc: suppressProviderFieldValue("vdc"),
+			},
 			"vapp_name": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
@@ -45,19 +61,6 @@ func resourceVcdVAppVm() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Computer name to assign to this virtual machine",
-			},
-			"org": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Description: "The name of organization to use, optional if defined at provider " +
-					"level. Useful when connected as sysadmin working across different organizations",
-			},
-			"vdc": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Description: "The name of VDC to use, optional if defined at provider level",
 			},
 			"template_name": &schema.Schema{
 				Type:        schema.TypeString,


### PR DESCRIPTION
This is a PoC for a solution which is described better in https://github.com/terraform-providers/terraform-provider-vcd/pull/449

# Draft state
This is just a PoC of method for handling changes/settings between _provider_ and _resource_ _org_ and _vdc_ fields. If this method proves to be the best one - then all resources must be aligned to use it (this PR only patches vcd_vapp and vcd_vapp_vm). 