### PR TITLE
Conditional running of test suite

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -470,6 +470,39 @@ To run these tests, you go inside `test-artifacts` and execute:
 
 The execution then proceeds as explained in [Binary testing](#Binary-testing).
 
+## Conditional running of tests
+
+The whole test suite takes several hours to run. If some errors happen during the run, we need to clean up and try again
+from the beginning, which is not always convenient.
+There are a few tags that help us gain some control on the flow:
+
+* `-vcd-pre-post-checks`    Perform checks before and after tests (false)
+* `-vcd-re-run-failed`      Run only tests that failed in a previous run (false)
+* `-vcd-remove-test-list`   Remove list of test runs (false)
+* `-vcd-show-count`         Show number of pass/fail tests (false)
+* `-vcd-show-elapsed-time`  Show elapsed time since the start of the suite in pre and post checks (false)
+* `-vcd-show-timestamp`     Show timestamp in pre and post checks (false)
+* `-vcd-skip-pattern`       Skip tests that match the pattern (implies vcd-pre-post-checks ()
+
+When `-vcd-pre-post-checks` is used, we have several advantages:
+
+1) After each successful test, the test name gets recorded in a file `vcd_test_pass_list_{VCD_IP}.txt`, and each failed
+   test goes to `vcd_test_fail_list_{VCD_IP}.txt`. When running the suite on the same VCD a second time, all tests in
+   the `pass` list are skipped. If the test run was interrupted (see #2 below), we can only run the tests that did not
+   run in the previous attempt.
+2) We can interrupt the tests by creating a file `skip_vcd_tests` in the `./vcd` directory. When this file is found by
+   the pre-run routine, all the tests are skipped. The file `skip_vcd_tests` will be removed automatically at the next run.
+3) We can skip one or more tests conditionally, using `-vcd-skip-pattern="{REGEXP}"`. All the test with a name that
+   matches the pattern are skipped.
+4) We can re-run only the tests that failed in the previous run, using `-vcd-re-run-failed`.
+5) We can add monitoring information with `-vcd-show-count`, `-vcd-show-elapsed-time`, `-vcd-show-timestamp`.
+
+If we use `-vcd-pre-post-checks` and the run was successful, the next run will skip all tests, because the test names
+would be all found in `vcd_test_pass_list_{VCD_IP}.txt`. To run again the test from scratch, we could either remove
+the file manually, or use the tag `-vcd-remove-test-list`.
+
+**VERY IMPORTANT**: for the conditional running to work, each test must have a call to `preTestChecks(t)`  at the beginning
+and to `postTestChecks(t)` right before the end.
 
 ## Environment variables and corresponding flags
 
@@ -500,5 +533,13 @@ used in the documentation index.
 * `GOVCD_KEEP_TEST_OBJECTS=1` does not delete test objects created with `VCD_TEST_DATA_GENERATION`
 * `VCD_MAX_ITEMS=number` during filter engine tests, limits the collection of data sources of a given type to the number
   indicated. The default is 5. The maximum is 100.
+* `VCD_PRE_POST_CHECKS` (`-vcd-pre-post-checks`) Perform checks before and after tests (false)
+* `VCD_RE_RUN_FAILED` (`-vcd-re-run-failed`) Run only tests that failed in a previous run (false)
+* `VCD_REMOVE_TEST_LIST` (`-vcd-remove-test-list`) Remove list of test runs (false)
+* `VCD_SHOW_COUNT` (`-vcd-show-count`) Show number of pass/fail tests (false)
+* `VCD_SHOW_ELAPSED_TIME` (`-vcd-show-elapsed-time`) Show elapsed time since the start of the suite in pre and post checks (false)
+* `VCD_SHOW_TIMESTAMP` (`-vcd-show-timestamp`) Show timestamp in pre and post checks (false)
+* `VCD_SKIP_PATTERN` (`-vcd-skip-pattern`) Skip tests that match the pattern (implies vcd-pre-post-checks ()
+
 
 When both the environment variable and the command line option are possible, the environment variable gets evaluated first.

--- a/TESTING.md
+++ b/TESTING.md
@@ -477,7 +477,7 @@ The whole test suite takes several hours to run. If some errors happen during th
 from the beginning, which is not always convenient.
 There are a few tags that help us gain some control on the flow:
 
-* `-vcd-pre-post-checks`    Perform checks before and after tests (false)
+* `-vcd-pre-post-checks`    Global switch enabling checks before and after tests (false). Also activated by using any of the flags below.
 * `-vcd-re-run-failed`      Run only tests that failed in a previous run (false)
 * `-vcd-remove-test-list`   Remove list of test runs (false)
 * `-vcd-show-count`         Show number of pass/fail tests (false)

--- a/TESTING.md
+++ b/TESTING.md
@@ -11,6 +11,7 @@
 - [Handling failures in binary tests](#handling-failures-in-binary-tests)
 - [Upgrade testing](#upgrade-testing)
 - [Custom terraform scripts](#custom-terraform-scripts)
+- [Conditional running of tests](#conditional-running-of-tests)
 - [Environment variables and corresponding flags](#environment-variables-and-corresponding-flags)
 
 ## Meeting prerequisites: Building the test environment
@@ -486,16 +487,17 @@ There are a few tags that help us gain some control on the flow:
 
 When `-vcd-pre-post-checks` is used, we have several advantages:
 
-1) After each successful test, the test name gets recorded in a file `vcd_test_pass_list_{VCD_IP}.txt`, and each failed
+1. After each successful test, the test name gets recorded in a file `vcd_test_pass_list_{VCD_IP}.txt`, and each failed
    test goes to `vcd_test_fail_list_{VCD_IP}.txt`. When running the suite on the same VCD a second time, all tests in
    the `pass` list are skipped. If the test run was interrupted (see #2 below), we can only run the tests that did not
    run in the previous attempt.
-2) We can interrupt the tests by creating a file `skip_vcd_tests` in the `./vcd` directory. When this file is found by
-   the pre-run routine, all the tests are skipped. The file `skip_vcd_tests` will be removed automatically at the next run.
-3) We can skip one or more tests conditionally, using `-vcd-skip-pattern="{REGEXP}"`. All the test with a name that
+2. We can **gracefully** interrupt the tests by creating a file `skip_vcd_tests` in the `./vcd` directory. 
+   When this file is found by the pre-run routine, all the tests are skipped. The file `skip_vcd_tests` will be removed
+   automatically at the next run.
+3. We can skip one or more tests conditionally, using `-vcd-skip-pattern="{REGEXP}"`. All the test with a name that
    matches the pattern are skipped.
-4) We can re-run only the tests that failed in the previous run, using `-vcd-re-run-failed`.
-5) We can add monitoring information with `-vcd-show-count`, `-vcd-show-elapsed-time`, `-vcd-show-timestamp`.
+4. We can re-run only the tests that failed in the previous run, using `-vcd-re-run-failed`.
+5. We can add monitoring information with `-vcd-show-count`, `-vcd-show-elapsed-time`, `-vcd-show-timestamp`.
 
 If we use `-vcd-pre-post-checks` and the run was successful, the next run will skip all tests, because the test names
 would be all found in `vcd_test_pass_list_{VCD_IP}.txt`. To run again the test from scratch, we could either remove

--- a/vcd/auth_saml_test.go
+++ b/vcd/auth_saml_test.go
@@ -14,6 +14,7 @@ import (
 // Note. The test cannot be run in parallel because it temporarily overrides authentication cache
 // and credentials for the purpose of its run. It restores them at the end.
 func TestAccVcdSamlAuth(t *testing.T) {
+	preTestChecks(t)
 
 	// Skip test if explicit SAML credentials are not specified
 	if testConfig.Provider.SamlUser == "" || testConfig.Provider.SamlPassword == "" {
@@ -102,6 +103,7 @@ func TestAccVcdSamlAuth(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdOrg = `

--- a/vcd/auth_test.go
+++ b/vcd/auth_test.go
@@ -22,6 +22,7 @@ import (
 // Note. Because this test does not use regular templateFill function - it will not generate binary
 // tests, but there should be no need for them as well.
 func TestAccAuth(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -229,6 +230,7 @@ func TestAccAuth(t *testing.T) {
 
 	// Clear connection cache to force other tests use their own mechanism
 	cachedVCDClients.reset()
+	postTestChecks(t)
 }
 
 func runAuthTest(t *testing.T, configText string) {

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1420,9 +1420,6 @@ func postTestChecks(t *testing.T) {
 	if err != nil {
 		fmt.Printf("WARNING: error adding test name '%s' to file '%s'\n", t.Name(), getTestListFile(fileType))
 	}
-	//if vcdShowCount {
-	//	fmt.Printf("Pass: %5d - Skip: %5d - Fail: %5d\n", vcdPassCount, vcdSkipCount, vcdFailCount)
-	//}
 }
 
 // getTestListFile returns the name of the file containing the wanted (pass/fail) list

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -36,6 +36,12 @@ func init() {
 	// To list the flags when we run "go test -tags functional -vcd-help", the flag name must start with "vcd"
 	// They will all appear alongside the native flags when we use an invalid one
 	setBoolFlag(&vcdHelp, "vcd-help", "VCD_HELP", "Show vcd flags")
+	setBoolFlag(&vcdRemoveTestList, "vcd-remove-test-list", "VCD_REMOVE_TEST_LIST", "Remove list of test runs")
+	setBoolFlag(&vcdPrePostChecks, "vcd-pre-post-checks", "VCD_PRE_POST_CHECKS", "Perform checks before and after tests")
+	setBoolFlag(&vcdShowTimestamp, "vcd-show-timestamp", "VCD_SHOW_TIMESTAMP", "Show timestamp in pre and post checks")
+	setBoolFlag(&vcdShowElapsedTime, "vcd-show-elapsed-time", "VCD_SHOW_ELAPSED_TIME", "Show elapsed time since the start of the suite in pre and post checks")
+	setBoolFlag(&vcdShowCount, "vcd-show-count", "VCD_SHOW_COUNT", "Show number of pass/fail tests")
+	setBoolFlag(&vcdReRunFailed, "vcd-re-run-failed", "VCD_RE_RUN_FAILED", "Run only tests that failed in a previous run")
 	setBoolFlag(&testDistributedNetworks, "vcd-test-distributed", "", "enables testing of distributed network")
 	setBoolFlag(&enableDebug, "vcd-debug", "GOVCD_DEBUG", "enables debug output")
 	setBoolFlag(&vcdTestVerbose, "vcd-verbose", "TEST_VERBOSE", "enables verbose output")
@@ -45,6 +51,7 @@ func init() {
 	setBoolFlag(&vcdSkipTemplateWriting, "vcd-skip-template-write", envVcdSkipTemplateWriting, "Skip writing templates to file")
 	setBoolFlag(&vcdRemoveOrgVdcFromTemplate, "vcd-remove-org-vdc-from-template", envVcdRemoveOrgVdcFromTemplate, "Remove org and VDC from template")
 	setBoolFlag(&vcdTestOrgUser, "vcd-test-org-user", envVcdTestOrgUser, "Run tests with org user")
+	setStringFlag(&vcdSkipPattern, "vcd-skip-pattern", "VCD_SKIP_PATTERN", "Skip tests that match the pattern (implies vcd-pre-post-checks")
 
 }
 
@@ -188,6 +195,38 @@ var (
 	// vcdTestOrgUser enables testing with the Org User
 	vcdTestOrgUser = false
 
+	// vcdRemoveTestList triggers the removal of the test run list if present
+	vcdRemoveTestList = false
+
+	// vcdPrePostChecks enables pre and post checks for all tests
+	vcdPrePostChecks = false
+
+	// vcdReRunFailed will run only tests that failed in a previous run
+	vcdReRunFailed = false
+
+	// vcdShowTimestamp shows a time stamp at the start of each test
+	vcdShowTimestamp = false
+
+	// vcdShowElapsedTime shows the elapsed time since the start od the suite
+	vcdShowElapsedTime = false
+
+	// vcdShowCount shows the count of pass/skip/fail at the end of the suite
+	vcdShowCount = false
+
+	// vcdSkipPattern will skip all tests with a name that matches a given pattern
+	vcdSkipPattern string
+
+	// vcdSkipAllFile is the name of the file that will skip all the tests if found during a pre-test check
+	vcdSkipAllFile = "skip_vcd_tests"
+
+	// vcdStartTime is he time when the tests started
+	vcdStartTime = time.Now()
+
+	// vcdPassCount, vcdFailCount, vcdSkipCount are the global counters for the tests result
+	vcdPassCount = 0
+	vcdFailCount = 0
+	vcdSkipCount = 0
+
 	// vcdHelp displays the vcd-* flags
 	vcdHelp = false
 
@@ -195,6 +234,9 @@ var (
 	// which in turn requires a NSX controller. To run the distributed test, users
 	// need to set the environment variable VCD_TEST_DISTRIBUTED_NETWORK
 	testDistributedNetworks = false
+
+	// runTestRunListFileLock regulates access to the list of run tests
+	runTestRunListFileLock = newMutexKVSilent()
 )
 
 const (
@@ -637,6 +679,15 @@ func TestMain(m *testing.M) {
 		fmt.Println()
 		os.Exit(0)
 	}
+	// If any of the checks is enabled, we enable the pre and post test functions
+	if vcdSkipPattern != "" || vcdShowElapsedTime || vcdShowTimestamp || vcdRemoveTestList ||
+		vcdShowCount || vcdReRunFailed {
+		vcdPrePostChecks = true
+	}
+	if vcdPrePostChecks {
+		// remove the user-placed skip file
+		_ = os.Remove(vcdSkipAllFile)
+	}
 
 	// Fills the configuration variable: it will be available to all tests,
 	// or the whole suite will fail if it is not found.
@@ -645,6 +696,16 @@ func TestMain(m *testing.M) {
 	configFile := getConfigFileName()
 	if configFile != "" {
 		testConfig = getConfigStruct(configFile)
+	}
+	if vcdRemoveTestList {
+		for _, ft := range []string{"pass", "fail"} {
+			err := removeTestRunList(ft)
+			if err != nil {
+				fmt.Printf("Error removing testRunList: %s", err)
+				fmt.Printf("You should remove the file %s manually before trying again", getTestListFile(ft))
+				os.Exit(0)
+			}
+		}
 	}
 	if !vcdShortTest {
 
@@ -695,6 +756,9 @@ func TestMain(m *testing.M) {
 		} else {
 			fmt.Printf("TestSuite destroy skipped - preserve turned on \n")
 		}
+	}
+	if vcdShowCount {
+		fmt.Printf("Pass: %5d - Skip: %5d - Fail: %5d\n", vcdPassCount, vcdSkipCount, vcdFailCount)
 	}
 
 	// TODO: cleanup leftovers
@@ -1035,6 +1099,16 @@ func setBoolFlag(varPointer *bool, name, envVar, help string) {
 	flag.BoolVar(varPointer, name, *varPointer, help)
 }
 
+// setStringFlag binds a flag to a string variable (passed as pointer)
+// it also uses an optional environment variable that, if set, will
+// update the variable before binding it to the flag.
+func setStringFlag(varPointer *string, name, envVar, help string) {
+	if envVar != "" && os.Getenv(envVar) != "" {
+		*varPointer = os.Getenv(envVar)
+	}
+	flag.StringVar(varPointer, name, *varPointer, help)
+}
+
 type envHelper struct {
 	vars map[string]string
 }
@@ -1250,4 +1324,192 @@ func testAccCheckVcdStandaloneVmDestroy(vmName string, orgName string, vdcName s
 
 		return nil
 	}
+}
+
+func timeStamp() string {
+	now := time.Now()
+	return now.Format(time.RFC3339)
+}
+
+// preTestChecks is to be called at the beginning of a test function.
+// It allows for several skipping mechanisms:
+//
+// 1) It will skip if the file 'skip_vcd_tests' is found.
+//   This allows to interrupt the test suite in  a clean way, by creating the skipping trigger file
+//   during the test run
+//   When the user creates such file, the tests still running will continue until their natural end
+//   and the other tests will skip
+//
+// 2) if the file 'skip_vcd_tests' contains a pattern, only the tests with a name that match such pattern will skip
+//
+// 3) It will skip if a test has already run successfully. This is useful when the suite was interrupted,
+//   so that we can repeat the run without repeating the tests that have succeeded
+//
+// 4) It will skip the test if a given environment variable was set
+//
+// 5) It will skip the test if the option -vcd-skip-pattern or the environment variable 'VCD_SKIP_PATTERN'
+//   contains a pattern that matches the test name.
+// 6) If the flag -vcd-re-run-failed is true, it will only run the tests that failed in the previous run
+func preTestChecks(t *testing.T) {
+	// if the test runs without -vcd-pre-post-checks, all post-checks will be skipped
+	if !vcdPrePostChecks {
+		return
+	}
+	if vcdShowTimestamp {
+		fmt.Printf("Test started at: %s\n", timeStamp())
+	}
+	if vcdShowElapsedTime {
+		elapsed := time.Since(vcdStartTime)
+		fmt.Printf("Elapsed: %s\n", elapsed.String())
+	}
+	if fileExists(vcdSkipAllFile) {
+		vcdSkipCount += 1
+		t.Skip(fmt.Sprintf("File '%s' found at %s. Test %s skipped", vcdSkipAllFile, timeStamp(), t.Name()))
+	}
+	if vcdSkipPattern != "" {
+		re := regexp.MustCompile(vcdSkipPattern)
+		if re.MatchString(t.Name()) {
+			vcdSkipCount += 1
+			t.Skip(fmt.Sprintf("Skip pattern '%s' matches test name '%s'", vcdSkipPattern, t.Name()))
+		}
+	}
+	skipEnvVar := fmt.Sprintf("skip-%s", t.Name())
+
+	if vcdTestVerbose {
+		fmt.Printf("ENV VAR for %s: %s\n", t.Name(), skipEnvVar)
+	}
+	if os.Getenv(skipEnvVar) != "" {
+		vcdSkipCount += 1
+		t.Skip(fmt.Sprintf("variable '%s' was set.", skipEnvVar))
+	}
+	// If this test has run already, we skip it
+	if isTestInFile(t.Name(), "pass") {
+		vcdSkipCount += 1
+		t.Skip(fmt.Sprintf("test '%s' found in '%s' ", t.Name(), getTestListFile("pass")))
+	}
+	if vcdReRunFailed {
+		if !isTestInFile(t.Name(), "fail") {
+			vcdSkipCount += 1
+			t.Skip("only running tests that have failed at the previous run")
+		}
+	}
+}
+
+// postTestChecks runs checks after the test
+// It performs the following:
+// 1) shows a time stamp (if enabled by -vcd-show-timestamp
+// 2) stores file name in the "pass" or "fail" list, depending on their outcome. The lists are distinct by VCD IP
+// 3) increments the pass/fail counters
+func postTestChecks(t *testing.T) {
+	// if the test runs without -vcd-pre-post-checks, all post-checks will be skipped
+	if !vcdPrePostChecks {
+		return
+	}
+	if vcdShowTimestamp {
+		fmt.Printf("Test ended at at: %s\n", timeStamp())
+	}
+	var err error
+	var fileType = "pass"
+	if t.Failed() {
+		fileType = "fail"
+		vcdFailCount += 1
+	} else {
+		vcdPassCount += 1
+	}
+	err = addToTestRunList(t.Name(), fileType)
+	if err != nil {
+		fmt.Printf("WARNING: error adding test name '%s' to file '%s'\n", t.Name(), getTestListFile(fileType))
+	}
+	//if vcdShowCount {
+	//	fmt.Printf("Pass: %5d - Skip: %5d - Fail: %5d\n", vcdPassCount, vcdSkipCount, vcdFailCount)
+	//}
+}
+
+// getTestListFile returns the name of the file containing the wanted (pass/fail) list
+// for the VCD being tested
+func getTestListFile(fileType string) string {
+	if testConfig.Provider.Url == "" {
+		return ""
+	}
+	testingVcdIp := strings.Replace(testConfig.Provider.Url, "https://", "", -1)
+	testingVcdIp = strings.Replace(testingVcdIp, "/api", "", -1)
+	testingVcdIp = strings.Replace(testingVcdIp, "/", "", -1)
+	testingVcdIp = strings.Replace(testingVcdIp, ".", "-", -1)
+	return fmt.Sprintf("vcd_test_%s_list-%s.txt", fileType, testingVcdIp)
+}
+
+// isTestInFile returns true if a given test name is found in the wanted (pass/fail) list
+func isTestInFile(testName, fileType string) bool {
+	fileName := getTestListFile(fileType)
+	if fileName == "" {
+		return false
+	}
+	runTestRunListFileLock.kvLock(fileName)
+	defer runTestRunListFileLock.kvUnlock(fileName)
+	if !fileExists(fileName) {
+		return false
+	}
+	f, err := os.Open(fileName) // #nosec G304
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == testName {
+			return true
+		}
+	}
+	return false
+}
+
+// removeTestRunList removes the wanted (pass/fail) list for the VCD being tested
+// This operation is triggered by -vcd-remove-test-list, and it is needed to run
+// a test again after running with -vcd-pre-post-checks
+func removeTestRunList(fileType string) error {
+	fileName := getTestListFile(fileType)
+	runTestRunListFileLock.kvLock(fileName)
+	defer runTestRunListFileLock.kvUnlock(fileName)
+	if fileExists(vcdSkipAllFile) {
+		err := os.Remove(vcdSkipAllFile)
+		if err != nil {
+			return err
+		}
+	}
+	if !fileExists(fileName) {
+		fmt.Printf("[removeTestRunList] '%s' not found\n", fileName)
+		return nil
+	}
+	return os.Remove(fileName)
+}
+
+// addToTestRunList adds a given test name to a wanted (pass/fail) list
+func addToTestRunList(testName, fileType string) error {
+	fileName := getTestListFile(fileType)
+	if fileName == "" {
+		return nil
+	}
+	runTestRunListFileLock.kvLock(fileName)
+	defer runTestRunListFileLock.kvUnlock(fileName)
+
+	var file *os.File
+	var err error
+	if fileExists(fileName) {
+		file, err = os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY, os.ModeAppend)
+	} else {
+		file, err = os.Create(fileName)
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	w := bufio.NewWriter(file)
+	_, err = fmt.Fprintf(w, "%s\n", testName)
+	if err != nil {
+		return fmt.Errorf("error writing to file %s: %s", fileName, err)
+	}
+	return w.Flush()
 }

--- a/vcd/datasource_filter_test.go
+++ b/vcd/datasource_filter_test.go
@@ -297,6 +297,7 @@ func generateTemplates(matches []govcd.FilterMatch) (string, map[string]string, 
 // 2. It will then generate the HCL script for the data source
 // 3. The test will check that each data source matches the expected entity name
 func TestAccSearchEngine(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -311,6 +312,7 @@ func TestAccSearchEngine(t *testing.T) {
 	t.Run("media", func(t *testing.T) { runSearchTest(types.QtMedia, "media", t) })
 	t.Run("catalog", func(t *testing.T) { runSearchTest(types.QtCatalog, "catalog", t) })
 	t.Run("edge_gateway", func(t *testing.T) { runSearchTest(types.QtEdgeGateway, "edge_gateway", t) })
+	postTestChecks(t)
 }
 
 // runSearchTest builds the test elements for the given entityType and run the test itself

--- a/vcd/datasource_nsxt_manager_test.go
+++ b/vcd/datasource_nsxt_manager_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdDatasourceNsxtManager(t *testing.T) {
+	preTestChecks(t)
 
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + " requires system admin privileges")
@@ -47,6 +48,7 @@ func TestAccVcdDatasourceNsxtManager(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdNsxtManager = `

--- a/vcd/datasource_nsxt_tier0_router_test.go
+++ b/vcd/datasource_nsxt_tier0_router_test.go
@@ -12,13 +12,17 @@ import (
 // TestAccVcdDatasourceNsxtTier0Router checks if datasource can find existing regular Tier-0 router
 // provided it is specified in configuration
 func TestAccVcdDatasourceNsxtTier0Router(t *testing.T) {
+	preTestChecks(t)
 	testAccVcdDatasourceNsxtTier0Router(t, testConfig.Nsxt.Tier0router)
+	postTestChecks(t)
 }
 
 // TestAccVcdDatasourceNsxtTier0Router checks if datasource can find existing VRF Tier-0 router
 // provided it is specified in configuration
 func TestAccVcdDatasourceNsxtTier0RouterVrf(t *testing.T) {
+	preTestChecks(t)
 	testAccVcdDatasourceNsxtTier0Router(t, testConfig.Nsxt.Tier0routerVrf)
+	postTestChecks(t)
 }
 
 func testAccVcdDatasourceNsxtTier0Router(t *testing.T, tier0RouterName string) {

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -16,6 +16,7 @@ import (
 // sources defined in this provider always return error and substring 'govcd.ErrorEntityNotFound' in it when an object
 // is not found.
 func TestAccDataSourceNotFound(t *testing.T) {
+	preTestChecks(t)
 	// Exit the test early
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -29,6 +30,7 @@ func TestAccDataSourceNotFound(t *testing.T) {
 	for _, dataSource := range Provider().DataSources() {
 		t.Run(dataSource.Name, testSpecificDataSourceNotFound(t, dataSource.Name, vcdClient))
 	}
+	postTestChecks(t)
 }
 
 func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClient *VCDClient) func(*testing.T) {

--- a/vcd/datasource_vcd_catalog_item_test.go
+++ b/vcd/datasource_vcd_catalog_item_test.go
@@ -15,6 +15,7 @@ import (
 // Using a catalog item data source we create another catalog item
 // where the description is the first data source ID
 func TestAccVcdCatalogAndItemDatasource(t *testing.T) {
+	preTestChecks(t)
 	var TestCatalogItemDS = "TestCatalogItemDS"
 
 	var params = StringMap{
@@ -73,6 +74,7 @@ func TestAccVcdCatalogAndItemDatasource(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func catalogItemDestroyed(catalog, itemName string) resource.TestCheckFunc {

--- a/vcd/datasource_vcd_catalog_media_test.go
+++ b/vcd/datasource_vcd_catalog_media_test.go
@@ -16,6 +16,7 @@ import (
 // Using a catalog media data source we create another catalog media
 // where the description is the first data source ID
 func TestAccVcdCatalogAndMediaDatasource(t *testing.T) {
+	preTestChecks(t)
 	var TestCatalogMediaDS = "TestCatalogMediaDS"
 	var TestAccVcdDataSourceMedia = "TestAccVcdCatalogMediaBasic"
 	var TestAccVcdDataSourceMediaDescription = "TestAccVcdCatalogMediaBasicDescription"
@@ -59,6 +60,7 @@ func TestAccVcdCatalogAndMediaDatasource(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func catalogMediaDestroyed(catalog, mediaName string) resource.TestCheckFunc {

--- a/vcd/datasource_vcd_external_network_v2_test.go
+++ b/vcd/datasource_vcd_external_network_v2_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdExternalNetworkV2Datasource(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + " requires system admin privileges")
 		return
@@ -57,6 +58,7 @@ func TestAccVcdExternalNetworkV2Datasource(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const externalNetworkV2Datasource = `

--- a/vcd/datasource_vcd_independent_disk_test.go
+++ b/vcd/datasource_vcd_independent_disk_test.go
@@ -15,6 +15,7 @@ import (
 // Test independent disk data resource
 // Using a disk data source we reference a disk data source
 func TestAccVcdDataSourceIndependentDisk(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdDataSourceIndependentDisk requires system admin privileges")
 	}
@@ -83,6 +84,7 @@ func TestAccVcdDataSourceIndependentDisk(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testCheckDiskNonStringOutputs() resource.TestCheckFunc {

--- a/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -81,6 +82,7 @@ func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkIsolatedV2NsxtDS = TestAccVcdNetworkIsolatedV2NsxtStep1 + `

--- a/vcd/datasource_vcd_network_isolated_v2_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdNetworkIsolatedV2NsxvDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -76,7 +77,7 @@ func TestAccVcdNetworkIsolatedV2NsxvDS(t *testing.T) {
 			},
 		},
 	})
-
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkIsolatedV2NsxvDS = `

--- a/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -82,6 +83,7 @@ func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkRoutedV2NsxtDS = TestAccVcdNetworkRoutedV2NsxtStep1 + `

--- a/vcd/datasource_vcd_network_routed_v2_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdNetworkRoutedV2NsxvDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -71,7 +72,7 @@ func TestAccVcdNetworkRoutedV2NsxvDS(t *testing.T) {
 			},
 		},
 	})
-
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkRoutedV2NsxvDS = `

--- a/vcd/datasource_vcd_network_test.go
+++ b/vcd/datasource_vcd_network_test.go
@@ -98,6 +98,7 @@ func getAvailableNetworks() error {
 }
 
 func TestAccVcdNetworkDirectDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -159,9 +160,11 @@ func TestAccVcdNetworkDirectDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -216,9 +219,11 @@ func TestAccVcdNetworkRoutedDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkIsolatedDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -274,6 +279,7 @@ func TestAccVcdNetworkIsolatedDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const datasourceTestNetworkDirect = `

--- a/vcd/datasource_vcd_nsxt_edge_cluster_test.go
+++ b/vcd/datasource_vcd_nsxt_edge_cluster_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdNsxtEdgeCluster(t *testing.T) {
+	preTestChecks(t)
 	skipNoNsxtConfiguration(t)
 
 	if !usingSysAdmin() {
@@ -70,6 +71,7 @@ func TestAccVcdNsxtEdgeCluster(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const nsxtEdgeClusterDatasource = `

--- a/vcd/datasource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_test.go
@@ -12,6 +12,7 @@ import (
 // TestAccVcdNsxtEdgeGatewayMultipleSubnets test creates its own external network with many subnets and tests if edge
 // gateway resource can correctly consume these multiple subnets
 func TestAccVcdNsxtEdgeGatewayMultipleSubnetsAndDS(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + " requires system admin privileges")
 		return
@@ -113,6 +114,7 @@ func TestAccVcdNsxtEdgeGatewayMultipleSubnetsAndDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccNsxtEdgeGatewayMultipleSubnets = `
@@ -254,6 +256,7 @@ data "vcd_nsxt_edgegateway" "egw-ds" {
 // using NSX-T datasource. There is a validator inside `vcd_nsxt_edgegateway` which is supposed to refer to
 // `vcd_edgegateway` when VDC is NSX-V
 func TestAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -284,6 +287,7 @@ func TestAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNsxtEdgeGatewayDSDoesNotAcceptNsxv = `

--- a/vcd/datasource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdOpenApiDhcpNsxtRoutedDS(t *testing.T) {
+	preTestChecks(t)
 	skipNoNsxtConfiguration(t)
 
 	// This test creates a resource and uses datasource which is not possible in single file
@@ -63,6 +64,7 @@ func TestAccVcdOpenApiDhcpNsxtRoutedDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccRoutedNetDhcpStep1DS = testAccRoutedNetDhcpConfig + `

--- a/vcd/datasource_vcd_nsxt_network_imported_test.go
+++ b/vcd/datasource_vcd_nsxt_network_imported_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -87,6 +88,7 @@ func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkImportedNsxtDS = TestAccVcdNetworkImportedV2NsxtStep1 + `

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -10,6 +10,7 @@ import (
 
 // Cloning an organization using an existing organization as data source
 func TestAccVcdDatasourceOrg(t *testing.T) {
+	preTestChecks(t)
 
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdDatasourceOrg requires system admin privileges")
@@ -82,6 +83,7 @@ func TestAccVcdDatasourceOrg(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdDatasourceOrg = `

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -13,6 +13,7 @@ import (
 var vdcName = "TestAccVcdVdcDatasource"
 
 func TestAccVcdVdcDatasource(t *testing.T) {
+	preTestChecks(t)
 	validateConfiguration(t)
 
 	var params = StringMap{
@@ -70,7 +71,7 @@ func TestAccVcdVdcDatasource(t *testing.T) {
 
 		validateResourceAndDataSource(t, configText, datasourceVdc)
 	}
-
+	postTestChecks(t)
 }
 
 func validateResourceAndDataSource(t *testing.T, configText string, datasourceVdc string) {

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -20,6 +20,7 @@ type listDef struct {
 }
 
 func TestAccVcdDatasourceResourceList(t *testing.T) {
+	preTestChecks(t)
 
 	var lists = []listDef{
 		{"resources", "resources", "", "vcd_org"},
@@ -73,6 +74,7 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 	for _, def := range lists {
 		t.Run(def.name+"-"+def.resourceType, func(t *testing.T) { runResourceInfoTest(def, t) })
 	}
+	postTestChecks(t)
 }
 
 func runResourceInfoTest(def listDef, t *testing.T) {

--- a/vcd/datasource_vcd_resource_schema_test.go
+++ b/vcd/datasource_vcd_resource_schema_test.go
@@ -10,10 +10,12 @@ import (
 )
 
 func TestAccVcdDatasourceResourceSchema(t *testing.T) {
+	preTestChecks(t)
 
 	for name := range globalResourceMap {
 		t.Run(name, func(t *testing.T) { runResourceSchemaTest(name, t) })
 	}
+	postTestChecks(t)
 }
 
 func runResourceSchemaTest(name string, t *testing.T) {

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccVcdStorageProfileDS(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -51,6 +52,7 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // checkStorageProfileOriginatesInParentVdc tries to evaluate reverse order and ensure that the found storage profile ID

--- a/vcd/datasource_vcd_vapp_network_test.go
+++ b/vcd/datasource_vcd_vapp_network_test.go
@@ -12,6 +12,7 @@ import (
 
 // TestAccVcdVappNetworkDS tests a vApp network data source if a vApp is found in the VDC
 func TestAccVcdVappNetworkDS(t *testing.T) {
+	preTestChecks(t)
 	networkName := "TestAccVcdVappNetworkDS"
 	description := "Created in test"
 	const gateway = "192.168.0.1"
@@ -83,6 +84,7 @@ func TestAccVcdVappNetworkDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testCheckVappNetworkNonStringOutputs(guestVlanAllowed, retainIpMacEnabled bool) resource.TestCheckFunc {

--- a/vcd/datasource_vcd_vapp_org_network_test.go
+++ b/vcd/datasource_vcd_vapp_org_network_test.go
@@ -13,6 +13,7 @@ import (
 
 // TestAccVcdVappOrgNetworkDS tests a vApp org network data source if a vApp is found in the VDC
 func TestAccVcdVappOrgNetworkDS(t *testing.T) {
+	preTestChecks(t)
 	var retainIpMacEnabled = true
 
 	var params = StringMap{
@@ -46,6 +47,7 @@ func TestAccVcdVappOrgNetworkDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testCheckVappOrgNetworkNonStringOutputs(retainIpMacEnabled bool) resource.TestCheckFunc {

--- a/vcd/datasource_vcd_vapp_test.go
+++ b/vcd/datasource_vcd_vapp_test.go
@@ -43,6 +43,7 @@ func getAvailableVapp() (*govcd.VApp, error) {
 
 // TestAccVcdVappDS tests a vApp data source if a vApp is found in the VDC
 func TestAccVcdVappDS(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -87,6 +88,7 @@ func TestAccVcdVappDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const datasourceTestVapp = `

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestAccVcdVappDS tests a VM data source if a vApp + VM is found in the VDC
 func TestAccVcdVappVmDS(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"VDC":         testConfig.VCD.Vdc,
@@ -45,6 +46,7 @@ func TestAccVcdVappVmDS(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const datasourceTestVappVm = `

--- a/vcd/datasource_vcenter_test.go
+++ b/vcd/datasource_vcenter_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVcenter(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + "  requires system admin privileges")
 	}
@@ -41,6 +42,7 @@ func TestAccVcdVcenter(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const datasourceTestVcenter = `

--- a/vcd/mutexkv.go
+++ b/vcd/mutexkv.go
@@ -14,23 +14,32 @@ import (
 // The initial use case is to let aws_security_group_rule resources serialize
 // their access to individual security groups based on SG ID.
 type mutexKV struct {
-	lock  sync.Mutex
-	store map[string]*sync.Mutex
+	lock   sync.Mutex
+	store  map[string]*sync.Mutex
+	silent bool
 }
 
 // Locks the mutex for the given key. Caller is responsible for calling kvUnlock
 // for the same key
 func (m *mutexKV) kvLock(key string) {
-	log.Printf("[DEBUG] Locking %q", key)
+	if !m.silent {
+		log.Printf("[DEBUG] Locking %q", key)
+	}
 	m.get(key).Lock()
-	log.Printf("[DEBUG] Locked %q", key)
+	if !m.silent {
+		log.Printf("[DEBUG] Locked %q", key)
+	}
 }
 
 // kvUnlock the mutex for the given key. Caller must have called kvLock for the same key first
 func (m *mutexKV) kvUnlock(key string) {
-	log.Printf("[DEBUG] Unlocking %q", key)
+	if !m.silent {
+		log.Printf("[DEBUG] Unlocking %q", key)
+	}
 	m.get(key).Unlock()
-	log.Printf("[DEBUG] Unlocked %q", key)
+	if !m.silent {
+		log.Printf("[DEBUG] Unlocked %q", key)
+	}
 }
 
 // Returns a mutex for the given key, no guarantee of its lock status
@@ -49,5 +58,13 @@ func (m *mutexKV) get(key string) *sync.Mutex {
 func newMutexKV() *mutexKV {
 	return &mutexKV{
 		store: make(map[string]*sync.Mutex),
+	}
+}
+
+//  newMutexKVSilent returns a properly initalized mutexKV with the silent property set
+func newMutexKVSilent() *mutexKV {
+	return &mutexKV{
+		store:  make(map[string]*sync.Mutex),
+		silent: true,
 	}
 }

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -20,12 +20,14 @@ var testAccProvider *schema.Provider
 var testAccProviders map[string]func() (*schema.Provider, error)
 
 func TestProvider(t *testing.T) {
+	// Do not add pre and post checks
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
+	// Do not add pre and post checks
 	var _ *schema.Provider = Provider()
 }
 
@@ -92,6 +94,7 @@ func minIfLess(min, value int) int {
 // TestAccClientUserAgent ensures that client initialization config.Client() used by provider initializes
 // go-vcloud-director client by having User-Agent set
 func TestAccClientUserAgent(t *testing.T) {
+	// Do not add pre and post checks
 	// Exit the test early
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -15,6 +15,7 @@ var TestAccVcdCatalogItem = "TestAccVcdCatalogItemBasic"
 var TestAccVcdCatalogItemDescription = "TestAccVcdCatalogItemBasicDescription"
 
 func TestAccVcdCatalogItemBasic(t *testing.T) {
+	preTestChecks(t)
 
 	var params = StringMap{
 		"Org":             testConfig.VCD.Org,
@@ -74,6 +75,7 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func preRunChecks(t *testing.T) {

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -15,6 +15,7 @@ var TestAccVcdCatalogMedia = "TestAccVcdCatalogMediaBasic"
 var TestAccVcdCatalogMediaDescription = "TestAccVcdCatalogMediaBasicDescription"
 
 func TestAccVcdCatalogMediaBasic(t *testing.T) {
+	preTestChecks(t)
 
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
@@ -86,6 +87,7 @@ func TestAccVcdCatalogMediaBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testCheckMediaNonStringOutputs() resource.TestCheckFunc {

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -19,6 +19,7 @@ var TestAccVcdCatalogName = "TestAccVcdCatalog"
 var TestAccVcdCatalogDescription = "TestAccVcdCatalogBasicDescription"
 
 func TestAccVcdCatalog(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":            testConfig.VCD.Org,
 		"CatalogName":    TestAccVcdCatalogName,
@@ -94,11 +95,13 @@ func TestAccVcdCatalog(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // TestAccVcdCatalogWithStorageProfile is very similar to TestAccVcdCatalog, but it ensure that a catalog can be created
 // using specific storage profile
 func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":            testConfig.VCD.Org,
 		"Vdc":            testConfig.VCD.Vdc,
@@ -142,6 +145,7 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdCatalogExists(name string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdEdgeGatewaySettingsFull(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("Edge Gateway resource tests require system admin privileges")
 		return
@@ -67,6 +68,7 @@ func TestAccVcdEdgeGatewaySettingsFull(t *testing.T) {
 	}
 	configText := templateFill(testAccEdgeGatewaySettingsFull, params)
 	debugPrintf("#[DEBUG] %s", configText)
+	postTestChecks(t)
 }
 
 func getEdgeGatewayInfo() (*govcd.EdgeGateway, error) {
@@ -95,6 +97,7 @@ func getEdgeGatewayInfo() (*govcd.EdgeGateway, error) {
 }
 
 func TestAccVcdEdgeGatewaySettingsBasic(t *testing.T) {
+	preTestChecks(t)
 
 	testName := "EdgeGatewaySettingsBasic"
 	var existingEgw *govcd.EdgeGateway
@@ -202,6 +205,7 @@ func TestAccVcdEdgeGatewaySettingsBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // boolComparisonToErr returns an error if the two provided values don't match

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -21,6 +21,7 @@ var (
 )
 
 func TestAccVcdEdgeGatewayBasic(t *testing.T) {
+	preTestChecks(t)
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_basic"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -72,9 +73,11 @@ func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdEdgeGatewayComplex(t *testing.T) {
+	preTestChecks(t)
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_basic"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -125,6 +128,7 @@ func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdEdgeGatewayDestroy(edgeName string) resource.TestCheckFunc {
@@ -158,6 +162,7 @@ func testAccCheckVcdEdgeGatewayDestroy(edgeName string) resource.TestCheckFunc {
 }
 
 func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
+	preTestChecks(t)
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_networks"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -319,6 +324,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // isPortGroupDistributed  checks if portgroup is defined in Distributed or Standard vSwitch
@@ -353,6 +359,7 @@ func isPortGroupDistributed(portGroupName string) (bool, error) {
 // network is of type "NETWORK" (standard switch portgroup) and only proceeds when it is of type
 // "DV_PORTGROUP" (Backed by distributed switch). Only "DV_PORTGROUP" support rate limiting.
 func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
+	preTestChecks(t)
 	isPgDistributed, err := isPortGroupDistributed(testConfig.Networking.ExternalNetworkPortGroup)
 	if err != nil {
 		t.Skipf("Skipping test because port group type could not be validated")
@@ -443,6 +450,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccEdgeGatewayRateLimits = testAccEdgeGatewayComplexNetwork + `
@@ -483,6 +491,7 @@ resource "vcd_edgegateway" "egw" {
 // same external network. If this test ever fails then it means locks have to be used on external
 // networks.
 func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
+	preTestChecks(t)
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_networks"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -532,6 +541,7 @@ func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // TODO external network has a bug that it uses a TypeList for `ip_scope` field. If the below two

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVpn_Basic(t *testing.T) {
+	preTestChecks(t)
 	var vpnName string = "TestAccVcdVpnVpn"
 
 	// String map to fill the template
@@ -54,6 +55,7 @@ func TestAccVcdVpn_Basic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVpnDestroy(s *terraform.State) error {

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -15,6 +15,7 @@ var TestAccVcdExternalNetwork = "TestAccVcdExternalNetworkBasic"
 var externalNetwork govcd.ExternalNetwork
 
 func TestAccVcdExternalNetworkBasic(t *testing.T) {
+	preTestChecks(t)
 
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdExternalNetworkBasic requires system admin privileges")
@@ -94,6 +95,7 @@ func TestAccVcdExternalNetworkBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdExternalNetworkExists(name string, externalNetwork *govcd.ExternalNetwork) resource.TestCheckFunc {

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccVcdExternalNetworkV2NsxtVrf(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -26,10 +27,13 @@ func TestAccVcdExternalNetworkV2NsxtVrf(t *testing.T) {
 		t.Skip("NSX-T VRF-Lite backed external networks are officially supported only in 10.2.0+")
 	}
 	testAccVcdExternalNetworkV2Nsxt(t, testConfig.Nsxt.Tier0routerVrf)
+	postTestChecks(t)
 }
 
 func TestAccVcdExternalNetworkV2Nsxt(t *testing.T) {
+	preTestChecks(t)
 	testAccVcdExternalNetworkV2Nsxt(t, testConfig.Nsxt.Tier0router)
+	postTestChecks(t)
 }
 
 func testAccVcdExternalNetworkV2Nsxt(t *testing.T, nsxtTier0Router string) {
@@ -248,6 +252,7 @@ output "nsxt-tier0-router" {
 `
 
 func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -363,6 +368,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdExternalNetworkV2NsxvDs = `

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -17,6 +17,7 @@ var resourceNameSecond = "TestAccVcdIndependentDiskBasic_2"
 var name = "TestAccVcdIndependentDiskBasic"
 
 func TestAccVcdIndependentDiskBasic(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdIndependentDiskBasic requires system admin privileges")
 	}
@@ -85,6 +86,7 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckDiskCreated(itemName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -19,6 +19,7 @@ var TestAccVcdCatalogMediaDescriptionForInsert = "TestAccVcdCatalogMediaBasicDes
 var TestAccVcdVAppVmNetForInsert = "TestAccVcdVAppVmNetForInsert"
 
 func TestAccVcdMediaInsertBasic(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
 		"Vdc":              testConfig.VCD.Vdc,
@@ -59,6 +60,7 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckMediaInserted(itemName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestAccVcdIpSet(t *testing.T) {
+	preTestChecks(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -110,6 +111,7 @@ func TestAccVcdIpSet(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdIpSetDestroy(resource, ipSetName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccVcdLBAppProfile(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":            testConfig.VCD.Org,
@@ -185,6 +186,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdLBAppProfileDestroy(appProfileName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_lb_app_rule_test.go
+++ b/vcd/resource_vcd_lb_app_rule_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestAccVcdLBAppRule(t *testing.T) {
+	preTestChecks(t)
 	// The Script parameter must be sent as multiline string separated by newline (\n) characters.
 	// Terraform has a native HEREDOC format for sending raw strings (with newline characters).
 	// This variable is established for easier test comparison and is wrapped into HEREDOC syntax
@@ -117,6 +118,7 @@ acl other_page2 url_beg / other2 redirect location https://www.other2.com/ ifoth
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdLBAppRuleDestroy(appRuleName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_lb_server_pool_test.go
+++ b/vcd/resource_vcd_lb_server_pool_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccVcdLbServerPool(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":                testConfig.VCD.Org,
@@ -215,6 +216,7 @@ func TestAccVcdLbServerPool(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdLbServerPoolDestroy(serverPoolName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_lb_service_monitor_test.go
+++ b/vcd/resource_vcd_lb_service_monitor_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestAccVcdLbServiceMonitor(t *testing.T) {
+	preTestChecks(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -93,6 +94,7 @@ func TestAccVcdLbServiceMonitor(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdLbServiceMonitorDestroy(serviceMonitorName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_lb_virtual_server_test.go
+++ b/vcd/resource_vcd_lb_virtual_server_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAccVcdLbVirtualServer(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":               testConfig.VCD.Org,
@@ -113,6 +114,7 @@ func TestAccVcdLbVirtualServer(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdLbVirtualServerDestroy(virtualServerName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestAccVcdNetworkIsolatedV2Nsxt tests out NSX-T backed Org VDC networking capabilities
 func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -104,6 +105,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const TestAccVcdNetworkIsolatedV2NsxtStep1 = `

--- a/vcd/resource_vcd_network_isolated_v2_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdNetworkIsolatedV2Nsxv(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.VCD.Vdc,
@@ -55,6 +56,7 @@ func TestAccVcdNetworkIsolatedV2Nsxv(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkIsolatedV2Nsxv = `

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -10,6 +10,7 @@ import (
 
 // TestAccVcdNetworkRoutedV2Nsxt tests out NSX-T backed Org VDC networking capabilities
 func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -116,6 +117,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const TestAccVcdNetworkRoutedV2NsxtStep1 = `

--- a/vcd/resource_vcd_network_routed_v2_test.go
+++ b/vcd/resource_vcd_network_routed_v2_test.go
@@ -11,6 +11,7 @@ import (
 // TestAccVcdNetworkRoutedV2NsxvInterfaceTypes attempts to test all supported interface types (except distributed) for
 // NSX-V Org VDC routed network
 func TestAccVcdNetworkRoutedV2NsxvInterfaceTypes(t *testing.T) {
+	preTestChecks(t)
 	var params = StringMap{
 		"Org":           testConfig.VCD.Org,
 		"Vdc":           testConfig.VCD.Vdc,
@@ -61,9 +62,11 @@ func TestAccVcdNetworkRoutedV2NsxvInterfaceTypes(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedV2NsxvDistributedInterface(t *testing.T) {
+	preTestChecks(t)
 	if !testDistributedNetworksEnabled() {
 		t.Skip("Distributed test skipped: not enabled")
 	}
@@ -117,6 +120,7 @@ func TestAccVcdNetworkRoutedV2NsxvDistributedInterface(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdNetworkRoutedV2Nsxv = `

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -58,6 +58,7 @@ const (
 )
 
 func TestAccVcdNetworkIsolatedStatic1(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  isolatedStaticNetwork1,
 		gateway:               "192.168.2.1",
@@ -76,9 +77,11 @@ func TestAccVcdNetworkIsolatedStatic1(t *testing.T) {
 	}
 
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkIsolatedStatic2(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  isolatedStaticNetwork2,
 		gateway:               "192.168.2.1",
@@ -100,9 +103,11 @@ func TestAccVcdNetworkIsolatedStatic2(t *testing.T) {
 		resourceName:          "vcd_network_isolated",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkIsolatedDhcp(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:               isolatedDhcpNetwork,
 		gateway:            "192.168.2.1",
@@ -124,9 +129,11 @@ func TestAccVcdNetworkIsolatedDhcp(t *testing.T) {
 		resourceName:       "vcd_network_isolated",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkIsolatedMixed1(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  isolatedMixedNetwork1,
 		gateway:               "192.168.2.1",
@@ -149,8 +156,10 @@ func TestAccVcdNetworkIsolatedMixed1(t *testing.T) {
 	}
 
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 func TestAccVcdNetworkIsolatedMixed2(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  isolatedMixedNetwork2,
 		gateway:               "192.168.2.1",
@@ -176,11 +185,13 @@ func TestAccVcdNetworkIsolatedMixed2(t *testing.T) {
 		resourceName:          "vcd_network_isolated",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 // TestAccVcdNetworkRoutedStatic1 tests a routed network with static IP pool
 // and implicit internal interface
 func TestAccVcdNetworkRoutedStatic1(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  routedStaticNetwork1,
 		gateway:               "10.10.102.1",
@@ -198,9 +209,11 @@ func TestAccVcdNetworkRoutedStatic1(t *testing.T) {
 		resourceName:          "vcd_network_routed",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedStatic2(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  routedStaticNetwork2,
 		gateway:               "10.10.102.1",
@@ -224,9 +237,11 @@ func TestAccVcdNetworkRoutedStatic2(t *testing.T) {
 		interfaceName:         "internal",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedStaticSub2(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  routedStaticNetworkSub2,
 		gateway:               "10.10.102.1",
@@ -250,9 +265,11 @@ func TestAccVcdNetworkRoutedStaticSub2(t *testing.T) {
 		interfaceName:         "subinterface",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedStaticDist(t *testing.T) {
+	preTestChecks(t)
 	if !testDistributedNetworksEnabled() {
 		t.Skip("Distributed test skipped: not enabled")
 	}
@@ -279,9 +296,11 @@ func TestAccVcdNetworkRoutedStaticDist(t *testing.T) {
 		interfaceName:         "distributed",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedStaticDist2(t *testing.T) {
+	preTestChecks(t)
 	if !testDistributedNetworksEnabled() {
 		t.Skip("Distributed test skipped: not enabled")
 	}
@@ -308,9 +327,11 @@ func TestAccVcdNetworkRoutedStaticDist2(t *testing.T) {
 		interfaceName:         "distributed",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedDhcp(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:               routedDhcpNetwork,
 		gateway:            "10.10.102.1",
@@ -331,9 +352,11 @@ func TestAccVcdNetworkRoutedDhcp(t *testing.T) {
 		interfaceName:      "internal",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedDhcpSub(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:               routedDhcpNetworkSub,
 		gateway:            "10.10.102.1",
@@ -353,9 +376,11 @@ func TestAccVcdNetworkRoutedDhcpSub(t *testing.T) {
 		interfaceName:      "subinterface",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedMixed(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  routedMixedNetwork,
 		gateway:               "10.10.102.1",
@@ -379,9 +404,11 @@ func TestAccVcdNetworkRoutedMixed(t *testing.T) {
 		interfaceName:         "internal",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkRoutedMixedSub(t *testing.T) {
+	preTestChecks(t)
 	var def = networkDef{
 		name:                  routedMixedNetworkSub,
 		gateway:               "10.10.102.1",
@@ -405,9 +432,11 @@ func TestAccVcdNetworkRoutedMixedSub(t *testing.T) {
 		interfaceName:         "subinterface",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func TestAccVcdNetworkDirect(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdNetworkDirect requires system admin privileges")
 		return
@@ -426,6 +455,7 @@ func TestAccVcdNetworkDirect(t *testing.T) {
 		resourceName:    "vcd_network_direct",
 	}
 	runTest(def, updateDef, t)
+	postTestChecks(t)
 }
 
 func runTest(def, updateDef networkDef, t *testing.T) {
@@ -734,6 +764,7 @@ func runTest(def, updateDef networkDef, t *testing.T) {
 // It tests some IP pairs with the hard coded hash result as of version 2.8.0
 // If this test fails, we may have introduced a breaking change that causes a plan update.
 func TestHashFunc(t *testing.T) {
+	preTestChecks(t)
 	var testsDhcp = []struct {
 		startIp      string
 		endIp        string
@@ -810,6 +841,7 @@ func TestHashFunc(t *testing.T) {
 			}
 		}
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdNetworkExists(name string, network *govcd.OrgVDCNetwork) resource.TestCheckFunc {

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -16,6 +16,7 @@ import (
 // TestAccVcdNsxtEdgeGateway tests out creating and updating edge gateway using existing external network
 // testConfig.Nsxt.ExternalNetwork which is expected to be correctly configured.
 func TestAccVcdNsxtEdgeGateway(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + " requires system admin privileges")
 		return
@@ -107,6 +108,7 @@ func TestAccVcdNsxtEdgeGateway(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccNsxtEdgeGatewayDataSources = `

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
+	preTestChecks(t)
 	skipNoNsxtConfiguration(t)
 
 	// String map to fill the template
@@ -70,6 +71,7 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccRoutedNetDhcpConfig = `

--- a/vcd/resource_vcd_nsxt_network_imported_test.go
+++ b/vcd/resource_vcd_nsxt_network_imported_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdNsxtNetworkImported(t *testing.T) {
+	preTestChecks(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -99,6 +100,7 @@ func TestAccVcdNsxtNetworkImported(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const TestAccVcdNetworkImportedV2NsxtStep1 = `

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -18,6 +18,7 @@ func init() {
 
 // TestAccVcdNsxtStandaloneVmTemplate tests NSX-T Routed network DHCP pools, static pools and manual IP assignment
 func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
+	preTestChecks(t)
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.Nsxt.EdgeGateway == "" {
 		t.Skip("Either NSXT VDC or edge gateway not defined")
@@ -111,9 +112,11 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdNsxtStandaloneEmptyVm(t *testing.T) {
+	preTestChecks(t)
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.Nsxt.EdgeGateway == "" {
 		t.Skip("Either NSXT VDC or edge gateway not defined")
@@ -193,6 +196,7 @@ func TestAccVcdNsxtStandaloneEmptyVm(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdNsxtStandaloneVm_basic = `

--- a/vcd/resource_vcd_nsxt_vapp_raw_test.go
+++ b/vcd/resource_vcd_nsxt_vapp_raw_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
+	preTestChecks(t)
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.Nsxt.EdgeGateway == "" {
 		t.Skip("Either NSXT VDC or edge gateway not defined")
@@ -62,6 +63,7 @@ func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdNsxtVAppRawExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {

--- a/vcd/resource_vcd_nsxv_dhcp_relay_test.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdNsxvDhcpRelay(t *testing.T) {
+	preTestChecks(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -95,6 +96,7 @@ func TestAccVcdNsxvDhcpRelay(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // testAccCheckVcdDhcpRelaySettingsEmpty reads DHCP relay configuration and ensure it has no

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdEdgeDnat(t *testing.T) {
+	preTestChecks(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -160,6 +161,7 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // importStateIdByResourceName constructs an import path (ID in Terraform import terms) in the format of:

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
@@ -482,6 +483,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // importStateFirewallUiNumberByResourceName constructs an import path (ID in Terraform import terms) in the format of:
@@ -876,6 +878,7 @@ resource "vcd_nsxv_firewall_rule" "rule6-6" {
 `
 
 func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
@@ -982,6 +985,7 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdEdgeFirewallRuleIpSets = `
@@ -1049,6 +1053,7 @@ resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
 `
 
 func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
+	preTestChecks(t)
 	// String map to fill the template
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
@@ -1151,6 +1156,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccVcdEdgeFirewallRuleVmsPrereqs = `

--- a/vcd/resource_vcd_nsxv_snat_test.go
+++ b/vcd/resource_vcd_nsxv_snat_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdEdgeSnat(t *testing.T) {
+	preTestChecks(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -88,6 +89,7 @@ func TestAccVcdEdgeSnat(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccNetForNat = `

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -27,6 +27,7 @@ import (
 // access internet so that it can download docker image. Also the environment where test is run must
 // be able to access external network IP so that monitoring is possible.
 func TestAccVcdOrgGroup(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdOrgGroup requires system admin privileges")
 		return
@@ -174,6 +175,7 @@ func TestAccVcdOrgGroup(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // testAccCheckVcdGroupDestroy verifies if Org Group with given name does not exist in vCD

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -15,6 +15,7 @@ import (
 const orgNameTestAccVcdOrg string = "TestAccVcdOrg"
 
 func TestAccVcdOrgBasic(t *testing.T) {
+	preTestChecks(t)
 
 	var params = StringMap{
 		"OrgName":     orgNameTestAccVcdOrg,
@@ -59,8 +60,10 @@ func TestAccVcdOrgBasic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 func TestAccVcdOrgFull(t *testing.T) {
+	preTestChecks(t)
 
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdOrgFull requires system admin privileges")
@@ -268,6 +271,7 @@ func TestAccVcdOrgFull(t *testing.T) {
 		return
 
 	}
+	postTestChecks(t)
 }
 
 func testAccCheckVcdOrgExists(resourceName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_org_user_test.go
+++ b/vcd/resource_vcd_org_user_test.go
@@ -83,6 +83,7 @@ func prepareUserData(t *testing.T) []userTestData {
 }
 
 func TestAccVcdOrgUserBasic(t *testing.T) {
+	preTestChecks(t)
 
 	userData := prepareUserData(t)
 	willSkipTests := false
@@ -135,9 +136,11 @@ func TestAccVcdOrgUserBasic(t *testing.T) {
 		return
 	}
 	cleanUserData(t)
+	postTestChecks(t)
 }
 
 func TestAccVcdOrgUserFull(t *testing.T) {
+	preTestChecks(t)
 
 	userData := prepareUserData(t)
 	willSkipTests := false
@@ -253,11 +256,13 @@ func TestAccVcdOrgUserFull(t *testing.T) {
 		return
 	}
 	cleanUserData(t)
+	postTestChecks(t)
 }
 
 // Tests the creation of a user that copies
 // properties values from organization data source
 func TestAccVcdOrgUserWithDS(t *testing.T) {
+	preTestChecks(t)
 
 	userData := prepareUserData(t)
 
@@ -314,6 +319,7 @@ func TestAccVcdOrgUserWithDS(t *testing.T) {
 		})
 	}
 	cleanUserData(t)
+	postTestChecks(t)
 }
 
 func testAccCheckVcdUserDestroy(userName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_org_vdc_nsxt_test.go
+++ b/vcd/resource_vcd_org_vdc_nsxt_test.go
@@ -5,6 +5,7 @@ package vcd
 import "testing"
 
 func TestAccVcdOrgVdcNsxt(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip(t.Name() + " requires system admin privileges")
 	}
@@ -45,4 +46,5 @@ func TestAccVcdOrgVdcNsxt(t *testing.T) {
 	}
 
 	runOrgVdcTest(t, params, allocationModel)
+	postTestChecks(t)
 }

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -11,6 +11,7 @@ func init() {
 }
 
 func TestAccVcdOrgVdcReservationPool(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
 	}
@@ -51,9 +52,11 @@ func TestAccVcdOrgVdcReservationPool(t *testing.T) {
 	}
 
 	runOrgVdcTest(t, params, allocationModel)
+	postTestChecks(t)
 }
 
 func TestAccVcdOrgVdcAllocationPool(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
 	}
@@ -93,9 +96,11 @@ func TestAccVcdOrgVdcAllocationPool(t *testing.T) {
 	}
 
 	runOrgVdcTest(t, params, allocationModel)
+	postTestChecks(t)
 }
 
 func TestAccVcdOrgVdcAllocationVApp(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
 	}
@@ -135,9 +140,11 @@ func TestAccVcdOrgVdcAllocationVApp(t *testing.T) {
 	}
 
 	runOrgVdcTest(t, params, allocationModel)
+	postTestChecks(t)
 }
 
 func TestAccVcdOrgVdcAllocationFlex(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVdcBasic requires system admin privileges")
 	}
@@ -177,6 +184,7 @@ func TestAccVcdOrgVdcAllocationFlex(t *testing.T) {
 		"MemoryOverheadUpdateValueForAssert": "true",
 	}
 	runOrgVdcTest(t, params, allocationModel)
+	postTestChecks(t)
 }
 
 func validateConfiguration(t *testing.T) {

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdOrgVdcWithVmSizingPolicy requires system admin privileges")
 	}
@@ -201,6 +202,7 @@ func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func init() {

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -16,6 +16,7 @@ func init() {
 }
 
 func TestAccVcdStandaloneVmTemplate(t *testing.T) {
+	preTestChecks(t)
 	// making sure the VM name is unique
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 	var diskResourceName = fmt.Sprintf("%s_disk", t.Name())
@@ -90,9 +91,11 @@ func TestAccVcdStandaloneVmTemplate(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdStandaloneEmptyVm(t *testing.T) {
+	preTestChecks(t)
 	// making sure the VM name is unique
 	standaloneVmName := fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
@@ -167,6 +170,7 @@ func TestAccVcdStandaloneEmptyVm(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdStandaloneVm_basic = `

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
+	preTestChecks(t)
 	var (
 		standaloneVmName        = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 		netVmName1              = standaloneVmName + "-1"
@@ -202,6 +203,7 @@ func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdStandaloneVmExistsByVdc(vdcName, vmName, node string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdVappAccessControl(t *testing.T) {
+	preTestChecks(t)
 
 	if testConfig.VCD.Org == "" {
 		t.Skip("[TestAccVcdVappAccessControl] no Org found in configuration")
@@ -158,6 +159,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVappAccessControlExists(resourceName string, orgName, vdcName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccVcdVAppEmptyVm(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -219,6 +220,7 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppEmpty = `

--- a/vcd/resource_vcd_vapp_firewall_rules_test.go
+++ b/vcd/resource_vcd_vapp_firewall_rules_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccVcdVappFirewallRules(t *testing.T) {
+	preTestChecks(t)
 	if testConfig.Networking.EdgeGateway == "" {
 		t.Skip("Variable testConfig.Networking.EdgeGateway must be configured")
 		return
@@ -198,7 +199,7 @@ func TestAccVcdVappFirewallRules(t *testing.T) {
 			},
 		},
 	})
-
+	postTestChecks(t)
 }
 
 func importStateVappFirewallRuleById(testConfig TestConfig, resourceName string) resource.ImportStateIdFunc {

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVAppMultiVmInTemplate(t *testing.T) {
+	preTestChecks(t)
 
 	if testConfig.VCD.Catalog.VmName1InMultiVmItem == "" || testConfig.VCD.Catalog.VmName2InMultiVmItem == "" {
 		t.Skip("Variables vmName1InMultiVmItem, VmName2InMultiVmItem  must be set to run multi VM in vApp template tests")
@@ -96,6 +97,7 @@ func TestAccVcdVAppMultiVmInTemplate(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const defaultCatalogItem = `

--- a/vcd/resource_vcd_vapp_nat_rules_test.go
+++ b/vcd/resource_vcd_vapp_nat_rules_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccVcdVappNatRules(t *testing.T) {
+	preTestChecks(t)
 	if testConfig.Networking.EdgeGateway == "" {
 		t.Skip("Variable testConfig.Networking.EdgeGateway must be configured")
 		return
@@ -145,7 +146,7 @@ func TestAccVcdVappNatRules(t *testing.T) {
 			},
 		},
 	})
-
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVappNatRulesExists(n string, rulesCount int) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -22,6 +22,7 @@ const (
 // go test -v -timeout 0 -tags multinetwork -run TestAccVcdVappNetworkMulti .
 //
 func TestAccVcdVappNetworkMulti(t *testing.T) {
+	preTestChecks(t)
 
 	const (
 		networkBaseIp1     = "192.168.11"
@@ -111,6 +112,7 @@ func TestAccVcdVappNetworkMulti(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVappNetworkMultiExists(n string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -21,6 +21,7 @@ const netmask = "255.255.255.0"
 const guestVlanAllowed = "true"
 
 func TestAccVcdVappNetwork_Isolated(t *testing.T) {
+	preTestChecks(t)
 	vappNetworkResourceName := "TestAccVcdVappNetwork_Isolated"
 
 	var params = StringMap{
@@ -66,9 +67,11 @@ func TestAccVcdVappNetwork_Isolated(t *testing.T) {
 	}
 
 	runVappNetworkTest(t, params)
+	postTestChecks(t)
 }
 
 func TestAccVcdVappNetwork_Nat(t *testing.T) {
+	preTestChecks(t)
 	vappNetworkResourceName := "TestAccVcdVappNetwork_Nat"
 
 	var params = StringMap{
@@ -115,6 +118,7 @@ func TestAccVcdVappNetwork_Nat(t *testing.T) {
 	}
 
 	runVappNetworkTest(t, params)
+	postTestChecks(t)
 }
 
 func runVappNetworkTest(t *testing.T, params StringMap) {

--- a/vcd/resource_vcd_vapp_org_network_test.go
+++ b/vcd/resource_vcd_vapp_org_network_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccVcdVappOrgNetwork_NotFenced(t *testing.T) {
+	preTestChecks(t)
 	vappNetworkResourceName := "TestAccVcdVappOrgNetwork_NotFenced"
 
 	var params = StringMap{
@@ -27,9 +28,11 @@ func TestAccVcdVappOrgNetwork_NotFenced(t *testing.T) {
 	}
 
 	runVappOrgNetworkTest(t, params)
+	postTestChecks(t)
 }
 
 func TestAccVcdVappOrgNetwork_Fenced(t *testing.T) {
+	preTestChecks(t)
 	vappNetworkResourceName := "TestAccVcdVappOrgNetwork_Fenced"
 
 	var params = StringMap{
@@ -48,6 +51,7 @@ func TestAccVcdVappOrgNetwork_Fenced(t *testing.T) {
 	}
 
 	runVappOrgNetworkTest(t, params)
+	postTestChecks(t)
 }
 
 func runVappOrgNetworkTest(t *testing.T, params StringMap) {

--- a/vcd/resource_vcd_vapp_properties_test.go
+++ b/vcd/resource_vcd_vapp_properties_test.go
@@ -14,6 +14,7 @@ func init() {
 }
 
 func TestAccVcdVAppProperties(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 
 	var params = StringMap{
@@ -74,6 +75,7 @@ func TestAccVcdVAppProperties(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVApp_properties = `

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -15,6 +15,7 @@ import (
 // To execute this test, run
 // go test -v -timeout 0 -tags multivm -run TestAccVcdVAppRawMulti .
 func TestAccVcdVAppRawMulti(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 
 	var params = StringMap{
@@ -51,6 +52,7 @@ func TestAccVcdVAppRawMulti(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVAppRawMultiExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdVAppRaw_Basic(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 
 	var params = StringMap{
@@ -46,6 +47,7 @@ func TestAccVcdVAppRaw_Basic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVAppRawExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_static_routing_test.go
+++ b/vcd/resource_vcd_vapp_static_routing_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccVcdVappStaticRouting(t *testing.T) {
+	preTestChecks(t)
 	if testConfig.Networking.EdgeGateway == "" {
 		t.Skip("Variable testConfig.Networking.EdgeGateway must be configured")
 		return
@@ -95,7 +96,7 @@ func TestAccVcdVappStaticRouting(t *testing.T) {
 			},
 		},
 	})
-
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVappStaticRoutesExists(n string, rulesCount int) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdVApp_Basic(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 	var vappName = "TestAccVcdVAppVapp"
 
@@ -81,6 +82,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVAppExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vapp_vm_capabilities_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVAppVmCapabilities(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 	var vm govcd.VM
 
@@ -58,6 +59,7 @@ func TestAccVcdVAppVmCapabilities(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVm_capabilities = `

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -18,6 +18,7 @@ import (
 // power on and force customization. (VM must be un-deployed for customization to work, otherwise it would stay in
 // "GC_PENDING" state for long time)
 func TestAccVcdVAppVmUpdateCustomization(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -83,6 +84,7 @@ func TestAccVcdVAppVmUpdateCustomization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // TestAccVcdVAppVmCreateCustomization tests that setting attribute customizaton.force to `true`
@@ -91,6 +93,7 @@ func TestAccVcdVAppVmUpdateCustomization(t *testing.T) {
 // power on and force customization. (VM must be un-deployed for customization to work, otherwise it would stay in
 // "GC_PENDING" state for long time)
 func TestAccVcdVAppVmCreateCustomization(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -139,6 +142,7 @@ func TestAccVcdVAppVmCreateCustomization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // testAccCheckVcdVMCustomization functions acts as a check and a function which waits until
@@ -288,6 +292,7 @@ resource "vcd_vapp_vm" "test-vm" {
 // TestAccVcdVAppVmCreateCustomizationFalse checks if VM is booted up successfully when  customization.force=true.
 // This test covers a previous bug.
 func TestAccVcdVAppVmCreateCustomizationFalse(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -330,10 +335,12 @@ func TestAccVcdVAppVmCreateCustomizationFalse(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // TestAccVcdVAppVmCustomizationSettings tests out possible customization options
 func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -430,6 +437,7 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVmUpdateCustomizationSettings = testAccCheckVcdVAppVmCustomizationShared + `

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestAccVcdVAppVmDhcpWait(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -108,6 +109,7 @@ func TestAccVcdVAppVmDhcpWait(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVmDhcpWaitShared = `

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdVAppHotUpdateVm(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -235,6 +236,7 @@ func TestAccVcdVAppHotUpdateVm(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVmNotRestarted(n string, vappName, vmName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
+	preTestChecks(t)
 	vappNameHwVirt := "TestAccVcdVAppHwVirt"
 	vmNameHwVirt := "TestAccVcdVAppHwVirt"
 	var vapp govcd.VApp
@@ -66,6 +67,7 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVm_hardwareVirtualization = `

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -14,6 +14,7 @@ import (
 // go test -v -timeout 0 -tags "multivm functional" -run TestAccVcdVAppVmMulti .
 // Extends TestAccVcdVappVM with multiple VMs
 func TestAccVcdVAppVmMulti(t *testing.T) {
+	preTestChecks(t)
 	var (
 		diskResourceNameM string = "TestAccVcdVAppVmMulti"
 		vappName2         string = "TestAccVcdVAppVmVappM"
@@ -68,6 +69,7 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVAppVmMultiExists(n string, vappName, vmName string) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVAppVmMultiNIC(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
@@ -252,6 +253,7 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVmNetworkShared = `

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAccVcdVAppVmProperties(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 	var vm govcd.VM
 
@@ -72,6 +73,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVm_properties = `

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -18,6 +18,7 @@ var vappName2 string = "TestAccVcdVAppVmVapp"
 var vmName string = "TestAccVcdVAppVmVm"
 
 func TestAccVcdVAppVm_Basic(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 	var vm govcd.VM
 	var diskResourceName = "TestAccVcdVAppVm_Basic_1"
@@ -87,9 +88,11 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func TestAccVcdVAppVm_Clone(t *testing.T) {
+	preTestChecks(t)
 	var vapp govcd.VApp
 	var vm govcd.VM
 
@@ -157,6 +160,7 @@ func TestAccVcdVAppVm_Clone(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVAppVm_basic = `

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
+	preTestChecks(t)
 	var (
 		vm            govcd.VM
 		netVappName   string = t.Name()
@@ -199,6 +200,7 @@ func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testAccCheckVcdVAppVmExistsByVdc(vdcName, vappName, vmName, node string, vm *govcd.VM) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vm_affinity_rule_test.go
+++ b/vcd/resource_vcd_vm_affinity_rule_test.go
@@ -26,6 +26,7 @@ type affinityRuleData struct {
 // TestAccVcdVmAffinityRule creates the pre-requisites for the VM affinity rule test
 // Creates several definitions, and calls runVmAffinityRuleTest for each one
 func TestAccVcdVmAffinityRule(t *testing.T) {
+	preTestChecks(t)
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
@@ -184,7 +185,7 @@ func TestAccVcdVmAffinityRule(t *testing.T) {
 			},
 		}, t)
 	})
-
+	postTestChecks(t)
 }
 
 // runVmAffinityRuleTest runs the test for a VM affinity rule definition

--- a/vcd/resource_vcd_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vm_capabilities_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdStandaloneVmCapabilities(t *testing.T) {
+	preTestChecks(t)
 
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 	var params = StringMap{
@@ -59,6 +60,7 @@ func TestAccVcdStandaloneVmCapabilities(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVm_capabilities = `

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -19,6 +19,7 @@ import (
 // power on and force customization. (VM must be un-deployed for customization to work, otherwise it would stay in
 // "GC_PENDING" state for long time)
 func TestAccVcdStandaloneVmUpdateCustomization(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -79,6 +80,7 @@ func TestAccVcdStandaloneVmUpdateCustomization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // TestAccVcdStandaloneVmCreateCustomization tests that setting attribute customizaton.force to `true`
@@ -87,6 +89,7 @@ func TestAccVcdStandaloneVmUpdateCustomization(t *testing.T) {
 // power on and force customization. (VM must be un-deployed for customization to work, otherwise it would stay in
 // "GC_PENDING" state for long time)
 func TestAccVcdStandaloneVmCreateCustomization(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -130,6 +133,7 @@ func TestAccVcdStandaloneVmCreateCustomization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 // testAccCheckVcdStandaloneVMCustomization functions acts as a check and a function which waits until
@@ -240,6 +244,7 @@ resource "vcd_vm" "test-vm" {
 
 // TestAccVcdStandaloneVmCustomizationSettings tests out possible customization options
 func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -330,6 +335,7 @@ func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVmUpdateCustomizationSettings = `

--- a/vcd/resource_vcd_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vm_dhcp_wait_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdStandaloneVmDhcpWait(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -104,6 +105,7 @@ func TestAccVcdStandaloneVmDhcpWait(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVmDhcpWaitShared = `

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	if testConfig.Media.MediaName == "" {
@@ -200,6 +201,7 @@ func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testStandaloneSharedHotUpdate = `

--- a/vcd/resource_vcd_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vm_hw_virtualization_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdStandaloneVm_HardwareVirtualization(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -64,6 +65,7 @@ func TestAccVcdStandaloneVm_HardwareVirtualization(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVm_hardwareVirtualization = `

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdVmInternalDisk(t *testing.T) {
+	preTestChecks(t)
 
 	// In general VM internal disks works with Org users, but since we need to create VDC with disabled fast provisioning value, we have to be sys admins
 	if !usingSysAdmin() {
@@ -150,6 +151,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func testCheckInternalDiskNonStringOutputs(internalDiskSize int) resource.TestCheckFunc {

--- a/vcd/resource_vcd_vm_properties_test.go
+++ b/vcd/resource_vcd_vm_properties_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAccVcdStandaloneVmProperties(t *testing.T) {
+	preTestChecks(t)
 	var standaloneVmName = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 
 	var params = StringMap{
@@ -72,6 +73,7 @@ func TestAccVcdStandaloneVmProperties(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 const testAccCheckVcdVm_properties = `

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -13,6 +13,7 @@ import (
 var TestVmPolicy = "TestVmPolicyBasic"
 
 func TestAccVcdVmSizingPolicy(t *testing.T) {
+	preTestChecks(t)
 	if !usingSysAdmin() {
 		t.Skip("TestAccVcdVmSizingPolicy requires system admin privileges")
 	}
@@ -193,6 +194,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 			},
 		},
 	})
+	postTestChecks(t)
 }
 
 func importStateVmSizingPolicyByIdOrName(testConfig TestConfig, resourceName string, byId bool) resource.ImportStateIdFunc {

--- a/vcd/terraform_binary_test.go
+++ b/vcd/terraform_binary_test.go
@@ -42,6 +42,7 @@ func readFile(filename string) (string, error) {
 
 // Fills custom templates with data from configuration file
 func TestCustomTemplates(t *testing.T) {
+	// do not add pre/post checks
 	var binaryTestList []string
 
 	fileList, err := ioutil.ReadDir(customTemplatesDirectory)


### PR DESCRIPTION
The whole test suite takes several hours to run. If some errors happen during the run, we need to clean up and try again
from the beginning, which is not always convenient.
There are a few tags that help us gain some control on the flow:

* `-vcd-pre-post-checks`    Perform checks before and after tests (false)
* `-vcd-re-run-failed`      Run only tests that failed in a previous run (false)
* `-vcd-remove-test-list`   Remove list of test runs (false)
* `-vcd-show-count`         Show number of pass/fail tests (false)
* `-vcd-show-elapsed-time`  Show elapsed time since the start of the suite in pre and post checks (false)
* `-vcd-show-timestamp`     Show timestamp in pre and post checks (false)
* `-vcd-skip-pattern`       Skip tests that match the pattern (implies vcd-pre-post-checks ()

When `-vcd-pre-post-checks` is used, we have several advantages:

1) After each successful test, the test name gets recorded in a file `vcd_test_pass_list_{VCD_IP}.txt`, and each failed
   test goes to `vcd_test_fail_list_{VCD_IP}.txt`. When running the suite on the same VCD a second time, all tests in
   the `pass` list are skipped. If the test run was interrupted (see #2 below), we can only run the tests that did not
   run in the previous attempt.
2) We can **gracefully** interrupt the tests by creating a file `skip_vcd_tests` in the `./vcd` directory. 
    When this file is found by the pre-run routine, all the tests are skipped. The file `skip_vcd_tests` will be removed 
    automatically at the next run.
3) We can skip one or more tests conditionally, using `-vcd-skip-pattern="{REGEXP}"`. All the test with a name that
   matches the pattern are skipped.
4) We can re-run only the tests that failed in the previous run, using `-vcd-re-run-failed`.
5) We can add monitoring information with `-vcd-show-count`, `-vcd-show-elapsed-time`, `-vcd-show-timestamp`.

If we use `-vcd-pre-post-checks` and the run was successful, the next run will skip all tests, because the test names
would be all found in `vcd_test_pass_list_{VCD_IP}.txt`. To run again the test from scratch, we could either remove
the file manually, or use the tag `-vcd-remove-test-list`.

**VERY IMPORTANT**: for the conditional running to work, each test must have a call to `preTestChecks(t)`  at the beginning
and to `postTestChecks(t)` right before the end.

**Default behavior**: by default, pre and post checks are disabled. The checks are activated only when we use one or more of the flags listed above.
