### PR TITLE
Update resource_vcd_org_vdc.go

### DIFF
--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -824,7 +824,9 @@ func addAssignedVmSizingPolicies(vcdClient *VCDClient, d *schema.ResourceData, m
 }
 
 func createOrUpdateMetadata(d *schema.ResourceData, meta interface{}) error {
-
+	
+	time.Sleep(5 * time.Second)
+	
 	log.Printf("[TRACE] adding/updating metadata to VDC")
 
 	vcdClient := meta.(*VCDClient)


### PR DESCRIPTION
When I use metadata, it sometimes fails to create a vapp. Adding a little lag to the metadata task solves the problem.