### PR TITLE
Fix TestAccDataSourceNotFound/vcd_nsxt_edgegateway for 10.1+ without NSX-T

### DIFF
--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -44,8 +44,8 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 		case dataSourceName == "vcd_external_network_v2" && vcdClient.Client.APIVCDMaxVersionIs("< 33"):
 			t.Skip("External network V2 requires at least API version 33 (VCD 10.0+)")
 		case (dataSourceName == "vcd_nsxt_edgegateway" || dataSourceName == "vcd_nsxt_edge_cluster") &&
-			vcdClient.Client.APIVCDMaxVersionIs("< 34"):
-			t.Skip("this datasource requires at least API version 34 (VCD 10.1+)")
+			(vcdClient.Client.APIVCDMaxVersionIs("< 34") || testConfig.Nsxt.Vdc == ""):
+			t.Skip("this datasource requires at least API version 34 (VCD 10.1+) and NSX-T VDC specified in configuration")
 		case (dataSourceName == "vcd_nsxt_tier0_router" || dataSourceName == "vcd_external_network_v2" ||
 			dataSourceName == "vcd_nsxt_manager" || dataSourceName == "vcd_nsxt_edge_cluster") &&
 			(testConfig.Nsxt.Manager == "" || testConfig.Nsxt.Tier0router == "") || !usingSysAdmin():


### PR DESCRIPTION
This PR fixes a failure in `TestAccDataSourceNotFound/vcd_nsxt_edgegateway` for VCD 10.1+ without NSX-T

```
=== RUN   TestAccDataSourceNotFound/vcd_nsxt_edgegateway
    datasource_test.go:82: Step 1/1, expected an error with pattern, no match on: Error running pre-apply refresh:
        Error: please use 'vcd_edgegateway' for NSX-V backed VDC
```

