### PR TITLE
Introduce NSX-T routed network DHCP pool management resource and data source

### DIFF
--- a/.changes/v3.2.0/628-features.md
+++ b/.changes/v3.2.0/628-features.md
@@ -1,2 +1,2 @@
-**New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
-**New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
+* **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
+* **New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]

--- a/.changes/v3.2.0/628-notes.md
+++ b/.changes/v3.2.0/628-notes.md
@@ -1,3 +1,1 @@
-* Internal functions `lockParentEdgeGtw` and `unLockParentEdgeGtw` will handle Edge gateway locks
-when `name` or `id` reference is used [GH-628]
-* Deprecate `vcd_network_routed` resource and data source in favor of `vcd_network_routed_v2` [GH-628]
+* Internal functions `lockParentEdgeGtw` and `unLockParentEdgeGtw` will handle Edge Gateway locks when `name` or `id` reference is used [GH-628]

--- a/.changes/v3.2.0/636-features
+++ b/.changes/v3.2.0/636-features
@@ -1,2 +1,0 @@
-**New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
-**New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]

--- a/.changes/v3.2.0/636-features.md
+++ b/.changes/v3.2.0/636-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
+* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]

--- a/.changes/v3.2.0/636-notes
+++ b/.changes/v3.2.0/636-notes
@@ -1,1 +1,0 @@
-* Deprecate `vcd_network_isolated` resource and data source in favor of `vcd_network_routed_v2` [GH-636]

--- a/.changes/v3.2.0/638-features.md
+++ b/.changes/v3.2.0/638-features.md
@@ -1,3 +1,2 @@
-* New Resource `vcd_vm` - Standalone VM [GH-638]
-* New Datasource `vcd_vm` - Standalone VM [GH-638]
-
+* **New Resource:** `vcd_vm` - Standalone VM [GH-638]
+* **New Data source:** `vcd_vm` - Standalone VM [GH-638]

--- a/.changes/v3.2.0/638-improvements.md
+++ b/.changes/v3.2.0/638-improvements.md
@@ -1,2 +1,1 @@
 * `datasource/vcd_resource_list` adds `vcd_vm` to the supported resource types [GH-638]
-

--- a/.changes/v3.2.0/645-features.md
+++ b/.changes/v3.2.0/645-features.md
@@ -1,2 +1,2 @@
-**New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
-**New Data source:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
+* **New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
+* **New Data source:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]

--- a/.changes/v3.2.0/650-features.md
+++ b/.changes/v3.2.0/650-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]
+* **New Data source:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]

--- a/.changes/v3.2.0/650-improvements.md
+++ b/.changes/v3.2.0/650-improvements.md
@@ -1,0 +1,4 @@
+* `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC [GH-650]
+* `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC [GH-650]
+* `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs [GH-650]
+* `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC (because NSX-T networks cannot be attached to vApp networks) [GH-650]

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
 	github.com/kr/pretty v0.2.0
-	github.com/vmware/go-vcloud-director/v2 v2.11.0-alpha.3
+	github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1
 )

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.11.0-alpha.3 h1:kcYx6KMfmhsQqyARMm6sWa6K23qrSkb18XCDJ/tm3L4=
-github.com/vmware/go-vcloud-director/v2 v2.11.0-alpha.3/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1 h1:w6DrOoSlbvwlmFCKFvqOHSPEvQinZcN65B5tDRG4o5o=
+github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -3,6 +3,7 @@
 package vcd
 
 import (
+	"fmt"
 	"regexp"
 	"testing"
 
@@ -57,6 +58,12 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 		mandatoryRuntimeFields := getMandatoryDataSourceRuntimeFields(dataSourceName)
 		mandatoryFields = append(mandatoryFields, mandatoryRuntimeFields...)
 		addedParams := addMandatoryParams(dataSourceName, mandatoryFields, t, vcdClient)
+
+		// Inject NSX-T VDC for resources that are known to require it
+		switch dataSourceName {
+		case "vcd_nsxt_edgegateway":
+			addedParams += fmt.Sprintf(`vdc = "%s"`, testConfig.Nsxt.Vdc)
+		}
 
 		var params = StringMap{
 			"DataSourceName":  dataSourceName,
@@ -159,6 +166,9 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			templateFields = templateFields + `name = "does-not-exist"` + "\n"
 		case "org_network_name":
 			templateFields = templateFields + `org_network_name = "does-not-exist"` + "\n"
+		// OpenAPI requires org_network_id to be a valid URN - chances of duplicating it are close enough to zero
+		case "org_network_id":
+			templateFields = templateFields + `org_network_id = "urn:vcloud:network:784feb3d-87e4-4905-202a-bfe9faa5476f"` + "\n"
 		}
 
 	}

--- a/vcd/datasource_vcd_network_isolated.go
+++ b/vcd/datasource_vcd_network_isolated.go
@@ -1,13 +1,14 @@
 package vcd
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func datasourceVcdNetworkIsolated() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Please use 'vcd_network_isolated_v2' data source which supports NSX-T and NSX-V",
-		Read:               datasourceVcdNetworkIsolatedRead,
+		Read: datasourceVcdNetworkIsolatedRead,
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
@@ -135,5 +136,16 @@ func datasourceVcdNetworkIsolated() *schema.Resource {
 }
 
 func datasourceVcdNetworkIsolatedRead(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	if vdc.IsNsxt() {
+		fmt.Fprintf(getTerraformStdout(), "WARNING: please use 'vcd_network_isolated_v2' for NSX-T VDCs")
+	}
+
 	return genericVcdNetworkIsolatedRead(d, meta, "datasource")
 }

--- a/vcd/datasource_vcd_network_routed.go
+++ b/vcd/datasource_vcd_network_routed.go
@@ -1,13 +1,14 @@
 package vcd
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func datasourceVcdNetworkRouted() *schema.Resource {
 	return &schema.Resource{
-		Read:               datasourceVcdNetworkRoutedRead,
-		DeprecationMessage: "Please use 'vcd_network_routed_v2' data source which supports NSX-T and NSX-V",
+		Read: datasourceVcdNetworkRoutedRead,
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
@@ -160,5 +161,16 @@ func datasourceVcdNetworkRouted() *schema.Resource {
 }
 
 func datasourceVcdNetworkRoutedRead(d *schema.ResourceData, meta interface{}) error {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	if vdc.IsNsxt() {
+		fmt.Fprintf(getTerraformStdout(), "WARNING: please use 'vcd_network_routed_v2' for NSX-T VDCs")
+	}
+
 	return genericVcdNetworkRoutedRead(d, meta, "datasource")
 }

--- a/vcd/datasource_vcd_nsxt_edgegateway.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway.go
@@ -111,6 +111,10 @@ func datasourceVcdNsxtEdgeGatewayRead(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(fmt.Errorf("error retrieving Org: %s", err))
 	}
 
+	if vdc.IsNsxv() {
+		return diag.Errorf("please use 'vcd_edgegateway' for NSX-V backed VDC")
+	}
+
 	edge, err := vdc.GetNsxtEdgeGatewayByName(d.Get("name").(string))
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("could not retrieve NSX-T edge gateway: %s", err))

--- a/vcd/datasource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_test.go
@@ -251,9 +251,8 @@ data "vcd_nsxt_edgegateway" "egw-ds" {
 `
 
 // TestAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv expects to get an error because it tries to lookup NSX-V edge gateway
-// using NSX-T datasource. Although OpenAPI endpoint does return both types by default - the NSX-T edge gateway
-// retrieval functions are not expected to find it. This is because NSX-T structure is less nested and allows to have
-// simpler schema.
+// using NSX-T datasource. There is a validator inside `vcd_nsxt_edgegateway` which is supposed to refer to
+// `vcd_edgegateway` when VDC is NSX-V
 func TestAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv(t *testing.T) {
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -281,7 +280,7 @@ func TestAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config:      configText,
-				ExpectError: regexp.MustCompile(".*entity not found.*"),
+				ExpectError: regexp.MustCompile("please use 'vcd_edgegateway' for NSX-V backed VDC"),
 			},
 		},
 	})

--- a/vcd/datasource_vcd_nsxt_network_dhcp.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp.go
@@ -1,0 +1,87 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var datasourceNsxtDhcpPoolSetSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"start_address": &schema.Schema{
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Start address of DHCP pool IP range",
+		},
+		"end_address": &schema.Schema{
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "End address of DHCP pool IP range",
+		},
+	},
+}
+
+func datasourceVcdOpenApiDhcp() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdOpenApiDhcpRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"org_network_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Parent Org VDC network name",
+			},
+			"pool": &schema.Schema{
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "IP ranges used for DHCP pool allocation in the network",
+				Elem:        datasourceNsxtDhcpPoolSetSchema,
+			},
+		},
+	}
+}
+
+func datasourceVcdOpenApiDhcpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool datasource read] error retrieving VDC: %s", err)
+	}
+
+	orgNetworkId := d.Get("org_network_id").(string)
+	orgNetwork, err := vdc.GetOpenApiOrgVdcNetworkById(orgNetworkId)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool datasource read] error retrieving Org VDC network with ID '%s': %s", orgNetworkId, err)
+	}
+
+	pool, err := vdc.GetOpenApiOrgVdcNetworkDhcp(orgNetwork.OpenApiOrgVdcNetwork.ID)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool datasource read] error retrieving DHCP pools for Org network ID '%s': %s",
+			orgNetwork.OpenApiOrgVdcNetwork.ID, err)
+	}
+
+	err = setOpenAPIOrgVdcNetworkDhcpData(orgNetwork.OpenApiOrgVdcNetwork.ID, pool.OpenApiOrgVdcNetworkDhcp, d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool datasource read] error setting DHCP pool: %s", err)
+	}
+
+	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp_test.go
@@ -1,0 +1,91 @@
+// +build network nsxt ALL functional
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdOpenApiDhcpNsxtRoutedDS(t *testing.T) {
+	skipNoNsxtConfiguration(t)
+
+	// This test creates a resource and uses datasource which is not possible in single file
+	// therefore skipping binary tests
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccRoutedNetDhcpStep1DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 0: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccRoutedNetDhcpStep2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-routed-dhcp"),
+		Steps: []resource.TestStep{
+			resource.TestStep{ // Define network and DHCP pools
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_network_dhcp.pools", "pool.*", map[string]string{
+						"start_address": "7.1.1.100",
+						"end_address":   "7.1.1.110",
+					}),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_network_dhcp.pools", "pool.*", map[string]string{
+						"start_address": "7.1.1.100",
+						"end_address":   "7.1.1.110",
+					}),
+					resourceFieldsEqual("vcd_nsxt_network_dhcp.pools", "data.vcd_nsxt_network_dhcp.pools", []string{}),
+				),
+			},
+		},
+	})
+}
+
+const testAccRoutedNetDhcpStep1DS = testAccRoutedNetDhcpConfig + `
+resource "vcd_nsxt_network_dhcp" "pools" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  org_network_id = vcd_network_routed_v2.net1.id
+  
+  pool {
+    start_address = "7.1.1.100"
+    end_address   = "7.1.1.110"
+  }
+}
+`
+
+const testAccRoutedNetDhcpStep2DS = testAccRoutedNetDhcpStep1DS + `
+data "vcd_nsxt_network_dhcp" "pools" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  org_network_id = vcd_network_routed_v2.net1.id
+
+  depends_on = [vcd_network_routed_v2.net1]
+}
+`

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -71,6 +71,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_network_routed_v2":     datasourceVcdNetworkRoutedV2(),     // 3.2
 	"vcd_network_isolated_v2":   datasourceVcdNetworkIsolatedV2(),   // 3.2
 	"vcd_nsxt_network_imported": datasourceVcdNsxtNetworkImported(), // 3.2
+	"vcd_nsxt_network_dhcp":     datasourceVcdOpenApiDhcp(),         // 3.2
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -118,6 +119,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_network_routed_v2":     resourceVcdNetworkRoutedV2(),          // 3.2
 	"vcd_network_isolated_v2":   resourceVcdNetworkIsolatedV2(),        // 3.2
 	"vcd_nsxt_network_imported": resourceVcdNsxtNetworkImported(),      // 3.2
+	"vcd_nsxt_network_dhcp":     resourceVcdOpenApiDhcp(),              // 3.2
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -274,6 +274,10 @@ func resourceVcdEdgeGatewayCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("no valid VDC named '%s' was found", vdcName)
 	}
 
+	if vdc.IsNsxt() {
+		return fmt.Errorf("please use 'vcd_nsxt_edgegateway' for NSX-T backed VDC")
+	}
+
 	var gwInterfaces []*types.GatewayInterface
 
 	log.Printf("[TRACE] creating edge gateway using 'external_network' blocks")
@@ -366,6 +370,11 @@ func genericVcdEdgeGatewayRead(d *schema.ResourceData, meta interface{}, origin 
 	if err != nil {
 		return fmt.Errorf("[edgegateway read] error retrieving org and vdc: %s", err)
 	}
+
+	if vdc.IsNsxt() {
+		return fmt.Errorf("please use 'vcd_nsxt_edgegateway' for NSX-T backed VDC")
+	}
+
 	var edgeGateway *govcd.EdgeGateway
 	var hasFilter bool
 	var filter interface{}
@@ -500,6 +509,11 @@ func resourceVcdEdgeGatewayImport(d *schema.ResourceData, meta interface{}) ([]*
 	if err != nil {
 		return nil, fmt.Errorf("unable to find VDC %s: %s", vdcName, err)
 	}
+
+	if vdc.IsNsxt() {
+		return nil, fmt.Errorf("please use 'vcd_nsxt_edgegateway' for NSX-T backed VDC")
+	}
+
 	edgeGateway, err := vdc.GetEdgeGatewayByNameOrId(edgeName, false)
 	if err != nil {
 		return nil, fmt.Errorf(errorUnableToFindEdgeGateway, err)

--- a/vcd/resource_vcd_network_isolated.go
+++ b/vcd/resource_vcd_network_isolated.go
@@ -13,11 +13,10 @@ import (
 
 func resourceVcdNetworkIsolated() *schema.Resource {
 	return &schema.Resource{
-		DeprecationMessage: "Please use 'vcd_network_isolated_v2' resource which supports NSX-T and NSX-V",
-		Create:             resourceVcdNetworkIsolatedCreate,
-		Read:               resourceVcdNetworkIsolatedRead,
-		Update:             resourceVcdNetworkIsolatedUpdate,
-		Delete:             resourceVcdNetworkDelete,
+		Create: resourceVcdNetworkIsolatedCreate,
+		Read:   resourceVcdNetworkIsolatedRead,
+		Update: resourceVcdNetworkIsolatedUpdate,
+		Delete: resourceVcdNetworkDelete,
 		Importer: &schema.ResourceImporter{
 			State: resourceVcdNetworkIsolatedImport,
 		},
@@ -164,6 +163,10 @@ func resourceVcdNetworkIsolatedCreate(d *schema.ResourceData, meta interface{}) 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	if vdc.IsNsxt() {
+		fmt.Fprintf(getTerraformStdout(), "WARNING: please use 'vcd_network_isolated_v2' for NSX-T VDCs")
 	}
 
 	gatewayName := d.Get("gateway").(string)
@@ -367,6 +370,10 @@ func resourceVcdNetworkIsolatedImport(d *schema.ResourceData, meta interface{}) 
 	_, vdc, err := vcdClient.GetOrgAndVdc(orgName, vdcName)
 	if err != nil {
 		return nil, fmt.Errorf("[isolated network import] unable to find VDC %s: %s ", vdcName, err)
+	}
+
+	if vdc.IsNsxt() {
+		return nil, fmt.Errorf("[isolated network import] please use 'vcd_network_isolated_v2' for NSX-T VDCs")
 	}
 
 	network, err := vdc.GetOrgVdcNetworkByName(networkName, false)

--- a/vcd/resource_vcd_network_routed.go
+++ b/vcd/resource_vcd_network_routed.go
@@ -14,11 +14,10 @@ import (
 
 func resourceVcdNetworkRouted() *schema.Resource {
 	return &schema.Resource{
-		Create:             resourceVcdNetworkRoutedCreate,
-		Read:               resourceVcdNetworkRoutedRead,
-		Delete:             resourceVcdNetworkDeleteLocked,
-		Update:             resourceVcdNetworkRoutedUpdate,
-		DeprecationMessage: "Please use 'vcd_network_routed_v2' resource which supports NSX-T and NSX-V",
+		Create: resourceVcdNetworkRoutedCreate,
+		Read:   resourceVcdNetworkRoutedRead,
+		Delete: resourceVcdNetworkDeleteLocked,
+		Update: resourceVcdNetworkRoutedUpdate,
 		Importer: &schema.ResourceImporter{
 			State: resourceVcdNetworkRoutedImport,
 		},
@@ -188,6 +187,10 @@ func resourceVcdNetworkRoutedCreate(d *schema.ResourceData, meta interface{}) er
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	if vdc.IsNsxt() {
+		fmt.Fprintf(getTerraformStdout(), "WARNING: please use 'vcd_network_routed_v2' for NSX-T VDCs")
 	}
 
 	edgeGatewayName := d.Get("edge_gateway").(string)
@@ -532,6 +535,10 @@ func resourceVcdNetworkRoutedImport(d *schema.ResourceData, meta interface{}) ([
 	_, vdc, err := vcdClient.GetOrgAndVdc(orgName, vdcName)
 	if err != nil {
 		return nil, fmt.Errorf("[routed network import] unable to find VDC %s: %s ", vdcName, err)
+	}
+
+	if vdc.IsNsxt() {
+		return nil, fmt.Errorf("[routed network import] please use 'vcd_network_routed_v2' for NSX-T VDCs")
 	}
 
 	network, err := vdc.GetOrgVdcNetworkByName(networkName, false)

--- a/vcd/resource_vcd_nsxt_edgegateway.go
+++ b/vcd/resource_vcd_nsxt_edgegateway.go
@@ -127,6 +127,10 @@ func resourceVcdNsxtEdgeGatewayCreate(ctx context.Context, d *schema.ResourceDat
 		return diag.FromErr(fmt.Errorf("error retrieving VDC: %s", err))
 	}
 
+	if vdc.IsNsxv() {
+		return diag.Errorf("please use 'vcd_edgegateway' for NSX-V backed VDC")
+	}
+
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
 		return diag.FromErr(fmt.Errorf("error getting adminOrg: %s", err))
@@ -244,6 +248,10 @@ func resourceVcdNsxtEdgeGatewayImport(ctx context.Context, d *schema.ResourceDat
 	_, vdc, err := vcdClient.GetOrgAndVdc(orgName, vdcName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find org %s: %s", vdcName, err)
+	}
+
+	if vdc.IsNsxv() {
+		return nil, fmt.Errorf("please use 'vcd_edgegateway' for NSX-V backed VDC")
 	}
 
 	edge, err := vdc.GetNsxtEdgeGatewayByName(edgeName)

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -1,0 +1,259 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var nsxtDhcpPoolSetSchema = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"start_address": &schema.Schema{
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Start address of DHCP pool IP range",
+		},
+		"end_address": &schema.Schema{
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "End address of DHCP pool IP range",
+		},
+	},
+}
+
+func resourceVcdOpenApiDhcp() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdOpenApiDhcpCreate,
+		ReadContext:   resourceVcdOpenApiDhcpRead,
+		UpdateContext: resourceVcdOpenApiDhcpUpdate,
+		DeleteContext: resourceVcdOpenApiDhcpDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdOpenApiDhcpImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+
+			"org_network_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Parent Org VDC network ID",
+			},
+			"pool": &schema.Schema{
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "IP ranges used for DHCP pool allocation in the network",
+				Elem:        nsxtDhcpPoolSetSchema,
+			},
+		},
+	}
+}
+
+func resourceVcdOpenApiDhcpCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool set] error retrieving VDC: %s", err)
+	}
+
+	orgNetworkId := d.Get("org_network_id").(string)
+
+	// Perform validations to only allow DHCP configuration on NSX-T backed Routed Org VDC networks
+	orgVdcNet, err := vdc.GetOpenApiOrgVdcNetworkById(orgNetworkId)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool create] error retrieving Org VDC network with ID '%s': %s", orgNetworkId, err)
+	}
+
+	if !orgVdcNet.IsRouted() || !vdc.IsNsxt() {
+		return diag.Errorf("[NSX-T DHCP pool set] DHCP configuration is only supported for Routed NSX-T networks: %s", err)
+	}
+
+	dhcpType := getOpenAPIOrgVdcNetworkDhcpType(d)
+	_, err = vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId, dhcpType)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool set] error setting DHCP pool for Org VDC network ID '%s': %s",
+			orgNetworkId, err)
+	}
+	// ID is in fact Org VDC network ID because DHCP pools do not have their own ID, only Org Network ID in API path
+	d.SetId(orgNetworkId)
+
+	return resourceVcdOpenApiDhcpRead(ctx, d, meta)
+}
+
+// resourceVcdOpenApiDhcpUpdate is exactly the same as resourceVcdOpenApiDhcpCreate because there is no "create"
+// operation in this endpoint, only update.
+func resourceVcdOpenApiDhcpUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcdOpenApiDhcpCreate(ctx, d, meta)
+}
+
+func resourceVcdOpenApiDhcpRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool read] error retrieving VDC: %s", err)
+	}
+
+	orgNetworkId := d.Id()
+	// There may be cases when parent Org VDC network is no longer present. In that case we want to report that
+	// DHCP pool no longer exists without breaking Terraform read.
+	_, err = vdc.GetOpenApiOrgVdcNetworkById(orgNetworkId)
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.Errorf("[NSX-T DHCP pool read] error retrieving Org VDC network with ID '%s': %s", orgNetworkId, err)
+	}
+
+	pool, err := vdc.GetOpenApiOrgVdcNetworkDhcp(d.Id())
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool read] error retrieving DHCP pools for Org network ID '%s': %s",
+			d.Id(), err)
+	}
+
+	err = setOpenAPIOrgVdcNetworkDhcpData(d.Id(), pool.OpenApiOrgVdcNetworkDhcp, d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool read] error setting DHCP pool data for Org network ID '%s': %s",
+			orgNetworkId, err)
+	}
+
+	return nil
+}
+
+func resourceVcdOpenApiDhcpDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// VCD versions < 10.2 do not allow to execute "DELETE" therefore we emit warning and "return success" to prevent
+	// destroy errors breaking Terraform flow.
+	if vcdClient.Client.APIVCDMaxVersionIs("< 35.0") {
+		_, _ = fmt.Fprint(getTerraformStdout(), "vcd_nsxt_network_dhcp WARNING: for VCD versions < 10.2 DHCP pool "+
+			"removal is not supported. Destroy is a NO-OP for VCD versions < 10.2. "+
+			"Please recreate parent network to remove DHCP pools.\n")
+		return nil
+	}
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool delete] error retrieving VDC: %s", err)
+	}
+
+	err = vdc.DeleteOpenApiOrgVdcNetworkDhcp(d.Id())
+	if err != nil {
+		return diag.Errorf("[NSX-T DHCP pool delete] error removing DHCP pool for Org network ID '%s': %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+func resourceVcdOpenApiDhcpImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 3 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.org_network_name")
+	}
+	orgName, vdcName, orgVdcNetworkName := resourceURI[0], resourceURI[1], resourceURI[2]
+
+	vcdClient := meta.(*VCDClient)
+	org, err := vcdClient.GetAdminOrg(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Org %s: %s", orgName, err)
+	}
+	vdc, err := org.GetVDCByName(vdcName, false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find VDC %s: %s", vdcName, err)
+	}
+
+	// Perform validations to only allow DHCP configuration on NSX-T backed Routed Org VDC networks
+	orgVdcNet, err := vdc.GetOpenApiOrgVdcNetworkByName(orgVdcNetworkName)
+	if err != nil {
+		return nil, fmt.Errorf("[NSX-T DHCP pool import] error retrieving Org VDC network with name '%s': %s", orgVdcNetworkName, err)
+	}
+
+	if !orgVdcNet.IsRouted() || !vdc.IsNsxt() {
+		return nil, fmt.Errorf("[NSX-T DHCP pool import] DHCP configuration is only supported for Routed NSX-T networks: %s", err)
+	}
+
+	_ = d.Set("org", orgName)
+	_ = d.Set("vdc", vdcName)
+	d.SetId(orgVdcNet.OpenApiOrgVdcNetwork.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getOpenAPIOrgVdcNetworkDhcpType(d *schema.ResourceData) *types.OpenApiOrgVdcNetworkDhcp {
+	orgVdcNetDhcp := &types.OpenApiOrgVdcNetworkDhcp{
+		DhcpPools: nil,
+	}
+
+	dhcpPool := d.Get("pool")
+	if dhcpPool == nil {
+		return orgVdcNetDhcp
+	}
+
+	dhcpPoolSet := dhcpPool.(*schema.Set)
+	dhcpPoolList := dhcpPoolSet.List()
+
+	if len(dhcpPoolList) > 0 {
+		dhcpPools := make([]types.OpenApiOrgVdcNetworkDhcpPools, len(dhcpPoolList))
+		for index, pool := range dhcpPoolList {
+			poolMap := pool.(map[string]interface{})
+			onePool := types.OpenApiOrgVdcNetworkDhcpPools{
+				IPRange: types.OpenApiOrgVdcNetworkDhcpIpRange{
+					StartAddress: poolMap["start_address"].(string),
+					EndAddress:   poolMap["end_address"].(string),
+				},
+			}
+			dhcpPools[index] = onePool
+		}
+
+		// Inject data into main structure
+		orgVdcNetDhcp.DhcpPools = dhcpPools
+	}
+
+	return orgVdcNetDhcp
+}
+
+func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdc *types.OpenApiOrgVdcNetworkDhcp, d *schema.ResourceData) error {
+	_ = d.Set("org_network_id", orgNetworkId)
+	if len(orgVdc.DhcpPools) > 0 {
+		poolInterfaceSlice := make([]interface{}, len(orgVdc.DhcpPools))
+
+		for index, pool := range orgVdc.DhcpPools {
+			onePool := make(map[string]interface{})
+			onePool["start_address"] = pool.IPRange.StartAddress
+			onePool["end_address"] = pool.IPRange.EndAddress
+
+			poolInterfaceSlice[index] = onePool
+		}
+
+		dhcpPoolSet := schema.NewSet(schema.HashResource(nsxtDhcpPoolSetSchema), poolInterfaceSlice)
+		err := d.Set("pool", dhcpPoolSet)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -1,0 +1,131 @@
+// +build network nsxt ALL functional
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccRoutedNetDhcpStep1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 0: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccRoutedNetDhcpStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-routed-dhcp"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_network_dhcp.pools", "pool.*", map[string]string{
+						"start_address": "7.1.1.100",
+						"end_address":   "7.1.1.110",
+					}),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_network_dhcp.pools", "pool.*", map[string]string{
+						"start_address": "7.1.1.100",
+						"end_address":   "7.1.1.110",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_network_dhcp.pools", "pool.*", map[string]string{
+						"start_address": "7.1.1.130",
+						"end_address":   "7.1.1.140",
+					}),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_network_dhcp.pools",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgNsxtVdcObject(testConfig, "nsxt-routed-dhcp"),
+			},
+		},
+	})
+}
+
+const testAccRoutedNetDhcpConfig = `
+data "vcd_nsxt_edgegateway" "existing" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+  name = "{{.EdgeGw}}"
+}
+
+resource "vcd_network_routed_v2" "net1" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+  name = "nsxt-routed-dhcp"
+  description = "NSX-T routed network for DHCP testing"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  gateway       = "7.1.1.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "7.1.1.10"
+    end_address   = "7.1.1.20"
+  }
+}
+`
+
+const testAccRoutedNetDhcpStep1 = testAccRoutedNetDhcpConfig + `
+resource "vcd_nsxt_network_dhcp" "pools" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  org_network_id = vcd_network_routed_v2.net1.id
+  
+  pool {
+    start_address = "7.1.1.100"
+    end_address   = "7.1.1.110"
+  }
+}
+`
+
+const testAccRoutedNetDhcpStep2 = testAccRoutedNetDhcpConfig + `
+resource "vcd_nsxt_network_dhcp" "pools" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  org_network_id = vcd_network_routed_v2.net1.id
+  
+  pool {
+    start_address = "7.1.1.100"
+    end_address   = "7.1.1.110"
+  }
+
+  pool {
+    start_address = "7.1.1.130"
+    end_address   = "7.1.1.140"
+  }
+}
+`

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -167,6 +167,10 @@ func resourceVappNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
 
+	if orgNetworkName, ok := d.GetOk("org_network_name"); ok && vdc.IsNsxt() {
+		return fmt.Errorf("org network '%s' cannot be connected in NSX-T VDC", orgNetworkName)
+	}
+
 	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
 	if err != nil {
 		return fmt.Errorf("error finding vApp. %s", err)

--- a/website/docs/d/network_isolated.html.markdown
+++ b/website/docs/d/network_isolated.html.markdown
@@ -13,9 +13,9 @@ internal networks for vApps to connect. This network is not attached to external
 
 Supported in provider *v2.5+*
 
-~> **Note:** This data source supports only NSX-V backed Org VDC networks and is **deprecated**.
+~> **Note:** This data source supports only NSX-V backed Org VDC networks.
 Please use newer [`vcd_network_isolated_v2`](/docs/providers/vcd/d/network_isolated_v2.html)
-data source which is compatible with both NSX-V and NSX-T.
+data source which is compatible with NSX-T.
 
 ## Example Usage
 

--- a/website/docs/d/network_routed.html.markdown
+++ b/website/docs/d/network_routed.html.markdown
@@ -12,9 +12,9 @@ Provides a vCloud Director Org VDC routed Network data source. This can be used 
 
 Supported in provider *v2.5+*
 
-~> **Note:** This data source supports only NSX-V backed Org VDC networks and is **deprecated**.
+~> **Note:** This data source supports only NSX-V backed Org VDC networks.
 Please use newer [`vcd_network_routed_v2`](/docs/providers/vcd/d/network_routed_v2.html)
-data source which is compatible with both NSX-V and NSX-T.
+data source which is compatible with NSX-T.
 
 ## Example Usage
 

--- a/website/docs/d/nsxt_network_dhcp.html.markdown
+++ b/website/docs/d/nsxt_network_dhcp.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_dhcp_relay"
+sidebar_current: "docs-vcd-datasource-nsxt-network-dhcp"
+description: |-
+  Provides a data source to read DHCP pools for NSX-T Org VDC Routed network.
+---
+
+# vcd\_nsxt\_network\_dhcp
+
+Provides a data source to read DHCP pools for NSX-T Org VDC Routed network.
+
+Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
+
+## Example Usage 1
+
+```hcl
+
+data "vcd_network_routed_v2" "parent" {
+  org  = "my-org"
+  vdc  = "my-vdc"
+
+  name = "my-parent-network"
+}
+
+data "vcd_nsxt_network_dhcp" "pools" {
+  org  = "my-org"
+  vdc  = "my-vdc"
+
+  org_network_id = vcd_network_routed_v2.parent.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `org_network_id` - (Required) ID of parent Org VDC Routed network
+
+## Attribute Reference
+
+All the attributes defined in [`vcd_nsxt_network_dhcp`](/docs/providers/vcd/r/nsxt_network_dhcp.html)
+resource are available.

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -13,9 +13,9 @@ modify, and delete internal networks for vApps to connect. This network is not a
 
 Supported in provider *v2.0+*
 
-~> **Note:** This resource supports only NSX-V backed Org VDC networks and is **deprecated**.
+~> **Note:** This resource supports only NSX-V backed Org VDC networks.
 Please use newer [`vcd_network_isolated_v2`](/docs/providers/vcd/r/network_isolated_v2.html) resource
-which is compatible with both NSX-V and NSX-T.
+which is compatible with NSX-T.
 
 ## Example Usage
 

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -13,9 +13,9 @@ modify, and delete internal networks for vApps to connect.
 
 Supported in provider *v2.0+*
 
-~> **Note:** This resource supports only NSX-V backed Org VDC networks and is **deprecated**.
+~> **Note:** This resource supports only NSX-V backed Org VDC networks.
 Please use newer [`vcd_network_routed_v2`](/docs/providers/vcd/r/network_routed_v2.html) resource
-which is compatible with both NSX-V and NSX-T.
+which is compatible with NSX-T.
 
 ## Example Usage
 

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -1,0 +1,112 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_network-dhcp"
+sidebar_current: "docs-vcd-resource-nsxt-network-dhcp"
+description: |-
+  Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
+---
+
+# vcd\_nsxt\_network\_dhcp
+
+Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
+
+Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
+
+## Specific usage notes
+
+**DHCP pool support** for NSX-T Routed networks is **limited** by the API in the following ways:
+
+* DHCP pools can only be added, but not updated/removed one by one
+
+* VCD 10.2+ allows to remove all DHCP pools at once (terraform destroy/resource removal)
+
+* VCD 10.1 **does not allow to remove DHCP pools** after they are created without removing parent network
+therefore **destroying the resource will emit warning and do nothing** (to avoid breaking Terraform flow). 
+See [Example usage 2](#example-usage-2-pool-removal-on-vcd-101) to see a way for changing/removing DHCP pools
+
+## Example Usage 1
+
+```hcl
+resource "vcd_network_routed_v2" "parent-network" {
+  name = "nsxt-routed-dhcp"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  gateway = "7.1.1.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "7.1.1.10"
+    end_address   = "7.1.1.20"
+  }
+}
+
+resource "vcd_nsxt_network_dhcp" "pools" {
+  org_network_id = vcd_network_routed_v2.parent-network.id
+  
+  pool {
+    start_address = "7.1.1.100"
+    end_address   = "7.1.1.110"
+  }
+
+  pool {
+    start_address = "7.1.1.111"
+    end_address   = "7.1.1.112"
+  }
+}
+```
+
+## Example Usage 2 (Pool removal on VCD 10.1)
+
+DHCP pool definitions cannot be removed once defined therefore the trick is to recreate parent Org VDC network.
+This can be done by following such procedure:
+
+* Define the network and DHCP pools as in [Example Usage 1](#example-usage-1)
+* Use `terraform taint` on the parent network to force recreation:
+   ```sh
+   # terraform taint vcd_network_routed_v2.parent-network
+   Resource instance vcd_network_routed_v2.parent-network has been marked as tainted.
+   ```
+* Modify/remove `vcd_nsxt_network_dhcp` definition as per your needs
+* Perform `terraform apply`. This will recreate tainted parent Org VDC network and new DHCP pools if defined.
+You will see a WARNING during removal but it will not break :
+```sh
+vcd_nsxt_network_dhcp.pools: Destroying... [id=urn:vcloud:network:209666ec-6253-418a-a816-076b15413fea]
+vcd_nsxt_network_dhcp WARNING: for VCD versions < 10.2 DHCP pool removal is not supported. Destroy is a NO-OP operation for VCD versions < 10.2. Please recreate parent network to remove DHCP pools.
+vcd_nsxt_network_dhcp.pools: Destruction complete after 0s
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `org_network_id` - (Required) ID of parent Org VDC Routed network
+* `pool` - (Required) One or more blocks to define DHCP pool ranges. See [Pools](#pools) and example 
+for usage details.
+
+## Pools
+
+* `start_address` - (Required) Start address of DHCP pool range
+* `end_address` - (Required) End address of DHCP pool range
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing DHCP configuration can be [imported][docs-import] into this resource
+via supplying the full dot separated path for your Org VDC network. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_network_dhcp.imported my-org.my-org-vdc.my-nsxt-vdc-network-name
+```
+
+The above would import the DHCP config settings that are defined on VDC network 
+`my-nsxt-vdc-network-name` which is configured in organization named `my-org` and VDC named 
+`my-org-vdc`.

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -64,6 +64,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-network-isolated-v2") %>>
               <a href="/docs/providers/vcd/d/network_isolated_v2.html">vcd_network_isolated_v2</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-datasource-nsxt-network-dhcp") %>>
+              <a href="/docs/providers/vcd/d/nsxt_network_dhcp.html">vcd_nsxt_network_dhcp</a>
+            </li>            
             <li<%= sidebar_current("docs-vcd-data-source-network-direct") %>>
               <a href="/docs/providers/vcd/d/network_direct.html">vcd_network_direct</a>
             </li>
@@ -198,6 +201,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-network-isolated-v2") %>>
               <a href="/docs/providers/vcd/r/network_isolated_v2.html">vcd_network_isolated_v2</a>
+            </li>            
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-network-dhcp") %>>
+              <a href="/docs/providers/vcd/r/nsxt_network_dhcp.html">vcd_nsxt_network_dhcp</a>
             </li>            
             <li<%= sidebar_current("docs-vcd-resource-edgegateway") %>>
               <a href="/docs/providers/vcd/r/edgegateway.html">vcd_edgegateway</a>


### PR DESCRIPTION
This PR introduces `vcd_nsxt_network_dhcp` resource and datasource to manage NSX-T `vcd_network_routed_v2` DHCP pools.

**WARNING**
DHCP pool support for NSX-T Routed networks is limited by the API in the following ways:
* DHCP pools can only be added, but **not updated/removed one by one**
* VCD 10.2+ allows to remove all DHCP pools at once (terraform destroy/resource removal)
* VCD 10.1 **does not allow to remove DHCP pools after they are created without removing parent network** therefore destroying the resource will emit warning and do nothing (to avoid breaking Terraform flow). See Example usage 2 to see a way for changing/removing DHCP pools


Additionally this PR does:

It also adds some user guiding errors and WARNING messages:
* Throws error and reference to correct resource when:
  * `vcd_edgegateway` resource and datasource  throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC
  * `vcd_nsxt_edgegateway` resource and datasource  throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC

* NSX-T isolated and routed networks V1 throw warnings on create and errors on import by referring to V2 versions
* `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC  (because NSX-T networks cannot be attached to vApps)
* Fixes `vcd_vapp_vm` and `vcd_vm` when `network_dhcp_wait_seconds` is used for NSX-T backed VDCs (does not try to query NSX-V Edge Gateway leases)
* Impvoes  at least a few NSX-T tests so that they consume all NSX-T capable networks and attach them to VMs