### PR TITLE
Remove redundant terraform block from inline tests

### DIFF
--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -207,15 +207,6 @@ const (
 # file {{.CallerFileName}}
 #
 
-terraform {
-  required_providers {
-    vcd = {
-      source = "vmware/vcd"
-    }
-  }
-  # required_version = ">= 0.13"
-}
-
 provider "vcd" {
   user                 = "{{.User}}"
   password             = "{{.Password}}"


### PR DESCRIPTION
The `terraform {}` block is needed to run HCL scripts with terraform 0.13.

However, should block was also added to the inline tests, and was failing tests when running with `vcd-add-provider` flag.

The binary tests already added such block to the files that missed it, so the block was redundant in the first place.

`test-binary.sh` was updated to add the block to validation tests as well as binary tests.