### PR TITLE
Add `storage_profile_id` to vcd_catalog and introduce datasource vcd_storage_profile

### DIFF
--- a/.changes/v3.1.0/602-features.md
+++ b/.changes/v3.1.0/602-features.md
@@ -1,0 +1,1 @@
+* **New Data Source**: `vcd_storage_profile` for storage profile lookup [GH-602]

--- a/.changes/v3.1.0/602-improvements.md
+++ b/.changes/v3.1.0/602-improvements.md
@@ -1,2 +1,2 @@
-* `resource/vcd_catalog` allows to set and update `storage_profile_id` [GH-602]
+* `resource/vcd_catalog` allows to set and update `storage_profile_id`, supports update for `description` [GH-602]
 * `datasource/vcd_catalog` exports `storage_profile_id` [GH-602]

--- a/.changes/v3.1.0/602-improvements.md
+++ b/.changes/v3.1.0/602-improvements.md
@@ -1,0 +1,2 @@
+* `resource/vcd_catalog` allows to set and update `storage_profile_id` [GH-602]
+* `datasource/vcd_catalog` exports `storage_profile_id` [GH-602]

--- a/.changes/v3.1.0/602-improvements.md
+++ b/.changes/v3.1.0/602-improvements.md
@@ -1,2 +1,3 @@
-* `resource/vcd_catalog` allows to set and update `storage_profile_id`, supports update for `description` [GH-602]
+* `resource/vcd_catalog` allows to set and update `storage_profile_id` [GH-602]
+* `resource/vcd_catalog` supports update for `description` [GH-602]
 * `datasource/vcd_catalog` exports `storage_profile_id` [GH-602]

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,4 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
 	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4
 )
+replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,5 @@ require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
-	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4
+	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.5
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
 	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4
 )
-replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f h1:wXRjl8qENlyGE8PFcznahMKC1qzzy+oXUYvWoozuta8=
-github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783 h1:BOu+DUOwJ7y2iU8GXev4SlyFzDkRVNxcdKyUH2QOwGM=
+github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783 h1:BOu+DUOwJ7y2iU8GXev4SlyFzDkRVNxcdKyUH2QOwGM=
-github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201203070703-768a16180783/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -320,6 +318,8 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.5 h1:WY3ESR98Xrq2et9yg8nT60EN3NnowBZVhKrjuShSsGc=
+github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.5/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f h1:wXRjl8qENlyGE8PFcznahMKC1qzzy+oXUYvWoozuta8=
+github.com/Didainius/go-vcloud-director/v2 v2.9.1-0.20201201213127-e7460c77ca2f/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
@@ -318,8 +320,6 @@ github.com/vmihailenco/msgpack v3.3.3+incompatible h1:wapg9xDUZDzGCNFlwc5SqI1rvc
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4 h1:AjMZWwcx897hAb+W0l3YDUc5uniX1Jyy47G/zplR1bY=
-github.com/vmware/go-vcloud-director/v2 v2.10.0-alpha.4/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -24,10 +24,10 @@ func datasourceVcdCatalog() *schema.Resource {
 				Description:  "Name of the catalog. (Optional if 'filter' is used)",
 				ExactlyOneOf: []string{"name", "filter"},
 			},
-			"storage_profile": &schema.Schema{
+			"storage_profile_id": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Optional storage profile name",
+				Description: "Storage profile ID",
 			},
 			"created": &schema.Schema{
 				Type:        schema.TypeString,

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -24,6 +24,11 @@ func datasourceVcdCatalog() *schema.Resource {
 				Description:  "Name of the catalog. (Optional if 'filter' is used)",
 				ExactlyOneOf: []string{"name", "filter"},
 			},
+			"storage_profile": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Optional storage profile name",
+			},
 			"created": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/vcd/datasource_vcd_storage_profile.go
+++ b/vcd/datasource_vcd_storage_profile.go
@@ -3,6 +3,8 @@ package vcd
 import (
 	"context"
 
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -45,8 +47,8 @@ func datasourceVcdStorageProfileRead(ctx context.Context, d *schema.ResourceData
 	name := d.Get("name").(string)
 	storageProfileReference, err := vdc.FindStorageProfileReference(name)
 	if err != nil {
-		return diag.Errorf("error finding Storage Profile '%s' in VDC '%s': %s",
-			name, vdc.Vdc.Name, err)
+		return diag.Errorf("%s: error finding Storage Profile '%s' in VDC '%s': %s",
+			govcd.ErrorEntityNotFound, name, vdc.Vdc.Name, err)
 	}
 	d.SetId(storageProfileReference.ID)
 	return nil

--- a/vcd/datasource_vcd_storage_profile.go
+++ b/vcd/datasource_vcd_storage_profile.go
@@ -1,0 +1,53 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdStorageProfile() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdStorageProfileRead,
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of storage profile",
+			},
+		},
+	}
+}
+
+func datasourceVcdStorageProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("error reading Org and Vdc: %s", err)
+	}
+
+	name := d.Get("name").(string)
+	storageProfileReference, err := vdc.FindStorageProfileReference(name)
+	if err != nil {
+		return diag.Errorf("error finding Storage Profile '%s' in VDC '%s': %s",
+			name, vdc.Vdc.Name, err)
+	}
+	d.SetId(storageProfileReference.ID)
+	return nil
+}

--- a/vcd/datasource_vcd_storage_profile.go
+++ b/vcd/datasource_vcd_storage_profile.go
@@ -41,7 +41,7 @@ func datasourceVcdStorageProfileRead(ctx context.Context, d *schema.ResourceData
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
-		return diag.Errorf("error reading Org and Vdc: %s", err)
+		return diag.Errorf("error reading Org and VDC: %s", err)
 	}
 
 	name := d.Get("name").(string)

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -85,7 +85,7 @@ func checkStorageProfileOriginatesInParentVdc(resource, storageProfileName, orgN
 			}
 		}
 
-		return fmt.Errorf("could not validate storage profile '%s' with ID '%s' belongs to Vdc '%s",
+		return fmt.Errorf("could not validate storage profile '%s' with ID '%s' belongs to VDC '%s",
 			storageProfileName, resourceId, testConfig.VCD.Vdc)
 	}
 }

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -116,7 +116,7 @@ func findStorageProfileIdInVdc(t *testing.T, storageProfileName string) string {
 		}
 	}
 	if foundVdc == nil {
-		t.Errorf("unable to find Vdc '%s'", testConfig.VCD.Vdc)
+		t.Errorf("unable to find VDC '%s'", testConfig.VCD.Vdc)
 		t.FailNow()
 	}
 

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -3,8 +3,11 @@
 package vcd
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 
@@ -40,10 +43,51 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 					// Ensure that ID matches storage profile URN format (e.g. urn:vcloud:vdcstorageProfile:db4aaa49-7593-4416-93df-37235a1a2c68)
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "id", regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
 					resource.TestCheckResourceAttr("data.vcd_storage_profile.sp", "id", storageProfileId),
+					checkStorageProfileOriginatesInParentVdc("data.vcd_storage_profile.sp",
+						params["StorageProfileName"].(string),
+						params["Org"].(string),
+						params["Vdc"].(string)),
 				),
 			},
 		},
 	})
+}
+
+// checkStorageProfileOriginatesInParentVdc tries to evaluate reverse order and ensure that the found storage profile ID
+// does really belong to Org and Vdc specified in datasource
+func checkStorageProfileOriginatesInParentVdc(resource, storageProfileName, orgName, vdcName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", resource)
+		}
+		// Lookup ID field of resource
+		resourceId := rs.Primary.ID
+
+		vcdClient := createTemporaryVCDConnection()
+		adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
+		if err != nil {
+			return fmt.Errorf("error getting adminOrg: %s", err)
+		}
+
+		// Retrieve VDCs
+		allVdcs, err := adminOrg.GetAllVDCs(false)
+		if err != nil {
+			return fmt.Errorf("error getting adminOrg: %s", err)
+		}
+
+		// Check if in any of Orgs child VDCs there is a storage profile that would match ID, Name and Vdc name
+		for _, vdc := range allVdcs {
+			for _, storageProfile := range vdc.Vdc.VdcStorageProfiles.VdcStorageProfile {
+				if storageProfile.ID == resourceId && storageProfile.Name == storageProfileName && vdc.Vdc.Name == vdcName {
+					return nil
+				}
+			}
+		}
+
+		return fmt.Errorf("could not validate storage profile '%s' with ID '%s' belongs to Vdc '%s",
+			storageProfileName, resourceId, testConfig.VCD.Vdc)
+	}
 }
 
 // findStorageProfileIdInCatalog should find storage profile ID using

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -21,7 +21,7 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 	}
 
 	// Lookup
-	storageProfileId := findStorageProfileIdInCatalog(t, testConfig.VCD.ProviderVdc.StorageProfile)
+	storageProfileId := findStorageProfileIdInVdc(t, testConfig.VCD.ProviderVdc.StorageProfile)
 
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
@@ -90,8 +90,8 @@ func checkStorageProfileOriginatesInParentVdc(resource, storageProfileName, orgN
 	}
 }
 
-// findStorageProfileIdInCatalog should find storage profile ID using
-func findStorageProfileIdInCatalog(t *testing.T, storageProfileName string) string {
+// findStorageProfileIdInVdc should find storage profile ID using the ID that comes from data source
+func findStorageProfileIdInVdc(t *testing.T, storageProfileName string) string {
 	vcdClient := createTemporaryVCDConnection()
 	adminOrg, err := vcdClient.GetAdminOrgByName(testConfig.VCD.Org)
 	if err != nil {

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -1,0 +1,48 @@
+// +build catalog ALL functional
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdStorageProfile(t *testing.T) {
+
+	var params = StringMap{
+		"Org":                testConfig.VCD.Org,
+		"Vdc":                testConfig.VCD.Vdc,
+		"StorageProfileName": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Tags":               "catalog",
+	}
+
+	configText := templateFill(testAccVcdStorageProfile, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { preRunChecks(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "id", regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:.*`)),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdStorageProfile = `
+data "vcd_storage_profile" "sp" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.StorageProfileName}}"
+}
+`

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -6,10 +6,20 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccVcdStorageProfileDS(t *testing.T) {
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	// Lookup
+	storageProfileId := findStorageProfileIdInCatalog(t, testConfig.VCD.ProviderVdc.StorageProfile)
+
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
 		"Vdc":                testConfig.VCD.Vdc,
@@ -18,10 +28,6 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 	}
 
 	configText := templateFill(testAccVcdStorageProfile, params)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{
@@ -31,11 +37,54 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "id", regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:.*`)),
+					// Ensure that ID matches storage profile URN format (e.g. urn:vcloud:vdcstorageProfile:db4aaa49-7593-4416-93df-37235a1a2c68)
+					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "id", regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
+					resource.TestCheckResourceAttr("data.vcd_storage_profile.sp", "id", storageProfileId),
 				),
 			},
 		},
 	})
+}
+
+// findStorageProfileIdInCatalog should find storage profile ID using
+func findStorageProfileIdInCatalog(t *testing.T, storageProfileName string) string {
+	vcdClient := createTemporaryVCDConnection()
+	adminOrg, err := vcdClient.GetAdminOrgByName(testConfig.VCD.Org)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	// get all child VDCs
+	childVdcs, err := adminOrg.GetAllVDCs(false)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	// Find VDC which should own storage profile defined in test configuration
+	var foundVdc *govcd.Vdc
+	for _, vdc := range childVdcs {
+		// We are looking in correct VDC
+		if vdc.Vdc.Name == testConfig.VCD.Vdc {
+			foundVdc = vdc
+
+		}
+	}
+	if foundVdc == nil {
+		t.Errorf("unable to find Vdc '%s'", testConfig.VCD.Vdc)
+		t.FailNow()
+	}
+
+	// Search for storage profile in found VDC and return its ID
+	for _, vdcStorageProfile := range foundVdc.Vdc.VdcStorageProfiles.VdcStorageProfile {
+		if vdcStorageProfile.Name == storageProfileName {
+			return vdcStorageProfile.ID
+		}
+	}
+
+	// Did not find ID - return empty value
+	return ""
 }
 
 const testAccVcdStorageProfile = `

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -1,4 +1,4 @@
-// +build catalog ALL functional
+// +build catalog vdc ALL functional
 
 package vcd
 
@@ -9,8 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccVcdStorageProfile(t *testing.T) {
-
+func TestAccVcdStorageProfileDS(t *testing.T) {
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
 		"Vdc":                testConfig.VCD.Vdc,

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -1,4 +1,4 @@
-// +build catalog vdc ALL functional
+// +build catalog ALL functional
 
 package vcd
 

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -64,6 +64,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_vcenter":             datasourceVcdVcenter(),           // 3.0
 	"vcd_resource_list":       datasourceVcdResourceList(),      // 3.1
 	"vcd_resource_schema":     datasourceVcdResourceSchema(),    // 3.1
+	"vcd_storage_profile":     datasourceVcdStorageProfile(),    // 3.1
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"strings"
 
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
@@ -37,6 +39,11 @@ func resourceVcdCatalog() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"storage_profile": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Optional storage profile name",
+			},
 			"created": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -58,6 +65,31 @@ func resourceVcdCatalog() *schema.Resource {
 	}
 }
 
+func getStorageProfileReferenceByName(adminOrg *govcd.AdminOrg, storageProfileName string) (*types.Reference, error) {
+	var storageProfileFound bool
+	var storageProfileReference *types.Reference
+
+	allOrgStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(false)
+	if err != nil {
+		return nil, fmt.Errorf("error looking up storage profiles: %s", err)
+	}
+
+	for _, orgStorageProfile := range allOrgStorageProfiles {
+		if orgStorageProfile.Name == storageProfileName {
+			storageProfileFound = true
+			storageProfileReference = orgStorageProfile
+			break
+		}
+	}
+
+	if !storageProfileFound {
+		return nil, fmt.Errorf("could not find storage profile with name '%s' in Org '%s'",
+			storageProfileName, adminOrg.AdminOrg.Name)
+	}
+
+	return storageProfileReference, nil
+}
+
 func resourceVcdCatalogCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] Catalog creation initiated")
 
@@ -70,7 +102,21 @@ func resourceVcdCatalogCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrg, err)
 	}
 
-	catalog, err := adminOrg.CreateCatalog(d.Get("name").(string), d.Get("description").(string))
+	var storageProfiles *types.CatalogStorageProfiles
+	storageProfileName := d.Get("storage_profile").(string)
+
+	if storageProfileName != "" {
+		storageProfileReference, err := getStorageProfileReferenceByName(adminOrg, storageProfileName)
+		if err != nil {
+			return fmt.Errorf("couuld not proces storage profile '%s': %s", storageProfileName, err)
+		}
+		storageProfiles = &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{storageProfileReference}}
+	}
+
+	name := d.Get("name").(string)
+	description := d.Get("description").(string)
+
+	catalog, err := adminOrg.CreateCatalogWithStorageProfile(name, description, storageProfiles)
 	if err != nil {
 		log.Printf("[TRACE] Error creating Catalog: %#v", err)
 		return fmt.Errorf("error creating Catalog: %#v", err)
@@ -91,23 +137,77 @@ func resourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrg, err)
 	}
 
-	catalog, err := adminOrg.GetCatalogByNameOrId(d.Id(), false)
+	adminCatalog, err := adminOrg.GetAdminCatalogByNameOrId(d.Id(), false)
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find catalog. Removing from tfstate")
 		d.SetId("")
 		return fmt.Errorf("error retrieving catalog %s : %s", d.Id(), err)
 	}
 
-	_ = d.Set("description", catalog.Catalog.Description)
-	_ = d.Set("created", catalog.Catalog.DateCreated)
-	d.SetId(catalog.Catalog.ID)
-	log.Printf("[TRACE] Catalog read completed: %#v", catalog.Catalog)
+	// Check if storage profile is set. Although storage profile structure accepts a list, in UI only one can be picked
+	if adminCatalog.AdminCatalog.CatalogStorageProfiles != nil && len(adminCatalog.AdminCatalog.CatalogStorageProfiles.VdcStorageProfile) > 0 {
+		// By default API does not return Storage Profile Name in response. It has ID and HREF, but not Name so name
+		// must be looked up
+		storageProfileId := adminCatalog.AdminCatalog.CatalogStorageProfiles.VdcStorageProfile[0].ID
+		storageProfileReference, err := adminOrg.GetStorageProfileReferenceById(storageProfileId, false)
+		if err != nil {
+			return fmt.Errorf("error retrieving storage profile reference: %s", err)
+		}
+		_ = d.Set("storage_profile", storageProfileReference.Name)
+	} else {
+		// In case no storage profile are defined in API call
+		_ = d.Set("storage_profile", "")
+	}
+
+	_ = d.Set("description", adminCatalog.AdminCatalog.Description)
+	_ = d.Set("created", adminCatalog.AdminCatalog.DateCreated)
+	d.SetId(adminCatalog.AdminCatalog.ID)
+	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)
 	return nil
 }
 
-//update function for "delete_force", "delete_recursive" no actions needed
-func resourceVcdCatalogUpdate(d *schema.ResourceData, m interface{}) error {
-	return nil
+// resourceVcdCatalogUpdate does not require actions for  fields "delete_force", "delete_recursive", but does allow to
+// change `storage_profile`
+func resourceVcdCatalogUpdate(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrg, err)
+	}
+
+	adminCatalog, err := adminOrg.GetAdminCatalogByNameOrId(d.Id(), false)
+	if err != nil {
+		log.Printf("[DEBUG] Unable to find catalog. Removing from tfstate")
+		d.SetId("")
+		return fmt.Errorf("error retrieving catalog %s : %s", d.Id(), err)
+	}
+
+	// Perform storage profile updates
+	if d.HasChange("storage_profile") {
+		storageProfileName := d.Get("storage_profile").(string)
+
+		// Unset storage profile name (use any)
+		if storageProfileName == "" {
+			// Set empty structure as `nil` would not update it at all
+			adminCatalog.AdminCatalog.CatalogStorageProfiles = &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{}}
+		}
+
+		if storageProfileName != "" {
+			storageProfileReference, err := getStorageProfileReferenceByName(adminOrg, storageProfileName)
+			if err != nil {
+				return fmt.Errorf("couuld not proces storage profile '%s': %s", storageProfileName, err)
+			}
+			adminCatalog.AdminCatalog.CatalogStorageProfiles = &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{storageProfileReference}}
+		}
+	}
+
+	err = adminCatalog.Update()
+	if err != nil {
+		return fmt.Errorf("error updating catalog '%s': %s", adminCatalog.AdminCatalog.Name, err)
+	}
+
+	return resourceVcdCatalogRead(d, meta)
 }
 
 func resourceVcdCatalogDelete(d *schema.ResourceData, meta interface{}) error {
@@ -137,7 +237,7 @@ func resourceVcdCatalogDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-// Imports a Catalog into Terraform state
+// resourceVcdCatalogImport imports a Catalog into Terraform state
 // This function task is to get the data from vCD and fill the resource data container
 // Expects the d.ID() to be a path to the resource made of org_name.catalog_name
 //
@@ -161,10 +261,13 @@ func resourceVcdCatalogImport(d *schema.ResourceData, meta interface{}) ([]*sche
 		return nil, govcd.ErrorEntityNotFound
 	}
 
-	_ = d.Set("org", orgName)
-	_ = d.Set("name", catalogName)
-	_ = d.Set("description", catalog.Catalog.Description)
 	d.SetId(catalog.Catalog.ID)
+
+	// Fill in other fields
+	err = resourceVcdCatalogRead(d, meta)
+	if err != nil {
+		return nil, err
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -123,10 +123,6 @@ func resourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) error {
 		// By default API does not return Storage Profile Name in response. It has ID and HREF, but not Name so name
 		// must be looked up
 		storageProfileId := adminCatalog.AdminCatalog.CatalogStorageProfiles.VdcStorageProfile[0].ID
-		// storageProfileReference, err := adminOrg.GetStorageProfileReferenceById(storageProfileId, false)
-		// if err != nil {
-		// 	return fmt.Errorf("error retrieving storage profile reference: %s", err)
-		// }
 		_ = d.Set("storage_profile_id", storageProfileId)
 	} else {
 		// In case no storage profile are defined in API call

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -65,31 +65,6 @@ func resourceVcdCatalog() *schema.Resource {
 	}
 }
 
-func getStorageProfileReferenceByName(adminOrg *govcd.AdminOrg, storageProfileName string) (*types.Reference, error) {
-	var storageProfileFound bool
-	var storageProfileReference *types.Reference
-
-	allOrgStorageProfiles, err := adminOrg.GetAllStorageProfileReferences(false)
-	if err != nil {
-		return nil, fmt.Errorf("error looking up storage profiles: %s", err)
-	}
-
-	for _, orgStorageProfile := range allOrgStorageProfiles {
-		if orgStorageProfile.Name == storageProfileName {
-			storageProfileFound = true
-			storageProfileReference = orgStorageProfile
-			break
-		}
-	}
-
-	if !storageProfileFound {
-		return nil, fmt.Errorf("could not find storage profile with name '%s' in Org '%s'",
-			storageProfileName, adminOrg.AdminOrg.Name)
-	}
-
-	return storageProfileReference, nil
-}
-
 func resourceVcdCatalogCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[TRACE] Catalog creation initiated")
 

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -33,11 +33,9 @@ func resourceVcdCatalog() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-
 			"description": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 			"storage_profile_id": &schema.Schema{
 				Type:        schema.TypeString,
@@ -166,10 +164,14 @@ func resourceVcdCatalogUpdate(d *schema.ResourceData, meta interface{}) error {
 		if storageProfileId != "" {
 			storageProfileReference, err := adminOrg.GetStorageProfileReferenceById(storageProfileId, false)
 			if err != nil {
-				return fmt.Errorf("couuld not proces storage profile '%s': %s", storageProfileId, err)
+				return fmt.Errorf("could not process storage profile '%s': %s", storageProfileId, err)
 			}
 			adminCatalog.AdminCatalog.CatalogStorageProfiles = &types.CatalogStorageProfiles{VdcStorageProfile: []*types.Reference{storageProfileReference}}
 		}
+	}
+
+	if d.HasChange("description") {
+		adminCatalog.AdminCatalog.Description = d.Get("description").(string)
 	}
 
 	err = adminCatalog.Update()

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -90,6 +90,8 @@ func TestAccVcdCatalog(t *testing.T) {
 	})
 }
 
+// TestAccVcdCatalogWithStorageProfile is very similar to TestAccVcdCatalog, but it ensure that a catalog can be created
+// using specific storage profile
 func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 	var params = StringMap{
 		"Org":            testConfig.VCD.Org,
@@ -99,7 +101,7 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 		"Tags":           "catalog",
 	}
 
-	configText := templateFill(testAccCheckVcdCatalog, params)
+	configText := templateFill(testAccCheckVcdCatalogStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	if vcdShortTest {

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -64,7 +64,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAddress, "name", TestAccVcdCatalogName),
 					resource.TestCheckResourceAttr(resourceAddress, "description", TestAccVcdCatalogDescription),
 					resource.TestMatchResourceAttr(resourceAddress, "storage_profile_id",
-						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:.*`)),
+						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0
@@ -95,6 +95,7 @@ func TestAccVcdCatalog(t *testing.T) {
 func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 	var params = StringMap{
 		"Org":            testConfig.VCD.Org,
+		"Vdc":            testConfig.VCD.Vdc,
 		"CatalogName":    TestAccVcdCatalogName,
 		"Description":    TestAccVcdCatalogDescription,
 		"StorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
@@ -110,6 +111,7 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 	}
 
 	resourceAddress := "vcd_catalog." + TestAccVcdCatalogName
+	dataSourceAddress := "data.vcd_storage_profile.sp"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -124,7 +126,12 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAddress, "name", TestAccVcdCatalogName),
 					resource.TestCheckResourceAttr(resourceAddress, "description", TestAccVcdCatalogDescription),
 					resource.TestMatchResourceAttr(resourceAddress, "storage_profile_id",
-						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:.*`)),
+						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
+					resource.TestCheckResourceAttrPair(resourceAddress, "storage_profile_id", dataSourceAddress, "id"),
+					checkStorageProfileOriginatesInParentVdc(dataSourceAddress,
+						params["StorageProfile"].(string),
+						params["Org"].(string),
+						params["Vdc"].(string)),
 				),
 			},
 		},

--- a/vcd/testcheck_funcs_test.go
+++ b/vcd/testcheck_funcs_test.go
@@ -56,6 +56,7 @@ func (c *testCachedFieldValue) testCheckCachedResourceFieldValue(resource, field
 			return fmt.Errorf("field %s in resource %s does not exist", field, resource)
 		}
 
+		debugPrintf("# Comparing field %s '%s==%s' in resource '%s'", field, value, c.fieldValue, resource)
 		if value != c.fieldValue {
 			return fmt.Errorf("got '%s - %s' field value %s, expected: %s",
 				resource, field, value, c.fieldValue)

--- a/vcd/testcheck_funcs_test.go
+++ b/vcd/testcheck_funcs_test.go
@@ -1,4 +1,4 @@
-// +build vapp vm user nsxt extnetwork network gateway ALL functional
+// +build vapp vm user nsxt extnetwork network gateway catalog ALL functional
 
 package vcd
 

--- a/website/docs/d/storage_profile.html.markdown
+++ b/website/docs/d/storage_profile.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_storage_profile"
+sidebar_current: "docs-vcd-data-source-storage-profile"
+description: |-
+  Provides a data source for VDC storage profile.
+---
+
+# vcd\_storage\_profile
+
+Provides a data source for VDC storage profile.
+
+Supported in provider *v3.1+*
+
+
+## Example Usage
+
+```hcl
+data "vcd_storage_profile" "sp" {
+  org  = "my-org"
+  vdc  = "my-vdc"
+  name = "ssd-storage-profile"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `name` - (Required) Storage profile name
+
+## Attribute reference
+
+This data source exports only `id` field.

--- a/website/docs/d/storage_profile.html.markdown
+++ b/website/docs/d/storage_profile.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations.
 * `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
-* `name` - (Required) Storage profile name
+* `name` - (Required) Storage profile name.
 
 ## Attribute reference
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -25,6 +25,28 @@ resource "vcd_catalog" "myNewCatalog" {
 }
 ```
 
+## Example Usage (Custom storage profile)
+
+```hcl
+
+data "vcd_storage_profile" "sp1" {
+  org  = "my-org"
+  vdc  = "my-vdc"
+  name = "ssd-storage-profile"
+}
+
+resource "vcd_catalog" "myNewCatalog" {
+  org = "my-org"
+
+  name               = "my-catalog"
+  description        = "catalog for files"
+  storage_profile_id = data.vcd_storage_profile.sp1.id
+
+  delete_recursive = "true"
+  delete_force     = "true"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -32,6 +54,8 @@ The following arguments are supported:
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `name` - (Required) Catalog name
 * `description` - (Optional) - Description of catalog
+* `storage_profile_id` (Optional, *v3.1+*) Allows to set specific storage profile to be used for catalog. **Note.** Data
+source [vcd_storage_profile](/docs/providers/vcd/d/storage_profile.html) can help to lookup storage profile ID.
 * `delete_recursive` - (Required) - When destroying use delete_recursive=True to remove the catalog and any objects it contains that are in a state that normally allows removal
 * `delete_force` -(Required) - When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state
 

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -127,6 +127,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-resource-schema") %>>
               <a href="/docs/providers/vcd/d/resource_schema.html">vcd_resource_schema</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-storage-profile") %>>
+              <a href="/docs/providers/vcd/d/storage_profile.html">vcd_storage_profile</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
Fixes #598 ,
This PR adds `storage_profile_id` attribute to `vcd_catalog` resource and datasource (for create and update)
Additionally it introduces `vcd_storage_profile` datasource for storage profile ID lookup.

It also allows to change `description` field for `vcd_catalog`

**Note.** Acceptance tests passed on at least one version (also `VCD_TEST_ORG_USER=1 go test -timeout 30m -v -tags "org catalog"`)