### PR TITLE
3.2.0 release cleanup

### DIFF
--- a/.changes/v3.2.0/628-improvements.md
+++ b/.changes/v3.2.0/628-improvements.md
@@ -1,1 +1,2 @@
 * `make install` will use lightweight tags for build version injection [GH-628]
+* `datasource/vcd_resource_list` adds `vcd_network_routed_v2` to the supported resource types [#628]

--- a/.changes/v3.2.0/636-improvements.md
+++ b/.changes/v3.2.0/636-improvements.md
@@ -1,0 +1,1 @@
+* `datasource/vcd_resource_list` adds `vcd_network_isolated_v2` to the supported resource types [#636]

--- a/.changes/v3.2.0/645-improvements.md
+++ b/.changes/v3.2.0/645-improvements.md
@@ -1,0 +1,1 @@
+* `datasource/vcd_resource_list` adds `vcd_nsxt_network_imported` to the supported resource types [#645]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0 (March 10, 2021)
+## 3.2.0 (March 11, 2021)
 
 ## FEATURES
 * **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
-## 3.2.0 (Unreleased)
+## 3.2.0 (March 10, 2021)
 
-Changes in progress for v3.2.0 are available at [.changes/v3.2.0](https://github.com/vmware/terraform-provider-vcd/tree/master/.changes/v3.2.0) until the release.
+## FEATURES
+* **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
+* **New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
+* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
+* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
+* **New Resource:** `vcd_vm` - Standalone VM [GH-638]
+* **New Data source:** `vcd_vm` - Standalone VM [GH-638]
+* **New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
+* **New Data source:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
+* **New Resource:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]
+* **New Data source:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]
+
+## IMPROVEMENTS
+* `make install` will use lightweight tags for build version injection [GH-628]
+* `datasource/vcd_resource_list` adds `vcd_vm` to the supported resource types [GH-638]
+* `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC [GH-650]
+* `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC [GH-650]
+* `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs [GH-650]
+* `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC (because NSX-T networks cannot be attached to vApp networks) [GH-650]
+
+## NOTES
+* Internal functions `lockParentEdgeGtw` and `unLockParentEdgeGtw` will handle Edge Gateway locks when `name` or `id` reference is used [GH-628]
 
 ## 3.1.0 (December 18, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,27 @@
 ## 3.2.0 (March 10, 2021)
 
 ## FEATURES
-* **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
-* **New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks [GH-628]
-* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
-* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks [GH-636]
-* **New Resource:** `vcd_vm` - Standalone VM [GH-638]
-* **New Data source:** `vcd_vm` - Standalone VM [GH-638]
-* **New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
-* **New Data source:** `vcd_nsxt_network_imported` for NSX-T imported networks [GH-645]
-* **New Resource:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]
-* **New Data source:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration [GH-650]
+* **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
+* **New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
+* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
+* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
+* **New Resource:** `vcd_vm` - Standalone VM ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
+* **New Data source:** `vcd_vm` - Standalone VM ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
+* **New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks ([#645](https://github.com/vmware/terraform-provider-vcd/issues/645))
+* **New Data source:** `vcd_nsxt_network_imported` for NSX-T imported networks ([#645](https://github.com/vmware/terraform-provider-vcd/issues/645))
+* **New Resource:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
+* **New Data source:** `vcd_nsxt_network_dhcp` for NSX-T routed network DHCP configuration ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 
 ## IMPROVEMENTS
-* `make install` will use lightweight tags for build version injection [GH-628]
-* `datasource/vcd_resource_list` adds `vcd_vm` to the supported resource types [GH-638]
-* `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC [GH-650]
-* `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC [GH-650]
-* `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs [GH-650]
-* `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC (because NSX-T networks cannot be attached to vApp networks) [GH-650]
+* `make install` will use lightweight tags for build version injection ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
+* `datasource/vcd_resource_list` adds `vcd_vm` to the supported resource types ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
+* `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
+* `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
+* `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
+* `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC (because NSX-T networks cannot be attached to vApp networks) ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 
 ## NOTES
-* Internal functions `lockParentEdgeGtw` and `unLockParentEdgeGtw` will handle Edge Gateway locks when `name` or `id` reference is used [GH-628]
+* Internal functions `lockParentEdgeGtw` and `unLockParentEdgeGtw` will handle Edge Gateway locks when `name` or `id` reference is used ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
 
 ## 3.1.0 (December 18, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 * `datasource/vcd_resource_list` adds `vcd_network_isolated_v2` to the supported resource types ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
 * `datasource/vcd_resource_list` adds `vcd_nsxt_network_imported` to the supported resource types ([#645](https://github.com/vmware/terraform-provider-vcd/issues/645))
 * `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
-* `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 * `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 * `vcd_vapp_network` throws error when `org_network_name` is specified for NSX-T VDC (because NSX-T networks cannot be attached to vApp networks) ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## FEATURES
 * **New Resource:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
 * **New Data source:** `vcd_network_routed_v2` for NSX-T and NSX-V routed networks ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
-* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
-* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V routed networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
+* **New Resource:** `vcd_network_isolated_v2` for NSX-T and NSX-V isolated networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
+* **New Data source:** `vcd_network_isolated_v2` for NSX-T and NSX-V isolated networks ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
 * **New Resource:** `vcd_vm` - Standalone VM ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
 * **New Data source:** `vcd_vm` - Standalone VM ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
 * **New Resource:** `vcd_nsxt_network_imported` for NSX-T imported networks ([#645](https://github.com/vmware/terraform-provider-vcd/issues/645))
@@ -15,6 +15,9 @@
 ## IMPROVEMENTS
 * `make install` will use lightweight tags for build version injection ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
 * `datasource/vcd_resource_list` adds `vcd_vm` to the supported resource types ([#638](https://github.com/vmware/terraform-provider-vcd/issues/638))
+* `datasource/vcd_resource_list` adds `vcd_network_routed_v2` to the supported resource types ([#628](https://github.com/vmware/terraform-provider-vcd/issues/628))
+* `datasource/vcd_resource_list` adds `vcd_network_isolated_v2` to the supported resource types ([#636](https://github.com/vmware/terraform-provider-vcd/issues/636))
+* `datasource/vcd_resource_list` adds `vcd_nsxt_network_imported` to the supported resource types ([#645](https://github.com/vmware/terraform-provider-vcd/issues/645))
 * `vcd_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_nsxt_edgegateway` for NSX-T backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 * `vcd_nsxt_edgegateway` resource and datasource throws error (on create, import and datasource read) and refers to `vcd_edgegateway` for NSX-V backed VDC ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))
 * `vcd_network_isolated`and `vcd_network_routed` throw warnings on create and errors on import by referring to `vcd_network_isolated_v2`and `vcd_network_routed_v2` for NSX VDCs ([#650](https://github.com/vmware/terraform-provider-vcd/issues/650))

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.2.0
 	github.com/kr/pretty v0.2.0
-	github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1
+	github.com/vmware/go-vcloud-director/v2 v2.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -278,8 +278,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1 h1:w6DrOoSlbvwlmFCKFvqOHSPEvQinZcN65B5tDRG4o5o=
-github.com/vmware/go-vcloud-director/v2 v2.11.0-rc.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/vmware/go-vcloud-director/v2 v2.11.0 h1:Ichr+OZfz6F0wb93npHP4mdvnDzTbpdEFpt0yTVAbVU=
+github.com/vmware/go-vcloud-director/v2 v2.11.0/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -150,6 +150,7 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			}
 			templateFields = templateFields + `vapp_name = "` + vapp.VApp.Name + `"` + "\n"
 		case "nsxt_manager_id":
+			skipNoNsxtConfiguration(t)
 			// This test needs a valid nsxt_manager_id
 			nsxtManager, err := vcdClient.QueryNsxtManagerByName(testConfig.Nsxt.Manager)
 			if err != nil {


### PR DESCRIPTION
This PR cleans up 3.2.0 release changelog

Additionally:
Fixes test panic when NSX-T is not available in 10.0 (skip test 'TestAccDataSourceNotFound/vcd_nsxt_tier0_router' on environments without NSX-T) (commit c66584e)