### PR TITLE
Add handling of vApp name and description

### DIFF
--- a/.changes/v3.3.0/664-bug-fixes.md
+++ b/.changes/v3.3.0/664-bug-fixes.md
@@ -1,0 +1,2 @@
+* (Issue #633) vApp description was ignored in creation and update. [GH-664]
+

--- a/.changes/v3.3.0/664-improvements.md
+++ b/.changes/v3.3.0/664-improvements.md
@@ -1,0 +1,2 @@
+* `vcd_vapp` Changing the `name` property does not trigger a resource rebuild [GH-664]
+

--- a/.changes/v3.3.0/664-improvements.md
+++ b/.changes/v3.3.0/664-improvements.md
@@ -1,2 +1,0 @@
-* `vcd_vapp` Changing the `name` property does not trigger a resource rebuild [GH-664]
-

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b
+
+// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1
+	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b
-
-// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
-	github.com/kr/pretty v0.2.0
+	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b h1:iwwXGfMu8siHWjUmputOf47Caq3OV2YnqVhv2yEIWjU=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -290,6 +288,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2 h1:4/tPT4/KJ3niBpEzyO8ZBrRXpSaurb+5hHr1mC20AgA=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.2/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37 h1:o/KpPbflQbd/ZqabRnWP3SbSmzqfQib38HdxvDcey/4=
-github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b h1:iwwXGfMu8siHWjUmputOf47Caq3OV2YnqVhv2yEIWjU=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210429082455-9994e0748a7b/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37 h1:o/KpPbflQbd/ZqabRnWP3SbSmzqfQib38HdxvDcey/4=
+github.com/dataclouder/go-vcloud-director/v2 v2.5.0-alpha.4.0.20210428122234-d5c42d5f6c37/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -218,8 +220,8 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT
 github.com/keybase/go-crypto v0.0.0-20161004153544-93f5b35093ba/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -288,8 +290,6 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1 h1:0/C6CI0YsrM+uMt0Lf1/CI5pA1Ff9d1ZMmuqjdEpC9I=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.1/go.mod h1:czvTQZlB4/WsOsL7rMVCb+SYAPJhx/dYoS/Sk7rc/O0=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -152,7 +152,7 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error finding VApp: %#v", err)
 	}
 
-	if d.HasChange("name") || d.HasChange("description") {
+	if d.HasChange("description") {
 		err = vapp.UpdateNameDescription(d.Get("name").(string), d.Get("description").(string))
 		if err != nil {
 			return fmt.Errorf("error updating VApp: %s", err)

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -26,6 +26,7 @@ func resourceVcdVApp() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "A name for the vApp, unique withing the VDC",
 			},
 			"org": {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -24,9 +24,9 @@ func resourceVcdVApp() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Type:     schema.TypeString,
+				Required: true,
+				//ForceNew:    true,
 				Description: "A name for the vApp, unique withing the VDC",
 			},
 			"org": {
@@ -92,10 +92,11 @@ func resourceVcdVAppCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	vappName := d.Get("name").(string)
+	vappDescription := d.Get("description").(string)
 	vcdClient.lockVapp(d)
 	defer vcdClient.unLockVapp(d)
 
-	e := vdc.ComposeRawVApp(d.Get("name").(string))
+	e := vdc.ComposeRawVApp(vappName, vappDescription)
 
 	if e != nil {
 		return fmt.Errorf("error: %#v", e)
@@ -151,6 +152,12 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error finding VApp: %#v", err)
 	}
 
+	if d.HasChange("name") || d.HasChange("description") {
+		err = vapp.UpdateNameDescription(d.Get("name").(string), d.Get("description").(string))
+		if err != nil {
+			return fmt.Errorf("error updating VApp: %s", err)
+		}
+	}
 	if d.HasChange("guest_properties") {
 		vappProperties, err := getGuestProperties(d)
 		if err != nil {

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -24,9 +24,8 @@ func resourceVcdVApp() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				//ForceNew:    true,
+				Type:        schema.TypeString,
+				Required:    true,
 				Description: "A name for the vApp, unique withing the VDC",
 			},
 			"org": {

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -16,23 +16,27 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 	preTestChecks(t)
 	var vapp govcd.VApp
 	var vappName = "TestAccVcdVAppVapp"
+	var vappDescription = "A long description containing some text."
+	var vappUpdateDescription = "A shorter description."
 
 	var params = StringMap{
-		"Org":          testConfig.VCD.Org,
-		"Vdc":          testConfig.VCD.Vdc,
-		"EdgeGateway":  testConfig.Networking.EdgeGateway,
-		"NetworkName":  "TestAccVcdVAppNet",
-		"NetworkName2": "TestAccVcdVAppNet2",
-		"NetworkName3": "TestAccVcdVAppNet3",
-		"Catalog":      testSuiteCatalogName,
-		"CatalogItem":  testSuiteCatalogOVAItem,
-		"VappName":     vappName,
-		"FuncName":     "TestAccCheckVcdVApp_PowerOff",
-		"Tags":         "vapp",
+		"Org":             testConfig.VCD.Org,
+		"Vdc":             testConfig.VCD.Vdc,
+		"EdgeGateway":     testConfig.Networking.EdgeGateway,
+		"NetworkName":     "TestAccVcdVAppNet",
+		"NetworkName2":    "TestAccVcdVAppNet2",
+		"NetworkName3":    "TestAccVcdVAppNet3",
+		"Catalog":         testSuiteCatalogName,
+		"CatalogItem":     testSuiteCatalogOVAItem,
+		"VappName":        vappName,
+		"VappDescription": vappDescription,
+		"FuncName":        "TestAccVcdVApp_Basic",
+		"Tags":            "vapp",
 	}
 	configText := templateFill(testAccCheckVcdVApp_basic, params)
 
 	params["FuncName"] = "TestAccCheckVcdVApp_update"
+	params["VappDescription"] = vappUpdateDescription
 	configTextUpdate := templateFill(testAccCheckVcdVApp_update, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -51,6 +55,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+vappName, &vapp),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "name", vappName),
+					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "description", vappDescription),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "status", "1"),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "metadata.vapp_metadata", "vApp Metadata."),
 					resource.TestMatchResourceAttr("vcd_vapp."+vappName, "href",
@@ -65,6 +70,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+vappName, &vapp),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "name", vappName),
+					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "description", vappUpdateDescription),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "power_on", "true"),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "status", "4"),
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, "metadata.vapp_metadata", "vApp Metadata updated"),
@@ -149,6 +155,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   org           = "{{.Org}}"
   vdc           = "{{.Vdc}}"
   name          = "{{.VappName}}"
+  description   = "{{.VappDescription}}"
 
   metadata = {
     vapp_metadata = "vApp Metadata."
@@ -180,6 +187,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   org           = "{{.Org}}"
   vdc           = "{{.Vdc}}"
   name          = "{{.VappName}}"
+  description   = "{{.VappDescription}}"
 
   metadata = {
     vapp_metadata = "vApp Metadata updated"

--- a/vcd/resource_vcd_vapp_update_test.go
+++ b/vcd/resource_vcd_vapp_update_test.go
@@ -1,0 +1,97 @@
+// +build vapp ALL functional
+
+package vcd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+func TestAccVcdVApp_Update(t *testing.T) {
+	preTestChecks(t)
+	var vapp govcd.VApp
+	var vappName = "TestAccVcdVAppUpdate"
+	var vappDescription = "A long description going up to 256 characters. " + strings.Repeat("x", 209)
+	var vappUpdateDescription = "A shorter description."
+	var vappUpdateName = vappName + "_new"
+
+	var params = StringMap{
+		"Org":             testConfig.VCD.Org,
+		"Vdc":             testConfig.VCD.Vdc,
+		"VappDef":         vappName,
+		"VappName":        vappName,
+		"VappDescription": vappDescription,
+		"FuncName":        "TestAccVcdVApp_Update",
+		"Note":            "",
+		"Tags":            "vapp",
+	}
+	configText := templateFill(testAccCheckVcdVAppUpdate, params)
+
+	params["FuncName"] = "TestAccCheckVcdVApp_Update_update"
+	params["VappDescription"] = vappUpdateDescription
+	params["VappName"] = vappUpdateName
+	params["Note"] = "# skip-binary-test: only for updates"
+	configTextUpdate := templateFill(testAccCheckVcdVAppUpdate, params)
+
+	params["FuncName"] = "TestAccCheckVcdVApp_Update_restore"
+	params["VappDescription"] = vappDescription
+	params["VappName"] = vappName
+	configTextRestore := templateFill(testAccCheckVcdVAppUpdate, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION basic: %s\n", configText)
+	debugPrintf("#[DEBUG] CONFIGURATION update: %s\n", configTextUpdate)
+	debugPrintf("#[DEBUG] CONFIGURATION restore: %s\n", configTextRestore)
+
+	resourceName := "vcd_vapp." + vappName
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVcdVAppDestroy,
+		Steps: []resource.TestStep{
+			// Deploy vApp
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppExists(resourceName, &vapp),
+					resource.TestCheckResourceAttr(resourceName, "name", vappName),
+					resource.TestCheckResourceAttr(resourceName, "description", vappDescription),
+				),
+			},
+			// Rename vApp and update description
+			resource.TestStep{
+				Config: configTextUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppExists(resourceName, &vapp),
+					resource.TestCheckResourceAttr(resourceName, "name", vappUpdateName),
+					resource.TestCheckResourceAttr(resourceName, "description", vappUpdateDescription),
+				),
+			},
+			// Restore original values
+			resource.TestStep{
+				Config: configTextRestore,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVcdVAppExists(resourceName, &vapp),
+					resource.TestCheckResourceAttr(resourceName, "name", vappName),
+					resource.TestCheckResourceAttr(resourceName, "description", vappDescription),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccCheckVcdVAppUpdate = `
+{{.Note}}
+resource "vcd_vapp" "{{.VappDef}}" {
+  org         = "{{.Org}}"
+  vdc         = "{{.Vdc}}"
+  name        = "{{.VappName}}"
+  description = "{{.VappDescription}}"
+}
+`

--- a/vcd/resource_vcd_vm_affinity_rule_test.go
+++ b/vcd/resource_vcd_vm_affinity_rule_test.go
@@ -389,7 +389,7 @@ func testAccCheckVmAffinityRuleDestroy(rule *govcd.VmAffinityRule, orgName, vdcN
 // makeEmptyVapp creates a given vApp without any VM
 func makeEmptyVapp(vdc *govcd.Vdc, name string) (*govcd.VApp, error) {
 
-	err := vdc.ComposeRawVApp(name)
+	err := vdc.ComposeRawVApp(name, name)
 	if err != nil {
 		return nil, err
 	}

--- a/vcd/resource_vcd_vm_affinity_rule_test.go
+++ b/vcd/resource_vcd_vm_affinity_rule_test.go
@@ -387,9 +387,9 @@ func testAccCheckVmAffinityRuleDestroy(rule *govcd.VmAffinityRule, orgName, vdcN
 }
 
 // makeEmptyVapp creates a given vApp without any VM
-func makeEmptyVapp(vdc *govcd.Vdc, name string) (*govcd.VApp, error) {
+func makeEmptyVapp(vdc *govcd.Vdc, name string, description string) (*govcd.VApp, error) {
 
-	err := vdc.ComposeRawVApp(name, name)
+	err := vdc.ComposeRawVApp(name, description)
 	if err != nil {
 		return nil, err
 	}
@@ -487,7 +487,7 @@ func makeVappGroup(label string, vdc *govcd.Vdc, groupDefinition map[string][]st
 		if vcdTestVerbose {
 			fmt.Printf("Creating vApp %s\n", vappName)
 		}
-		vapp, err := makeEmptyVapp(vdc, vappName)
+		vapp, err := makeEmptyVapp(vdc, vappName, "")
 		if err != nil {
 			return nil, err
 		}

--- a/website/docs/d/vapp.html.markdown
+++ b/website/docs/d/vapp.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 
 ## Attribute reference
 
+* `description` An optional description for the vApp
 * `href` - The vApp Hyper Reference
 * `metadata` -  Key value map of metadata to assign to this vApp. Key and value can be any string. 
 * `guest_properties` -  Key value map of vApp guest properties.

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -93,6 +93,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the vApp
 * `org` - (Optional; *v2.0+*) The name of organization to use, optional if defined at provider level. Useful when connected as sysadmin working across different organisations
 * `vdc` - (Optional; *v2.0+*) The name of VDC to use, optional if defined at provider level
+* `description` (Optional; *v3.3*) An optional description for the vApp, up to 256 characters.
 * `power_on` - (Optional) A boolean value stating if this vApp should be powered on. Default is `false`. Works only on update when vApp already has VMs.
 * `metadata` - (Optional) Key value map of metadata to assign to this vApp. Key and value can be any string. (Since *v2.2+* metadata is added directly to vApp instead of first VM in vApp)
 * `guest_properties` - (Optional; *v2.5+*) Key value map of vApp guest properties


### PR DESCRIPTION
<s>* vApp `name` is now updatable. Changing it doesn't force a resource rebuild.</s> (reverted, because of possible side effects on VMs)
* vApp `description` was ignored up to now. It was not added to new vApps or updated when requested. Now it can be inserted and changed.


Solves issue #633