### PR TITLE
Add support for bearer token

### DIFF
--- a/.changes/v3.1.0/590-improvements.md
+++ b/.changes/v3.1.0/590-improvements.md
@@ -1,2 +1,2 @@
 * Provider: add support for bearer tokens in addition to authorization tokens [GH-590]
-* Provider: enable fallback connection using `/cloudapi/1.0.0/sessions/provider` when `/api/sessions` was disabled [GH-590]
+* Provider: automatically use `/cloudapi/1.0.0/sessions/provider` when `/api/sessions` is disabled [GH-590]

--- a/.changes/v3.1.0/590-improvements.md
+++ b/.changes/v3.1.0/590-improvements.md
@@ -1,1 +1,2 @@
-* Provider: add support for bearer tokens in addition to authorization tokens
+* Provider: add support for bearer tokens in addition to authorization tokens [GH-590]
+* Provider: enable fallback connection using `/cloudapi/1.0.0/sessions/provider` when `/api/sessions` was disabled [GH-590]

--- a/.changes/v3.1.0/590-improvements.md
+++ b/.changes/v3.1.0/590-improvements.md
@@ -1,0 +1,1 @@
+* Provider: add support for bearer tokens in addition to authorization tokens

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,5 @@ require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
-	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.1
+	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.2
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.1.0
 	github.com/vmware/go-vcloud-director/v2 v2.9.0
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director 6166a2c7a616f66d817e49e32527f861d2079b9d

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110100614-6166a2c7a616
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14 h1:ZUZIq4xSsTL5ocUOnvmwPcQMO83pwp/NGDHgiah245o=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -314,6 +312,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.2 h1:8okNiJPAe+UP9mQcJZGQFwyI6H4ZkHd/sBknfca6T5c=
+github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.2/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,6 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.9.0 h1:6HxKdIwbRtTkw+up829ZRCTaC1EyuAqSm5jRnd9zHQ4=
-github.com/vmware/go-vcloud-director/v2 v2.9.0/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110100614-6166a2c7a616 h1:9LfD5Kq6utBaBvAnIb9VSOSR8XhmJr3NDOfjFm0ZvPg=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110100614-6166a2c7a616/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14 h1:ZUZIq4xSsTL5ocUOnvmwPcQMO83pwp/NGDHgiah245o=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20201110143305-699bd00cdf14/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This script will connect to the vCD using username and password,
-# and show the header that contains an authorization token.
+# and show the headers that contain a bearer or authorization token.
 #
 user=$1
 password=$2
@@ -19,7 +19,24 @@ curl -I -k --header "Accept: application/*;version=32.0" \
     --header "Authorization: Basic $auth" \
     --request POST https://$IP/api/sessions
 
-# If successful, the output of this command will include a line like the following
-# x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
+# If successful, the output of this command will include lines like the following
+# X-VCLOUD-AUTHORIZATION: 08a321735de84f1d9ec80c3b3e18fa8b
+# X-VMWARE-VCLOUD-ACCESS-TOKEN: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbmlzdHJhdG9yI[562 more characters]
 #
-# The string after `x-vcloud-authorization:` is the token.
+# The string after `X-VCLOUD-AUTHORIZATION:` is the old (deprecated) token.
+# The 612-character string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
+
+# For VCD version 10.0+, you can use one of the following commands instead.
+
+# PROVIDER:
+# curl -I -k --header "Accept: application/*;version=33.0" \
+#    --header "Authorization: Basic $auth" \
+#    --request POST https://$IP/cloudapi/1.0.0/sessions/provider
+
+# TENANT
+# curl -I -k --header "Accept: application/*;version=33.0" \
+#    --header "Authorization: Basic $auth" \
+#    --request POST https://$IP/cloudapi/1.0.0/sessions
+#
+# The cloudapi requests will only return the bearer token
+

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -527,7 +527,7 @@ function run_with_recover {
                 run terraform destroy -auto-approve
                 # if 'run' doesn't produce an error, we continue the tests,
                 # leaving behind the name of the test failed in failed_tests.txt
-                # otherwise, the test is definitely aborted
+                # otherwise, the test is definitely terminated
                 ;;
 
             *)
@@ -738,7 +738,7 @@ do
                 # During upgrades, 'destroy' runs with the latest plugin
                 if [ ! -f terraform.tfstate ]
                 then
-                    echo "terraform.tfstate not found - aborting"
+                    echo "terraform.tfstate not found - exiting"
                     exit 1
                 fi
                 [ -n "$upgrading" ] && run terraform version

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -388,7 +388,11 @@ func (cli *VCDClient) GetEdgeGatewayFromResource(d *schema.ResourceData, edgeGat
 func ProviderAuthenticate(client *govcd.VCDClient, user, password, token, org string) error {
 	var err error
 	if token != "" {
-		err = client.SetToken(org, govcd.AuthorizationHeader, token)
+		if len(token) > 32 {
+			err = client.SetToken(org, govcd.BearerTokenHeader, token)
+		} else {
+			err = client.SetToken(org, govcd.AuthorizationHeader, token)
+		}
 		if err != nil {
 			err = fmt.Errorf("error during token-based authentication: %s", err)
 		}

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -674,11 +674,11 @@ func createSuiteCatalogAndItem(config TestConfig) {
 	ovaFilePath := getCurrentDir() + "/../test-resources/" + config.Ova.OvaTestFileName
 
 	if config.Ova.OvaTestFileName == "" && testConfig.VCD.Catalog.CatalogItem == "" {
-		panic(fmt.Errorf("ovaTestFileName isn't configured. Tests aborted\n"))
+		panic(fmt.Errorf("ovaTestFileName isn't configured. Tests terminated\n"))
 	}
 
 	if config.Ova.OvaDownloadUrl == "" && testConfig.VCD.Catalog.CatalogItem == "" {
-		panic(fmt.Errorf("ovaDownloadUrl isn't configured. Tests aborted\n"))
+		panic(fmt.Errorf("ovaDownloadUrl isn't configured. Tests terminated\n"))
 	} else if testConfig.VCD.Catalog.CatalogItem == "" {
 		fmt.Printf("Downloading OVA. File will be saved as: %s\n", ovaFilePath)
 

--- a/vcd/terraform_binary_test.go
+++ b/vcd/terraform_binary_test.go
@@ -164,7 +164,7 @@ func TestCustomTemplates(t *testing.T) {
 
 		reHasProvider := regexp.MustCompile(`(?m)^\s*provider\s+"`)
 
-		// If there is already a provider in the template, we abort
+		// If there is already a provider in the template, we exit
 		if reHasProvider.MatchString(templateText) {
 			fmt.Printf("File %s has already a provider: remove it and try again\n", sourceFile)
 			fmt.Println("The provider will be generated using data from configuration file")

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -135,7 +135,7 @@ resource "vcd_network_routed" "net2" {
 }
 ```
 
-## Connecting with authorization token
+## Connecting with authorization or bearer token
 
 You can connect using an authorization token instead of username and password.
 
@@ -181,14 +181,20 @@ curl -I -k --header "Accept: application/*;version=32.0" \
     --request POST https://$IP/api/sessions
 ```
 
-If successful, the output of this command will include a line like the following
-```
-x-vcloud-authorization: 08a321735de84f1d9ec80c3b3e18fa8b
-```
-The string after `x-vcloud-authorization:` is the token.
+If successful, the output of this command will include lines like the following:
 
-The token will grant the same abilities as the account used to run the above script. Using a token produced
-by an org admin to run a task that requires a system administrator will fail.
+```
+X-VCLOUD-AUTHORIZATION: 08a321735de84f1d9ec80c3b3e18fa8b
+X-VMWARE-VCLOUD-ACCESS-TOKEN: eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhZG1pbmlzdHJhdG9yIiwiaXNzIjoiYTkzYzlkYjktNzQ3MS0zMTkyLThkMDktYThmN2VlZGE4NWY5QGY5MDZlODE1LTM0NjgtNGQ0ZS04MmJlLTcyYzFjMmVkMTBiMyIsImV4cCI6MTYwNzUxMjgyOCwidmVyc2lvbiI6InZjbG91ZF8xLjAiLCJqdGkiOiJjY2IwZjIwN2JjY2Y0NmYwYmEwNTcyNzgxZDQyNDg2MyJ9.SMjp5wsSd7CXGMdlj-weeCRdr5AazA74pwwx2w3Eqh3RdzyiEMvQfWQAuPAQjM1oOsEUnFOg2u0gYsnIyQg_p7kzXKPQwPNz3BPi0tm2DxxQtQVhOBRXCqUJ9OmRlMVu7FZZ6gKD4GhpbTkZyKMN_IgOFkkt8iXs1-weNZw5TmyVHeWiJdV0JFM45CV47jQNdQMy4OSsU-CqE2VVLOK83oJhRnlnc3O4OAAIfuVZ4SLWqgi1lIoc2vbZv0HYeWO7L_2pGfmja8CVzVhPrgIGEoDhXnvO29z1ToEXRnyMKh9cisiRkhUISpsh4aHRGUUzaZYeOejVX3PAO9aCX3iYWA
+
+The string after `X-VCLOUD-AUTHORIZATION:` is the old (deprecated) token.
+The string after `X-VMWARE-VCLOUD-ACCESS-TOKEN` is the bearer token
+```
+
+Either token will grant the same abilities as the account used to run the above script. Note, however, that the deprecated
+token may not work in recent VCD versions.
+
+Using a token produced by an org admin to run a task that requires a system administrator will fail.
 
 ### Connecting with SAML user using Microsoft Active Directory Federation Services (ADFS) and setting custom Relaying Party Trust Identifier
 
@@ -232,10 +238,11 @@ The following arguments are used to configure the VMware vCloud Director Provide
   set with `VCD_AUTH_TYPE` environment variable.
   * `token` allows to specify token in [`token`](#token) field.
   
-* `token` - (Optional; *v2.6+*) This is the authorization token that can be used instead of username
+* `token` - (Optional; *v2.6+*) This is the token that can be used instead of username
    and password (in combination with field `auth_type=token`). When this is set, username and
    password will be ignored, but should be left in configuration either empty or with any custom
    values. A token can be specified with the `VCD_TOKEN` environment variable.
+   Both a (deprecated) authorization token or a bearer token (*v3.1+*) can be used in this field.
 
 * `saml_adfs_rpt_id` - (Optional) When using `auth_type=saml_adfs` vCD SAML entity ID will be used
   as Relaying Party Trust Identifier (RPT ID) by default. If a different RPT ID is needed - one can


### PR DESCRIPTION
Adds support for bearer tokens, in addition to the deprecated autorization token.

Test in the same way defined for [PR 341 in govcd](https://github.com/vmware/go-vcloud-director/pull/341)