### PR TITLE
NSX-T Security Group resource and datasource

### DIFF
--- a/.changes/v3.3.0/663-features.md
+++ b/.changes/v3.3.0/663-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_nsxt_security_group` for NSX-T Edge Gateways [GH-663]
+* **New Data source:** `vcd_nsxt_security_group` for NSX-T Edge Gateways [GH-663]

--- a/.changes/v3.3.0/663-improvements.md
+++ b/.changes/v3.3.0/663-improvements.md
@@ -1,0 +1,2 @@
+* Fix a few typos and add example in Routed Network V2 docs [GH-663]
+* Add compatibility with Terraform 0.15.0 for `TestAccVcdNsxtStandaloneVmTemplate` [GH-663]

--- a/.changes/v3.3.0/663-improvements.md
+++ b/.changes/v3.3.0/663-improvements.md
@@ -1,2 +1,3 @@
 * Fix a few typos and add example in Routed Network V2 docs [GH-663]
-* Add compatibility with Terraform 0.15.0 for `TestAccVcdNsxtStandaloneVmTemplate` [GH-663]
+* Add compatibility with Terraform 0.15.0 for `TestAccVcdNsxtStandaloneVmTemplate` and
+  `TestAccVcdStandaloneVmTemplate` [GH-663]

--- a/.changes/v3.3.0/663-notes.md
+++ b/.changes/v3.3.0/663-notes.md
@@ -1,0 +1,4 @@
+* Add VCDClient.GetNsxtEdgeGateway, VCDClient.GetNsxtEdgeGatewayById, and
+  GetNsxtEdgeGatewayFromResourceById convenience functions [GH-663]
+* Add `importStateIdNsxtEdgeGatewayObject` function for import testing of NSX-T Edge Gateway child
+  objects [GH-663]

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2
+	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.3
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.0
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9 h1:D1slW0q47CNSuJLNuUCSShS/C9WDMTEUDxw92MruDso=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215 h1:I9TsShmIeJ1HZYl5lx0BLt0S9jvI7JEDqDFtXt/cgfY=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215 h1:I9TsShmIeJ1HZYl5lx0BLt0S9jvI7JEDqDFtXt/cgfY=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210510074611-e0dd75351215/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -290,6 +288,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.3 h1:HqJWXz1hnLfHRIQvRKQR/RvdZurVOFtCgrfEs08Au5c=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.3/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d h1:cTp6cmcwa2fvQUTGnR1B7f2DUtl6p9+fXmx5tX65d+Q=
+github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -288,8 +290,6 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1 h1:0/C6CI0YsrM+uMt0Lf1/CI5pA1Ff9d1ZMmuqjdEpC9I=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d h1:cTp6cmcwa2fvQUTGnR1B7f2DUtl6p9+fXmx5tX65d+Q=
-github.com/Didainius/go-vcloud-director/v2 v2.10.1-0.20210416084531-19957ad60b6d/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9 h1:D1slW0q47CNSuJLNuUCSShS/C9WDMTEUDxw92MruDso=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210505093343-c8e91ff2ffd9/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -220,7 +220,6 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -405,7 +405,7 @@ func (cli *VCDClient) GetAdminOrgFromResource(d *schema.ResourceData) (org *govc
 	return cli.GetAdminOrg(orgName)
 }
 
-// Gets an edge gateway when you don't need org or vdc for other purposes
+// GetEdgeGateway gets an NSX-V Edge Gateway when you don't need org or vdc for other purposes
 func (cli *VCDClient) GetEdgeGateway(orgName, vdcName, edgeGwName string) (eg *govcd.EdgeGateway, err error) {
 
 	if edgeGwName == "" {
@@ -413,13 +413,54 @@ func (cli *VCDClient) GetEdgeGateway(orgName, vdcName, edgeGwName string) (eg *g
 	}
 	_, vdc, err := cli.GetOrgAndVdc(orgName, vdcName)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving org and vdc: %s", err)
+		return nil, fmt.Errorf("error retrieving Org and VDC: %s", err)
 	}
 	eg, err = vdc.GetEdgeGatewayByName(edgeGwName, true)
 
 	if err != nil {
 		if os.Getenv("GOVCD_DEBUG") != "" {
 			return nil, fmt.Errorf(fmt.Sprintf("(%s) [%s] ", edgeGwName, callFuncName())+errorUnableToFindEdgeGateway, err)
+		}
+		return nil, fmt.Errorf(errorUnableToFindEdgeGateway, err)
+	}
+	return eg, nil
+}
+
+// GetNsxtEdgeGateway gets an NSX-T Edge Gateway when you don't need Org or VDC for other purposes
+func (cli *VCDClient) GetNsxtEdgeGateway(orgName, vdcName, edgeGwName string) (eg *govcd.NsxtEdgeGateway, err error) {
+
+	if edgeGwName == "" {
+		return nil, fmt.Errorf("empty NSX-T Edge Gateway name provided")
+	}
+	_, vdc, err := cli.GetOrgAndVdc(orgName, vdcName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Org and VDC: %s", err)
+	}
+	eg, err = vdc.GetNsxtEdgeGatewayByName(edgeGwName)
+
+	if err != nil {
+		if os.Getenv("GOVCD_DEBUG") != "" {
+			return nil, fmt.Errorf(fmt.Sprintf("(%s) [%s] ", edgeGwName, callFuncName())+errorUnableToFindEdgeGateway, err)
+		}
+		return nil, fmt.Errorf(errorUnableToFindEdgeGateway, err)
+	}
+	return eg, nil
+}
+
+// GetNsxtEdgeGatewayById gets an NSX-T Edge Gateway when you don't need Org or VDC for other purposes
+func (cli *VCDClient) GetNsxtEdgeGatewayById(orgName, vdcName, edgeGwId string) (eg *govcd.NsxtEdgeGateway, err error) {
+	if edgeGwId == "" {
+		return nil, fmt.Errorf("empty NSX-T Edge Gateway ID provided")
+	}
+	_, vdc, err := cli.GetOrgAndVdc(orgName, vdcName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Org and VDC: %s", err)
+	}
+	eg, err = vdc.GetNsxtEdgeGatewayById(edgeGwId)
+
+	if err != nil {
+		if os.Getenv("GOVCD_DEBUG") != "" {
+			return nil, fmt.Errorf(fmt.Sprintf("(%s) [%s] ", edgeGwId, callFuncName())+errorUnableToFindEdgeGateway, err)
 		}
 		return nil, fmt.Errorf(errorUnableToFindEdgeGateway, err)
 	}
@@ -437,6 +478,22 @@ func (cli *VCDClient) GetEdgeGatewayFromResource(d *schema.ResourceData, edgeGat
 	if err != nil {
 		if os.Getenv("GOVCD_DEBUG") != "" {
 			return nil, fmt.Errorf("(%s) [%s] : %s", edgeGatewayName, callFuncName(), err)
+		}
+		return nil, err
+	}
+	return egw, nil
+}
+
+// GetNsxtEdgeGatewayFromResource helps to retrieve NSX-T Edge Gateway when Org org VDC are not
+// needed. It performs a query By ID.
+func (cli *VCDClient) GetNsxtEdgeGatewayFromResourceById(d *schema.ResourceData, edgeGatewayFieldName string) (eg *govcd.NsxtEdgeGateway, err error) {
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get(edgeGatewayFieldName).(string)
+	egw, err := cli.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		if os.Getenv("GOVCD_DEBUG") != "" {
+			return nil, fmt.Errorf("(%s) [%s] : %s", edgeGatewayId, callFuncName(), err)
 		}
 		return nil, err
 	}

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -666,6 +666,14 @@ func TestMain(m *testing.M) {
 	// Enable custom flags
 	flag.Parse()
 	setTestEnv()
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		if f.Name == "test.v" {
+			if f.Value.String() == "false" {
+				fmt.Printf("Missing '-v' flag\n")
+				os.Exit(1)
+			}
+		}
+	})
 	// If -vcd-help was in the command line
 	if vcdHelp {
 		fmt.Println("vcd flags:")

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1071,6 +1071,22 @@ func importStateIdEdgeGatewayObject(vcd TestConfig, edgeGatewayName, objectName 
 	}
 }
 
+// importStateIdNsxtEdgeGatewayObject used by all entities that depend on Org + NSX-T VDC + edge gateway (such as FW, NAT, Security Groups)
+func importStateIdNsxtEdgeGatewayObject(vcd TestConfig, edgeGatewayName, objectName string) resource.ImportStateIdFunc {
+	return func(*terraform.State) (string, error) {
+		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || edgeGatewayName == "" || objectName == "" {
+			return "", fmt.Errorf("missing information to generate import path")
+		}
+		return testConfig.VCD.Org +
+			ImportSeparator +
+			testConfig.Nsxt.Vdc +
+			ImportSeparator +
+			edgeGatewayName +
+			ImportSeparator +
+			objectName, nil
+	}
+}
+
 // Used by all entities that depend on Org + VDC + vApp VM (such as VM internal disks)
 func importStateIdVmObject(orgName, vdcName, vappName, vmName, objectIdentifier string) resource.ImportStateIdFunc {
 	return func(*terraform.State) (string, error) {

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -43,7 +43,8 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 			t.Skip(`Works only with system admin privileges`)
 		case dataSourceName == "vcd_external_network_v2" && vcdClient.Client.APIVCDMaxVersionIs("< 33"):
 			t.Skip("External network V2 requires at least API version 33 (VCD 10.0+)")
-		case (dataSourceName == "vcd_nsxt_edgegateway" || dataSourceName == "vcd_nsxt_edge_cluster") &&
+		case (dataSourceName == "vcd_nsxt_edgegateway" || dataSourceName == "vcd_nsxt_edge_cluster" ||
+			dataSourceName == "vcd_nsxt_security_group") &&
 			(vcdClient.Client.APIVCDMaxVersionIs("< 34") || testConfig.Nsxt.Vdc == ""):
 			t.Skip("this datasource requires at least API version 34 (VCD 10.1+) and NSX-T VDC specified in configuration")
 		case (dataSourceName == "vcd_nsxt_tier0_router" || dataSourceName == "vcd_external_network_v2" ||
@@ -140,6 +141,13 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			templateFields = templateFields + `org = "` + testConfig.VCD.Org + `"` + "\n"
 		case "edge_gateway":
 			templateFields = templateFields + `edge_gateway = "` + testConfig.Networking.EdgeGateway + `"` + "\n"
+		case "edge_gateway_id":
+			nsxtEdgeGw, err := vcdClient.GetNsxtEdgeGateway(testConfig.VCD.Org, testConfig.Nsxt.Vdc, testConfig.Nsxt.EdgeGateway)
+			if err != nil {
+				t.Skipf("Unable to lookup NSX-T Edge Gateway '%s' : %s", testConfig.Nsxt.EdgeGateway, err)
+				return ""
+			}
+			templateFields = templateFields + `edge_gateway_id = "` + nsxtEdgeGw.EdgeGateway.ID + `"` + "\n"
 		case "catalog":
 			templateFields = templateFields + `catalog = "` + testConfig.VCD.Catalog.Name + `"` + "\n"
 		case "vapp_name":

--- a/vcd/datasource_vcd_nsxt_security_group.go
+++ b/vcd/datasource_vcd_nsxt_security_group.go
@@ -1,0 +1,96 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func datasourceVcdNsxtSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdSecurityGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Security Group name",
+			},
+			"edge_gateway_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge Gateway ID in which security group is located",
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Security Group description",
+			},
+			"member_org_network_ids": {
+				Computed:    true,
+				Type:        schema.TypeSet,
+				Description: "Set of Org VDC network IDs attached to this security group",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"member_vms": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Set of VM IDs",
+				Elem:        nsxtFirewallGroupMemberVms,
+			},
+		},
+	}
+}
+
+func datasourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	nsxtEdgeGateway, err := vcdClient.GetNsxtEdgeGatewayFromResourceById(d, "edge_gateway_id")
+	if err != nil {
+		return diag.Errorf(errorUnableToFindEdgeGateway, err)
+	}
+
+	// Name uniqueness is enforce by VCD for types.FirewallGroupTypeSecurityGroup
+	secGroup, err := nsxtEdgeGateway.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeSecurityGroup)
+	if err != nil {
+		return diag.Errorf("error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+	}
+
+	err = setNsxtSecurityGroupData(d, secGroup.NsxtFirewallGroup)
+	if err != nil {
+		return diag.Errorf("error reading NSX-T Security Group: %s", err)
+	}
+
+	// A separate GET call is required to get all associated VMs
+	associatedVms, err := secGroup.GetAssociatedVms()
+	if err != nil {
+		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", secGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
+	if err != nil {
+		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", secGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	d.SetId(secGroup.NsxtFirewallGroup.ID)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_security_group_test.go
+++ b/vcd/datasource_vcd_nsxt_security_group_test.go
@@ -1,0 +1,3 @@
+// +build network nsxt ALL functional
+
+package vcd

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -72,6 +72,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_network_isolated_v2":   datasourceVcdNetworkIsolatedV2(),   // 3.2
 	"vcd_nsxt_network_imported": datasourceVcdNsxtNetworkImported(), // 3.2
 	"vcd_nsxt_network_dhcp":     datasourceVcdOpenApiDhcp(),         // 3.2
+	"vcd_nsxt_security_group":   datasourceVcdNsxtSecurityGroup(),   // 3.2
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -120,6 +121,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_network_isolated_v2":   resourceVcdNetworkIsolatedV2(),        // 3.2
 	"vcd_nsxt_network_imported": resourceVcdNsxtNetworkImported(),      // 3.2
 	"vcd_nsxt_network_dhcp":     resourceVcdOpenApiDhcp(),              // 3.2
+	"vcd_nsxt_security_group":   resourceVcdSecurityGroup(),            //3.3
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -144,7 +144,7 @@ func resourceVcdIndependentDiskCreate(d *schema.ResourceData, meta interface{}) 
 	if sizeProvided {
 		diskCreateParams = &types.DiskCreateParams{Disk: &types.Disk{
 			Name:   diskName,
-			SizeMb: size.(int64),
+			SizeMb: int64(size.(int)),
 		}}
 	}
 

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -143,8 +143,8 @@ func resourceVcdIndependentDiskCreate(d *schema.ResourceData, meta interface{}) 
 	var diskCreateParams *types.DiskCreateParams
 	if sizeProvided {
 		diskCreateParams = &types.DiskCreateParams{Disk: &types.Disk{
-			Name: diskName,
-			Size: int64(size.(int) * 1024 * 1024),
+			Name:   diskName,
+			SizeMb: size.(int64),
 		}}
 	}
 
@@ -254,15 +254,11 @@ func resourceVcdIndependentDiskRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func setMainData(d *schema.ResourceData, disk *govcd.Disk) {
-	sizeInMb := int64(0)
-	if disk.Disk.Size != 0 && disk.Disk.Size >= 1024*1024 {
-		sizeInMb = disk.Disk.Size / 1024 / 1024
-	}
 	d.SetId(disk.Disk.Id)
 	_ = d.Set("name", disk.Disk.Name)
 	_ = d.Set("description", disk.Disk.Description)
 	_ = d.Set("storage_profile", disk.Disk.StorageProfile.Name)
-	_ = d.Set("size_in_mb", sizeInMb)
+	_ = d.Set("size_in_mb", disk.Disk.SizeMb)
 	_ = d.Set("bus_type", busTypesFromValues[disk.Disk.BusType])
 	_ = d.Set("bus_sub_type", busSubTypesFromValues[disk.Disk.BusSubType])
 	_ = d.Set("iops", disk.Disk.Iops)
@@ -387,10 +383,10 @@ func listDisksForImport(meta interface{}, orgName, vdcName, diskName string) ([]
 
 	writer := tabwriter.NewWriter(getTerraformStdout(), 0, 8, 1, '\t', tabwriter.AlignRight)
 
-	fmt.Fprintln(writer, "No\tID\tName\tDescription\tSize")
+	fmt.Fprintln(writer, "No\tID\tName\tDescription\tSizeMb")
 	fmt.Fprintln(writer, "--\t--\t----\t------\t----")
 	for index, disk := range *disks {
-		fmt.Fprintf(writer, "%d\t%s\t%s\t%s\t%d\n", (index + 1), disk.Disk.Id, disk.Disk.Name, disk.Disk.Description, disk.Disk.Size)
+		fmt.Fprintf(writer, "%d\t%s\t%s\t%s\t%d\n", (index + 1), disk.Disk.Id, disk.Disk.Name, disk.Disk.Description, disk.Disk.SizeMb)
 	}
 	writer.Flush()
 

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -83,8 +83,8 @@ var nsxtFirewallGroupMemberVms = &schema.Resource{
 			Description: "Member VM Name",
 		},
 		"vapp_id": {
-			Type:     schema.TypeString,
-			Optional: true, Computed: true,
+			Type:        schema.TypeString,
+			Computed:    true,
 			Description: "Parent vApp name (if exists) for member VM",
 		},
 		"vapp_name": {

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -1,0 +1,320 @@
+package vcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func resourceVcdSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdSecurityGroupCreate,
+		ReadContext:   resourceVcdSecurityGroupRead,
+		UpdateContext: resourceVcdSecurityGroupUpdate,
+		DeleteContext: resourceVcdSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdSecurityGroupImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"edge_gateway_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge Gateway ID in which security group is located",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Security Group name",
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Security Group description",
+			},
+			"member_org_network_ids": {
+				Optional:    true,
+				Type:        schema.TypeSet,
+				Description: "Set of Org VDC network IDs attached to this security group",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"member_vms": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Set of VM IDs",
+				Elem:        nsxtFirewallGroupMemberVms,
+			},
+		},
+	}
+}
+
+var nsxtFirewallGroupMemberVms = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"vm_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Member VM ID",
+		},
+		"vm_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Member VM Name",
+		},
+		"vapp_id": {
+			Type:     schema.TypeString,
+			Optional: true, Computed: true,
+			Description: "Parent vApp name (if exists) for member VM",
+		},
+		"vapp_name": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Parent vApp ID (if exists) for member VM",
+		},
+	},
+}
+
+func resourceVcdSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	fwGroup := getNsxtSecurityGroupType(d)
+
+	createdFwGroup, err := vdc.CreateNsxtFirewallGroup(fwGroup)
+	if err != nil {
+		return diag.Errorf("error creating NSX-T Security Group '%s': %s", fwGroup.Name, err)
+	}
+
+	d.SetId(createdFwGroup.NsxtFirewallGroup.ID)
+
+	return resourceVcdSecurityGroupRead(ctx, d, meta)
+}
+
+func resourceVcdSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		return diag.Errorf("error getting NSX-T Security Group: %s", err)
+	}
+
+	updateFwGroup := getNsxtSecurityGroupType(d)
+	// Inject existing ID for update
+	updateFwGroup.ID = d.Id()
+
+	_, err = fwGroup.Update(updateFwGroup)
+	if err != nil {
+		return diag.Errorf("error updating NSX-T Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	return resourceVcdSecurityGroupRead(ctx, d, meta)
+}
+
+func resourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+	}
+
+	err = setNsxtSecurityGroupData(d, fwGroup.NsxtFirewallGroup)
+	if err != nil {
+		return diag.Errorf("error reading NSX-T Security Group: %s", err)
+	}
+
+	// time.Sleep(60 * time.Second)
+
+	// A separate GET call is required to get all associated VMs
+	associatedVms, err := fwGroup.GetAssociatedVms()
+	if err != nil {
+		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
+	if err != nil {
+		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	return nil
+}
+
+func resourceVcdSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+	}
+
+	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		return diag.Errorf("error getting NSX-T Security Group: %s", err)
+	}
+
+	err = fwGroup.Delete()
+	if err != nil {
+		return diag.Errorf("error deleting NSX-T Security Group: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+// resourceVcdSecurityGroupImport
+func resourceVcdSecurityGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 4 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.edge_gateway_name.security_group_name")
+	}
+	orgName, vdcName, edgeGatewayName, securityGroupName := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
+
+	vcdClient := meta.(*VCDClient)
+	org, err := vcdClient.GetAdminOrg(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Org %s: %s", orgName, err)
+	}
+	vdc, err := org.GetVDCByName(vdcName, false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find VDC %s: %s", vdcName, err)
+	}
+
+	if !vdc.IsNsxt() {
+		return nil, errors.New("security groups are only supported by NSX-T VDCs")
+	}
+
+	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Edge Gateway '%s': %s", edgeGatewayName, err)
+	}
+
+	securityGroup, err := edgeGateway.GetNsxtFirewallGroupByName(securityGroupName, types.FirewallGroupTypeSecurityGroup)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Security Group '%s': %s", edgeGatewayName, err)
+	}
+
+	if !securityGroup.IsSecurityGroup() {
+		return nil, fmt.Errorf("firewall group '%s' is not a Security Group, but '%s'",
+			securityGroup.NsxtFirewallGroup.Name, securityGroup.NsxtFirewallGroup.Type)
+	}
+
+	_ = d.Set("org", orgName)
+	_ = d.Set("vdc", vdcName)
+	_ = d.Set("edge_gateway_id", edgeGateway.EdgeGateway.ID)
+	d.SetId(securityGroup.NsxtFirewallGroup.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func setNsxtSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGroup) error {
+	_ = d.Set("name", fw.Name)
+	_ = d.Set("description", fw.Description)
+
+	netIds := make([]string, len(fw.Members))
+	for i := range fw.Members {
+		netIds[i] = fw.Members[i].ID
+	}
+
+	// Convert `member_org_network_ids` to set
+	memberNetIds := convertToTypeSet(netIds)
+	memberNetSet := schema.NewSet(schema.HashSchema(&schema.Schema{Type: schema.TypeString}), memberNetIds)
+
+	err := d.Set("member_org_network_ids", memberNetSet)
+	if err != nil {
+		return fmt.Errorf("error setting 'member_org_network_ids': %s", err)
+	}
+
+	return nil
+}
+
+func setNsxtSecurityGroupAssociatedVmsData(d *schema.ResourceData, fw []*types.NsxtFirewallGroupMemberVms) error {
+	memberVmSlice := make([]interface{}, len(fw))
+	for index, vmAssociation := range fw {
+		singleVm := make(map[string]interface{})
+
+		if vmAssociation.VmRef != nil {
+			singleVm["vm_id"] = vmAssociation.VmRef.ID
+			singleVm["vm_name"] = vmAssociation.VmRef.Name
+		}
+
+		if vmAssociation.VappRef != nil {
+			singleVm["vapp_id"] = vmAssociation.VappRef.ID
+			singleVm["vapp_name"] = vmAssociation.VappRef.Name
+		}
+
+		memberVmSlice[index] = singleVm
+	}
+	memberVmSet := schema.NewSet(schema.HashResource(nsxtFirewallGroupMemberVms), memberVmSlice)
+
+	return d.Set("member_vms", memberVmSet)
+}
+
+func getNsxtSecurityGroupType(d *schema.ResourceData) *types.NsxtFirewallGroup {
+	fwGroup := &types.NsxtFirewallGroup{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		EdgeGatewayRef: &types.OpenApiReference{
+			ID: d.Get("edge_gateway_id").(string),
+		},
+		Type: types.FirewallGroupTypeSecurityGroup,
+	}
+
+	// Expand member networks
+	orgNetworkIds := convertSchemaSetToSliceOfStrings(d.Get("member_org_network_ids").(*schema.Set))
+	memberReferences := make([]types.OpenApiReference, len(orgNetworkIds))
+	for i := range orgNetworkIds {
+		memberReferences[i].ID = orgNetworkIds[i]
+	}
+
+	if len(memberReferences) > 0 {
+		fwGroup.Members = memberReferences
+	}
+
+	return fwGroup
+}

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -168,8 +168,6 @@ func resourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("error reading NSX-T Security Group: %s", err)
 	}
 
-	// time.Sleep(60 * time.Second)
-
 	// A separate GET call is required to get all associated VMs
 	associatedVms, err := fwGroup.GetAssociatedVms()
 	if err != nil {
@@ -209,7 +207,6 @@ func resourceVcdSecurityGroupDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-// resourceVcdSecurityGroupImport
 func resourceVcdSecurityGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 4 {

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -1,0 +1,436 @@
+// +build network nsxt ALL functional
+
+package vcd
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// TestAccVcdNsxtSecurityGroupEmpty tests out capabilities to setup Security Groups without
+// attaching member networks
+func TestAccVcdNsxtSecurityGroupEmpty(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccNsxtSecurityGroupEmpty, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccNsxtSecurityGroupEmpty2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "name", "test-security-group"),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "description", "test-security-group-description"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_org_network_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_vm_ids"),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "name", "test-security-group-changed"),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "description", ""),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_org_network_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_vm_ids"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_security_group.group1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-security-group-changed"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtSecurityGroupPrereqsEmpty = `
+data "vcd_nsxt_edgegateway" "existing" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+
+	name = "{{.EdgeGw}}"
+}
+`
+
+const testAccNsxtSecurityGroupEmpty = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "test-security-group"
+  description = "test-security-group-description"
+}
+`
+
+const testAccNsxtSecurityGroupEmpty2 = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "test-security-group-changed"
+}
+`
+
+// TestAccVcdNsxtSecurityGroup is similar to TestAccVcdNsxtFirewallGroupEmpty, but it also creates
+// Org VDC networks and attaches them to security group.
+
+// Additionally it tests `vcd_nsxt_security_group` datasource to save testing time and avoid creating
+// the same prerequisite resources.
+func TestAccVcdNsxtSecurityGroup(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccNsxtSecurityGroup, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText1 := templateFill(testAccNsxtSecurityGroupDatasource, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step3"
+	configText2 := templateFill(testAccNsxtSecurityGroupStep3, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "name", "test-security-group"),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "description", "test-security-group-description"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_security_group.group1", "member_vms.*", map[string]string{
+						"vm_name":   "vapp-vm",
+						"vapp_name": "web",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_security_group.group1", "member_vms.*", map[string]string{
+						"vm_name":   "standalone-VM",
+						"vapp_name": "",
+					}),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "name", "test-security-group"),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "description", "test-security-group-description"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_security_group.group1", "member_vms.*", map[string]string{
+						"vm_name":   "vapp-vm",
+						"vapp_name": "web",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_security_group.group1", "member_vms.*", map[string]string{
+						"vm_name":   "standalone-VM",
+						"vapp_name": "",
+					}),
+					// Ensure datasource has all the fields
+					resourceFieldsEqual("vcd_nsxt_security_group.group1", "data.vcd_nsxt_security_group.group1", []string{}),
+				),
+			},
+			resource.TestStep{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "name", "test-security-group-changed"),
+					resource.TestCheckResourceAttr("vcd_nsxt_security_group.group1", "description", ""),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_org_network_ids"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_vm_ids"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_security_group.group1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-security-group"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtSecurityGroupPrereqs = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_network_routed_v2" "nsxt-backed" {
+	# This value could be larger to test more members, but left 2 for the sake of testing speed
+	count = 2
+
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+	name        = "nsxt-routed-${count.index}"
+	description = "My routed Org VDC network backed by NSX-T"
+  
+	edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  
+	gateway       = "212.1.${count.index}.1"
+	prefix_length = 24
+  
+	static_ip_pool {
+	  start_address = "212.1.${count.index}.10"
+	  end_address   = "212.1.${count.index}.20"
+	}
+}
+
+# Create stanadlone VM to check membership
+resource "vcd_vm" "emptyVM" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+
+	name          = "standalone-VM"
+	computer_name = "emptyVM"
+	memory        = 2048
+	cpus          = 2
+	cpu_cores     = 1
+  
+	os_type = "sles10_64Guest"
+	hardware_version = "vmx-14"
+	
+	network {
+		type               = "org"
+		name               = vcd_network_routed_v2.nsxt-backed[0].name
+		ip_allocation_mode = "POOL"
+		is_primary         = true
+	}
+
+	depends_on = [vcd_network_routed_v2.nsxt-backed]
+  }
+
+# Create a vApp and VM
+resource "vcd_vapp" "web" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  name = "web"
+}
+
+resource "vcd_vapp_org_network" "vappOrgNet" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+  
+	vapp_name         = vcd_vapp.web.name
+  
+   # Comment below line to create an isolated vApp network
+	org_network_name  = vcd_network_routed_v2.nsxt-backed[1].name
+
+	depends_on = [vcd_vapp.web,vcd_network_routed_v2.nsxt-backed]
+  }
+
+resource "vcd_vapp_vm" "emptyVM" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  vapp_name     = vcd_vapp.web.name
+  name          = "vapp-vm"
+  computer_name = "emptyVM"
+  memory        = 2048
+  cpus          = 2
+  cpu_cores     = 1
+
+  os_type = "sles10_64Guest"
+  hardware_version = "vmx-14"
+
+  network {
+	type               = "org"
+	name               = vcd_network_routed_v2.nsxt-backed[1].name
+	ip_allocation_mode = "POOL"
+	is_primary         = true
+  }
+
+  depends_on = [vcd_vapp_org_network.vappOrgNet,vcd_network_routed_v2.nsxt-backed]
+}
+`
+
+const testAccNsxtSecurityGroup = testAccNsxtSecurityGroupPrereqs + `
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "test-security-group"
+  description = "test-security-group-description"
+
+  member_org_network_ids = vcd_network_routed_v2.nsxt-backed.*.id
+
+  depends_on = [vcd_vapp_vm.emptyVM, vcd_vm.emptyVM]
+}
+`
+
+const testAccNsxtSecurityGroupStep3 = testAccNsxtSecurityGroupPrereqs + `
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "test-security-group-changed"
+
+  depends_on = [vcd_vapp_vm.emptyVM, vcd_vm.emptyVM]
+}
+`
+
+const testAccNsxtSecurityGroupDatasource = testAccNsxtSecurityGroup + `
+data "vcd_nsxt_security_group" "group1" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+
+	edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+	name            = "test-security-group"
+}
+`
+
+// TestAccVcdNsxtSecurityGroupIncorrectEdgeGateway is expected to fail when:
+// * NSX-V Edge Gateway ID is supplied
+// * Invalid (non existent) Edge Gateway ID is presented
+func TestAccVcdNsxtSecurityGroupIncorrectEdgeGateway(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// This test is meant to fail
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Networking.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccVcdNsxtSecurityGroupIncorrectEdgeGateway, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText1 := templateFill(testAccVcdNsxtSecurityGroupIncorrectEdgeGatewayStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText1)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      configText,
+				ExpectError: regexp.MustCompile(`please use 'vcd_nsxt_edgegateway' for NSX-T backed VDC`),
+			},
+			resource.TestStep{
+				Config:      configText1,
+				ExpectError: regexp.MustCompile(`error creating NSX-T Security Group`),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdNsxtSecurityGroupIncorrectEdgeGateway = `
+data "vcd_edgegateway" "existing" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+
+	name = "{{.EdgeGw}}"
+}
+
+resource "vcd_nsxt_security_group" "group1" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+  
+	edge_gateway_id = data.vcd_edgegateway.existing.id
+  
+	name = "test-security-group"
+	description = "test-security-group-description"
+  }
+`
+
+const testAccVcdNsxtSecurityGroupIncorrectEdgeGatewayStep2 = `
+resource "vcd_nsxt_security_group" "group1" {
+	org  = "{{.Org}}"
+	vdc  = "{{.NsxtVdc}}"
+  
+	# A correct syntax of non existing NSX-T Edge Gateway
+	edge_gateway_id = "urn:vcloud:gateway:71df3e4b-6da9-404d-8e44-1111111c1c38"
+  
+	name = "test-security-group"
+	description = "test-security-group-description"
+  }
+`
+
+func testAccCheckNsxtFirewallGroupDestroy(vdcName, firewalGroupName, firewallGroupType string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, vdcName)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingVdcFromOrg, vdcName, testConfig.VCD.Org, err)
+		}
+
+		_, err = vdc.GetNsxtFirewallGroupByName(firewalGroupName, firewallGroupType)
+		if err == nil {
+			return fmt.Errorf("firewall group '%s' of type '%s' still exists", firewalGroupName, firewallGroupType)
+		}
+
+		return nil
+	}
+}

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -135,9 +135,10 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 	configText1 := templateFill(testAccNsxtSecurityGroupDatasource, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText1)
 
+	delete(params, "SkipTest")
 	params["FuncName"] = t.Name() + "-step3"
 	configText2 := templateFill(testAccNsxtSecurityGroupStep3, params)
-	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText1)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText2)
 
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -313,7 +314,7 @@ resource "vcd_nsxt_security_group" "group1" {
 }
 `
 
-const testAccNsxtSecurityGroupStep3 = testAccNsxtSecurityGroupPrereqs + `
+const testAccNsxtSecurityGroupStep3 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_security_group" "group1" {
   org  = "{{.Org}}"
   vdc  = "{{.NsxtVdc}}"
@@ -321,12 +322,11 @@ resource "vcd_nsxt_security_group" "group1" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name = "test-security-group-changed"
-
-  depends_on = [vcd_vapp_vm.emptyVM, vcd_vm.emptyVM]
 }
 `
 
 const testAccNsxtSecurityGroupDatasource = testAccNsxtSecurityGroup + `
+# skip-binary-test: Terraform resource cannot have resource and datasource in the same file
 data "vcd_nsxt_security_group" "group1" {
 	org  = "{{.Org}}"
 	vdc  = "{{.NsxtVdc}}"

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -210,72 +210,72 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 
 const testAccNsxtSecurityGroupPrereqs = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_network_routed_v2" "nsxt-backed" {
-	# This value could be larger to test more members, but left 2 for the sake of testing speed
-	count = 2
+  # This value could be larger to test more members, but left 2 for the sake of testing speed
+  count = 2
 
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
-	name        = "nsxt-routed-${count.index}"
-	description = "My routed Org VDC network backed by NSX-T"
-  
-	edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
-  
-	gateway       = "212.1.${count.index}.1"
-	prefix_length = 24
-  
-	static_ip_pool {
-	  start_address = "212.1.${count.index}.10"
-	  end_address   = "212.1.${count.index}.20"
-	}
+  org         = "{{.Org}}"
+  vdc         = "{{.NsxtVdc}}"
+  name        = "nsxt-routed-${count.index}"
+  description = "My routed Org VDC network backed by NSX-T"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  gateway       = "212.1.${count.index}.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "212.1.${count.index}.10"
+    end_address   = "212.1.${count.index}.20"
+  }
 }
 
 # Create stanadlone VM to check membership
 resource "vcd_vm" "emptyVM" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
-    power_on      = false
-	name          = "standalone-VM"
-	computer_name = "emptyVM"
-	memory        = 2048
-	cpus          = 2
-	cpu_cores     = 1
-  
-	os_type = "sles10_64Guest"
-	hardware_version = "vmx-14"
-	
-	network {
-		type               = "org"
-		name               = (vcd_network_routed_v2.nsxt-backed[0].id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed[0].name)
-		ip_allocation_mode = "POOL"
-		is_primary         = true
-	}
+  power_on      = false
+  name          = "standalone-VM"
+  computer_name = "emptyVM"
+  memory        = 2048
+  cpus          = 2
+  cpu_cores     = 1
 
-	depends_on = [vcd_network_routed_v2.nsxt-backed]
+  os_type          = "sles10_64Guest"
+  hardware_version = "vmx-14"
+
+  network {
+    type               = "org"
+    name               = (vcd_network_routed_v2.nsxt-backed[0].id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed[0].name)
+    ip_allocation_mode = "POOL"
+    is_primary         = true
   }
+
+  depends_on = [vcd_network_routed_v2.nsxt-backed]
+}
 
 # Create a vApp and VM
 resource "vcd_vapp" "web" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name     = "web"
   power_on = false
 }
 
 resource "vcd_vapp_org_network" "vappOrgNet" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
-  
-	vapp_name         = vcd_vapp.web.name
-	org_network_name  = (vcd_network_routed_v2.nsxt-backed[1].id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed[1].name)
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
-	depends_on = [vcd_vapp.web,vcd_network_routed_v2.nsxt-backed]
-  }
+  vapp_name        = vcd_vapp.web.name
+  org_network_name = (vcd_network_routed_v2.nsxt-backed[1].id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed[1].name)
+
+  depends_on = [vcd_vapp.web, vcd_network_routed_v2.nsxt-backed]
+}
 
 resource "vcd_vapp_vm" "emptyVM" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   power_on      = false
   vapp_name     = vcd_vapp.web.name
@@ -285,28 +285,28 @@ resource "vcd_vapp_vm" "emptyVM" {
   cpus          = 2
   cpu_cores     = 1
 
-  os_type = "sles10_64Guest"
+  os_type          = "sles10_64Guest"
   hardware_version = "vmx-14"
 
   network {
-	type               = "org"
-	name               = (vcd_vapp_org_network.vappOrgNet.id == "always-not-equal" ? null : vcd_vapp_org_network.vappOrgNet.org_network_name)
-	ip_allocation_mode = "POOL"
-	is_primary         = true
+    type               = "org"
+    name               = (vcd_vapp_org_network.vappOrgNet.id == "always-not-equal" ? null : vcd_vapp_org_network.vappOrgNet.org_network_name)
+    ip_allocation_mode = "POOL"
+    is_primary         = true
   }
 
-  depends_on = [vcd_vapp_org_network.vappOrgNet,vcd_network_routed_v2.nsxt-backed]
+  depends_on = [vcd_vapp_org_network.vappOrgNet, vcd_network_routed_v2.nsxt-backed]
 }
 `
 
 const testAccNsxtSecurityGroup = testAccNsxtSecurityGroupPrereqs + `
 resource "vcd_nsxt_security_group" "group1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  name = "test-security-group"
+  name        = "test-security-group"
   description = "test-security-group-description"
 
   member_org_network_ids = vcd_network_routed_v2.nsxt-backed.*.id
@@ -317,8 +317,8 @@ resource "vcd_nsxt_security_group" "group1" {
 
 const testAccNsxtSecurityGroupStep3 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_security_group" "group1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -329,11 +329,11 @@ resource "vcd_nsxt_security_group" "group1" {
 const testAccNsxtSecurityGroupDatasource = testAccNsxtSecurityGroup + `
 # skip-binary-test: Terraform resource cannot have resource and datasource in the same file
 data "vcd_nsxt_security_group" "group1" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
-	edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
-	name            = "test-security-group"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  name            = "test-security-group"
 }
 `
 
@@ -397,40 +397,40 @@ func TestAccVcdNsxtSecurityGroupInvalidConfigs(t *testing.T) {
 
 const testAccVcdNsxtSecurityGroupIncorrectEdgeGateway = `
 data "vcd_edgegateway" "existing" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
-	name = "{{.EdgeGw}}"
+  name = "{{.EdgeGw}}"
 }
 
 resource "vcd_nsxt_security_group" "group1" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
-  
-	edge_gateway_id = data.vcd_edgegateway.existing.id
-  
-	name = "test-security-group"
-	description = "test-security-group-description"
-  }
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_edgegateway.existing.id
+
+  name        = "test-security-group"
+  description = "test-security-group-description"
+}
 `
 
 const testAccVcdNsxtSecurityGroupIncorrectEdgeGatewayStep2 = `
 resource "vcd_nsxt_security_group" "group1" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
-  
-	# A correct syntax of non existing NSX-T Edge Gateway
-	edge_gateway_id = "urn:vcloud:gateway:71df3e4b-6da9-404d-8e44-1111111c1c38"
-  
-	name = "test-security-group"
-	description = "test-security-group-description"
-  }
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
+  # A correct syntax of non existing NSX-T Edge Gateway
+  edge_gateway_id = "urn:vcloud:gateway:71df3e4b-6da9-404d-8e44-1111111c1c38"
+
+  name        = "test-security-group"
+  description = "test-security-group-description"
+}
 `
 
 const testAccVcdNsxtSecurityGroupIncorrectEdgeGatewayStep3 = `
 resource "vcd_network_isolated_v2" "nsxt-backed" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name        = "nsxt-isolated-test"
   description = "My isolated Org VDC network backed by NSX-T"
@@ -445,15 +445,15 @@ resource "vcd_network_isolated_v2" "nsxt-backed" {
 
 }
 resource "vcd_nsxt_security_group" "group1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
-  
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
   # A correct syntax of non existing NSX-T Edge Gateway
   edge_gateway_id = "urn:vcloud:gateway:71df3e4b-6da9-404d-8e44-1111111c1c38"
-  
-  name = "test-security-group"
+
+  name        = "test-security-group"
   description = "test-security-group-description"
-  
+
   member_org_network_ids = [vcd_network_isolated_v2.nsxt-backed.id]
 }
 `

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -349,6 +349,8 @@ output "disk_unit_number" {
 }
 output "vm" {
   value = vcd_vm.{{.VmName}}
+  
+  sensitive = true
 }
 `
 

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -245,6 +245,8 @@ output "disk_unit_number" {
 }
 output "vm" {
   value = vcd_vm.{{.VmName}}
+  
+  sensitive = true
 }
 `
 

--- a/website/docs/d/nsxt_network_dhcp.html.markdown
+++ b/website/docs/d/nsxt_network_dhcp.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: vcd_nsxt_dhcp_relay"
+page_title: "VMware Cloud Director: vcd_nsxt_network_dhcp"
 sidebar_current: "docs-vcd-datasource-nsxt-network-dhcp"
 description: |-
   Provides a data source to read DHCP pools for NSX-T Org VDC Routed network.

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_security_group"
+sidebar_current: "docs-vcd-datasource-nsxt-security-group"
+description: |-
+  Provides a datasource to access NSX-T Security Group configuration. Security groups are groups of
+  data center group networks to which distributed firewall rules apply. Grouping networks helps you 
+  to reduce the total number of distributed firewall rules to be created. 
+---
+
+# vcd\_nsxt\_security\_group
+
+Provides a datasource to access NSX-T Security Group configuration. Security groups are groups of
+data center group networks to which distributed firewall rules apply. Grouping networks helps you to
+reduce the total number of distributed firewall rules to be created. 
+
+Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
+
+## Example Usage 1
+
+```hcl
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "my-org"
+  vdc  = "my-org-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "test-security-group-changed"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `name` - (Required)  - Unique name of existing Security Group.
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_security_group`](/docs/providers/vcd/r/nsxt_security_group.html) resource are available.

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -10,11 +10,11 @@ description: |-
 
 # vcd\_nsxt\_security\_group
 
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+
 Provides a datasource to access NSX-T Security Group configuration. Security groups are groups of
 data center group networks to which distributed firewall rules apply. Grouping networks helps you to
-reduce the total number of distributed firewall rules to be created. 
-
-Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+reduce the total number of distributed firewall rules to be created.
 
 ## Example Usage 1
 

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -19,7 +19,7 @@ Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 ## Example Usage 1
 
 ```hcl
-resource "vcd_nsxt_security_group" "group1" {
+data "vcd_nsxt_security_group" "group1" {
   org  = "my-org"
   vdc  = "my-org-vdc"
 

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -14,7 +14,7 @@ Provides a datasource to access NSX-T Security Group configuration. Security gro
 data center group networks to which distributed firewall rules apply. Grouping networks helps you to
 reduce the total number of distributed firewall rules to be created. 
 
-Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
 ## Example Usage 1
 

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -40,6 +40,38 @@ resource "vcd_network_routed_v2" "nsxt-backed" {
 }
 ```
 
+## Example Usage (NSX-T backed routed Org VDC network and a DHCP pool)
+
+```hcl
+resource "vcd_network_routed_v2" "parent-network" {
+  name = "nsxt-routed-dhcp"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  gateway = "7.1.1.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "7.1.1.10"
+    end_address   = "7.1.1.20"
+  }
+}
+
+resource "vcd_nsxt_network_dhcp" "pools" {
+  org_network_id = vcd_network_routed_v2.parent-network.id
+  
+  pool {
+    start_address = "7.1.1.100"
+    end_address   = "7.1.1.110"
+  }
+
+  pool {
+    start_address = "7.1.1.111"
+    end_address   = "7.1.1.112"
+  }
+}
+```
+
 ## Example Usage (NSX-V backed routed Org VDC network using `subinterface` NIC)
 
 ```hcl
@@ -74,7 +106,7 @@ The following arguments are supported:
 * `description` - (Optional) An optional description of the network
 * `interface_type` - (Optional) An interface for the network. One of `internal` (default), `subinterface`, 
   `distributed` (requires the edge gateway to support distributed networks). NSX-T supports only `internal`
-* `edge_gateway_id` - (Required) The ID name of the edge gateway (NSX-V or NSX-T)
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-V or NSX-T)
 * `gateway` (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
 * `dns1` - (Optional) First DNS server to use.
@@ -86,7 +118,7 @@ The following arguments are supported:
 <a id="ip-pools"></a>
 ## IP Pools
 
-Static IP Pools and DHCP Pools support the following attributes:
+Static IP Pools support the following attributes:
 
 * `start_address` - (Required) The first address in the IP Range
 * `end_address` - (Required) The final address in the IP Range

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: vcd_nsxt_network-dhcp"
+page_title: "VMware Cloud Director: vcd_nsxt_network_dhcp"
 sidebar_current: "docs-vcd-resource-nsxt-network-dhcp"
 description: |-
   Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -26,8 +26,8 @@ resource "vcd_nsxt_security_group" "frontend-servers" {
   # Referring to a datasource for existing NSX-T Edge Gateway
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  name = "frontend-servers"
-  description = "Security group consisting of frontend servers"
+  name        = "frontend-servers"
+  description = "Security Group for a network connecting the frontend servers"
 
   member_org_network_ids = [vcd_network_routed_v2.frontend.id]
 }

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -3,18 +3,18 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_security_group"
 sidebar_current: "docs-vcd-resource-nsxt-security-group"
 description: |-
-Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
-group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
-the total number of distributed firewall rules to be created.
+  Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
+  group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
+  the total number of distributed firewall rules to be created.
 ---
 
 # vcd\_nsxt\_security\_group
 
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+
 Provides a resource to manage NSX-T Security Group. Security groups are groups of data center group
 networks to which distributed firewall rules apply. Grouping networks helps you to reduce the total
 number of distributed firewall rules to be created.
-
-Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
 ## Example Usage 1 (Security Group with member networks)
 

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -16,8 +16,6 @@ number of distributed firewall rules to be created.
 
 Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
-## Specific usage notes
-
 ## Example Usage 1 (Security Group with member networks)
 
 ```hcl
@@ -25,7 +23,7 @@ resource "vcd_nsxt_security_group" "frontend-servers" {
   org  = "my-org"
   vdc  = "my-nsxt-vdc"
 
-  # refering to a datasource for existing NSX-T Edge Gateway
+  # Referring to a datasource for existing NSX-T Edge Gateway
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name = "frontend-servers"
@@ -41,7 +39,7 @@ resource "vcd_nsxt_security_group" "group1" {
   org  = "my-org"
   vdc  = "my-nsxt-vdc"
 
-  # refering to a datasource for existing NSX-T Edge Gateway
+  # Referring to a datasource for existing NSX-T Edge Gateway
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name = "precreated security group"

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -1,0 +1,96 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_security_group"
+sidebar_current: "docs-vcd-resource-nsxt-security-group"
+description: |-
+  Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
+  group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
+  the total number of distributed firewall rules to be created. 
+---
+
+# vcd\_nsxt\_security\_group
+
+Provides a resource to manage NSX-T Security Group. Security groups are groups of data center group
+networks to which distributed firewall rules apply. Grouping networks helps you to reduce the total
+number of distributed firewall rules to be created. 
+
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+
+## Specific usage notes
+
+## Example Usage 1 (Security Group with member networks)
+
+```hcl
+resource "vcd_nsxt_security_group" "frontend-servers" {
+  org  = "my-org"
+  vdc  = "my-nsxt-vdc"
+
+  # refering to a datasource for existing NSX-T Edge Gateway
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "frontend-servers"
+  description = "Security group consisting of frontend servers"
+
+  member_org_network_ids = [vcd_network_routed_v2.frontend.id]
+}
+```
+
+## Example Usage 2 (Empty Security Group)
+```hcl
+resource "vcd_nsxt_security_group" "group1" {
+  org  = "my-org"
+  vdc  = "my-nsxt-vdc"
+
+  # refering to a datasource for existing NSX-T Edge Gateway
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "precreated security group"
+  description = "Members to be added later"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `name` - (Required) A unique name for Security Group
+* `description` - (Optional) An optional description of the Security Group
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+  `vcd_nsxt_edgegateway` datasource
+* `member_org_network_ids` (Optional) A set of Org Network IDs
+
+## Attribute Reference
+* `member_vms` A set of member VMs (if exist). see [Member VMs](#member-vms) below for details.
+
+<a id="member-vms"></a>
+## Member VMs
+
+Each member VM contains following attributes:
+
+* `vm_id` - Member VM ID
+* `vm_name` - Member VM name
+* `vapp_id` - Parent vApp ID for member VM (empty for standalone VMs)
+* `vapp_name` - Parent vApp Name for member VM (empty for standalone VMs)
+
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing Security Group configuration can be [imported][docs-import] into this resource
+via supplying the full dot separated path for your Security Group name. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_security_group.imported my-org.my-org-vdc.my-nsxt-edge-gateway.my-security-group-name
+```
+
+The above would import the `my-security-group-name` Security Group config settings that are defined
+on NSX-T Edge Gateway `my-nsxt-edge-gateway` which is configured in organization named `my-org` and
+VDC named `my-org-vdc`.

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -3,16 +3,16 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_security_group"
 sidebar_current: "docs-vcd-resource-nsxt-security-group"
 description: |-
-  Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
-  group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
-  the total number of distributed firewall rules to be created. 
+Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
+group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
+the total number of distributed firewall rules to be created.
 ---
 
 # vcd\_nsxt\_security\_group
 
 Provides a resource to manage NSX-T Security Group. Security groups are groups of data center group
 networks to which distributed firewall rules apply. Grouping networks helps you to reduce the total
-number of distributed firewall rules to be created. 
+number of distributed firewall rules to be created.
 
 Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
@@ -75,6 +75,9 @@ Each member VM contains following attributes:
 * `vapp_id` - Parent vApp ID for member VM (empty for standalone VMs)
 * `vapp_name` - Parent vApp Name for member VM (empty for standalone VMs)
 
+~> There may be cases where Org Networks and Security Groups are already created, but
+not all VMs are already created and not shown in this structure. Additional `depends_on` can ensure
+that Security Group is created only after all networks and VMs are there.
 
 ## Importing
 

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -151,6 +151,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-storage-profile") %>>
               <a href="/docs/providers/vcd/d/storage_profile.html">vcd_storage_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-datas-source-nsxt-security-group") %>>
+              <a href="/docs/providers/vcd/d/nsxt_security_group.html">vcd_nsxt_security_group</a>
+            </li>
           </ul>
         </li>
 
@@ -288,6 +291,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-edge-gateway") %>>
               <a href="/docs/providers/vcd/r/nsxt_edgegateway.html">vcd_nsxt_edgegateway</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-security-group") %>>
+              <a href="/docs/providers/vcd/r/nsxt_security_group.html">vcd_nsxt_security_group</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR introduces NSX-T Security Groups datasource and resource.

Additionally it:
* Fixes a few typos and adds an example in Routed Network V2 docs
* Adds compatibility with Terraform 0.15.0 for `TestAccVcdNsxtStandaloneVmTemplate` which complained about `sensitive` `output` 

On the code side:
* Adds VCDClient.GetNsxtEdgeGateway, VCDClient.GetNsxtEdgeGatewayById, and
  GetNsxtEdgeGatewayFromResourceById convenience functions
* Adds `importStateIdNsxtEdgeGatewayObject` function for import testing of NSX-T Edge Gateway child
  objects

* Also - adds a validator that `-v` flag is passed to tests as running it without it can cause panic in Terraform acceptance tests.