### PR TITLE
Add NSX-T NAT rule resource and data source

### DIFF
--- a/.changes/v3.3.0/676-bug-fixes.md
+++ b/.changes/v3.3.0/676-bug-fixes.md
@@ -1,0 +1,1 @@
+* `resource/vcd_org_vdc` complained about storage profile name update from empty to specified on some VCD versions [GH-676]

--- a/.changes/v3.3.0/676-features.md
+++ b/.changes/v3.3.0/676-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_nsxt_nat_rule` for NSX-T Edge Gateways [GH-676]
+* **New Data source:** `vcd_nsxt_nat_rule` for NSX-T Edge Gateways [GH-676]

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ vcd/go-vcloud-director.log
 vcd/test-artifacts
 website/vendor
 vcd/org_user_pwd.txt
+vcd/vcd_test_pass_list*.txt
 
 # Test exclusions
 !command/test-fixtures/**/*.tfstate

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.5
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.5
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614124911-a2e2c9f0269f

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.5
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623110520-b35e4d543b11
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623114451-c83e659e566b
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623110520-b35e4d543b11
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.2.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.4.4
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623110520-b35e4d543b11
+	github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625090333-222985edfebb
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c h1:um4dVzbLTAn6hGi49vIU4OjFMsYead4KisZ8NFKWfj0=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -288,8 +290,6 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.5 h1:szPJrKFFUakS3nEVOEOcVjBk/5kzEpAgFI1zpj/gSE0=
-github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.5/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c h1:um4dVzbLTAn6hGi49vIU4OjFMsYead4KisZ8NFKWfj0=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210613120100-16d8b08ea54c/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7 h1:9umdrb+Zh/Ifvf27SiW4P4Ek+jWDi1Yrkk/9K/FNi5s=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18 h1:qXpmMTt1GsSiyh5JJ+YiaLNyjTiSfkek4mA3Ywjdvn4=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -290,6 +288,8 @@ github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oW
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625090333-222985edfebb h1:BQ1EydrAqx55f8OA7ilF4rJAH+qeg8nE7VWk6hrKFEo=
+github.com/vmware/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625090333-222985edfebb/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7 h1:9umdrb+Zh/Ifvf27SiW4P4Ek+jWDi1Yrkk/9K/FNi5s=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614121303-f4e6c2f85ef7/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614124911-a2e2c9f0269f h1:/qekNza45J4c3iYzQxnEHgwtkcimMBC10jK+jcMO7gY=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.1.0.20210614124911-a2e2c9f0269f/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106 h1:khJSX+m829VXXN1y3CN6yrIml+ocbFYsZ/rqdQjg7e4=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18 h1:qXpmMTt1GsSiyh5JJ+YiaLNyjTiSfkek4mA3Ywjdvn4=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210625082608-12eb4cb20c18/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623114451-c83e659e566b h1:qoSwgjYlqoiu8j4AOx+fIvAfm9jsM3yUmfEw7y04d+U=
-github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623114451-c83e659e566b/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106 h1:khJSX+m829VXXN1y3CN6yrIml+ocbFYsZ/rqdQjg7e4=
+github.com/Didainius/go-vcloud-director/v2 v2.12.0-alpha.6.0.20210623213838-0b431494d106/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1096,7 +1096,7 @@ func importStateIdEdgeGatewayObject(vcd TestConfig, edgeGatewayName, objectName 
 func importStateIdNsxtEdgeGatewayObject(vcd TestConfig, edgeGatewayName, objectName string) resource.ImportStateIdFunc {
 	return func(*terraform.State) (string, error) {
 		if testConfig.VCD.Org == "" || testConfig.VCD.Vdc == "" || edgeGatewayName == "" || objectName == "" {
-			return "", fmt.Errorf("missing information to generate import path")
+			return "", fmt.Errorf("missing information to generate import path for object %s", objectName)
 		}
 		return testConfig.VCD.Org +
 			ImportSeparator +

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1547,3 +1547,9 @@ func addToTestRunList(testName, fileType string) error {
 	}
 	return w.Flush()
 }
+
+// noTestCredentials helps to check if a config file with credentials is actually provided. It helps to conditionally
+// ignore tests in such case
+func noTestCredentials() bool {
+	return testConfig.Provider.User == ""
+}

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -44,7 +44,8 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 		case dataSourceName == "vcd_external_network_v2" && vcdClient.Client.APIVCDMaxVersionIs("< 33"):
 			t.Skip("External network V2 requires at least API version 33 (VCD 10.0+)")
 		case (dataSourceName == "vcd_nsxt_edgegateway" || dataSourceName == "vcd_nsxt_edge_cluster" ||
-			dataSourceName == "vcd_nsxt_security_group" || dataSourceName == "vcd_nsxt_ip_set") &&
+			dataSourceName == "vcd_nsxt_security_group" || dataSourceName == "vcd_nsxt_nat_rule" ||
+			dataSourceName == "vcd_nsxt_app_port_profile" || dataSourceName == "vcd_nsxt_ip_set") &&
 			(vcdClient.Client.APIVCDMaxVersionIs("< 34") || testConfig.Nsxt.Vdc == ""):
 			t.Skip("this datasource requires at least API version 34 (VCD 10.1+) and NSX-T VDC specified in configuration")
 		case (dataSourceName == "vcd_nsxt_tier0_router" || dataSourceName == "vcd_external_network_v2" ||

--- a/vcd/datasource_vcd_nsxt_nat.go
+++ b/vcd/datasource_vcd_nsxt_nat.go
@@ -46,12 +46,12 @@ func datasourceVcdNsxtNatRule() *schema.Resource {
 				Computed:    true,
 				Description: "Description of NAT rule",
 			},
-			"external_addresses": &schema.Schema{
+			"external_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address or CIDR of external network",
 			},
-			"internal_addresses": &schema.Schema{
+			"internal_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
@@ -66,7 +66,7 @@ func datasourceVcdNsxtNatRule() *schema.Resource {
 				Computed:    true,
 				Description: "For DNAT only. Port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
 			},
-			"snat_destination_addresses": &schema.Schema{
+			"snat_destination_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "For SNAT only. Limits SNAT rule by destination IP address or range in CIDR format.",

--- a/vcd/datasource_vcd_nsxt_nat.go
+++ b/vcd/datasource_vcd_nsxt_nat.go
@@ -84,7 +84,7 @@ func datasourceVcdNsxtNatRule() *schema.Resource {
 			"firewall_match": &schema.Schema{
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. Below are valid values.",
+				Description: "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. One of 'MATCH_INTERNAL_ADDRESS', 'MATCH_EXTERNAL_ADDRESS', 'BYPASS'",
 			},
 			"priority": &schema.Schema{
 				Type:        schema.TypeInt,

--- a/vcd/datasource_vcd_nsxt_nat.go
+++ b/vcd/datasource_vcd_nsxt_nat.go
@@ -1,0 +1,124 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdNsxtNatRule() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdNsxtNatRuleRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"edge_gateway_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway name in which NAT Rule is located",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of NAT rule",
+			},
+			"rule_type": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Rule type - one of 'DNAT', 'NO_DNAT', 'SNAT', 'NO_SNAT'",
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of NAT rule",
+			},
+			"external_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address or CIDR of external network",
+			},
+			"internal_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
+			},
+			"app_port_profile_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Application Port Profile ID applied for this rule",
+			},
+			"dnat_external_port": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "For DNAT only. Port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
+			},
+			"snat_destination_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "For SNAT only. Limits SNAT rule by destination IP address or range in CIDR format.",
+			},
+			"logging": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Enable logging when this rule is applied",
+			},
+			"enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Enables or disables this rule",
+			},
+			"firewall_match": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. Below are valid values.",
+			},
+			"priority": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "VCD 10.2.2+ If an address has multiple NAT rules, the rule with the highest priority is applied. A lower value means a higher precedence for this rule.",
+			},
+		},
+	}
+}
+
+func datasourceVcdNsxtNatRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	}
+
+	natRuleName := d.Get("name").(string)
+
+	existingRule, err := nsxtEdge.GetNatRuleByName(natRuleName)
+	if err != nil {
+		return diag.Errorf("unable to find NSX-T NAT rule with Name '%s': %s", natRuleName, err)
+	}
+
+	err = setNsxtNatRuleData(existingRule.NsxtNatRule, d, vcdClient)
+	if err != nil {
+		return diag.Errorf("error storing NSX-T NAT rule in statefile: %s", err)
+	}
+	d.SetId(existingRule.NsxtNatRule.ID)
+
+	return nil
+}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -75,6 +75,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_ip_set":           datasourceVcdNsxtIpSet(),           // 3.3
 	"vcd_nsxt_security_group":   datasourceVcdNsxtSecurityGroup(),   // 3.3
 	"vcd_nsxt_app_port_profile": datasourceVcdNsxtAppPortProfile(),  // 3.3
+	"vcd_nsxt_nat_rule":         datasourceVcdNsxtNatRule(),         // 3.3
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -125,6 +126,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_ip_set":           resourceVcdNsxtIpSet(),                // 3.3
 	"vcd_nsxt_security_group":   resourceVcdSecurityGroup(),            // 3.3
 	"vcd_nsxt_app_port_profile": resourceVcdNsxtAppPortProfile(),       // 3.3
+	"vcd_nsxt_nat_rule":         resourceVcdNsxtNatRule(),              // 3.3
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_nsxt_nat_rule.go
+++ b/vcd/resource_vcd_nsxt_nat_rule.go
@@ -105,7 +105,7 @@ func resourceVcdNsxtNatRule() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				Description:  "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. Below are valid values.",
+				Description:  "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. One of 'MATCH_INTERNAL_ADDRESS', 'MATCH_EXTERNAL_ADDRESS', 'BYPASS'",
 				ValidateFunc: validation.StringInSlice([]string{"MATCH_INTERNAL_ADDRESS", "MATCH_EXTERNAL_ADDRESS", "BYPASS"}, false),
 			},
 			"priority": &schema.Schema{

--- a/vcd/resource_vcd_nsxt_nat_rule.go
+++ b/vcd/resource_vcd_nsxt_nat_rule.go
@@ -64,12 +64,12 @@ func resourceVcdNsxtNatRule() *schema.Resource {
 				Optional:    true,
 				Description: "Description of NAT rule",
 			},
-			"external_addresses": &schema.Schema{
+			"external_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "IP address or CIDR of external network",
 			},
-			"internal_addresses": &schema.Schema{
+			"internal_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
@@ -84,7 +84,7 @@ func resourceVcdNsxtNatRule() *schema.Resource {
 				Optional:    true,
 				Description: "For DNAT only. Enter a port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
 			},
-			"snat_destination_addresses": &schema.Schema{
+			"snat_destination_address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "For SNAT only. If you want the rule to apply only for traffic to a specific domain, enter an IP address for this domain or an IP address range in CIDR format.",
@@ -310,9 +310,9 @@ func getNsxtNatType(d *schema.ResourceData, client *VCDClient) (*types.NsxtNatRu
 		Name:                     d.Get("name").(string),
 		Description:              d.Get("description").(string),
 		Enabled:                  d.Get("enabled").(bool),
-		ExternalAddresses:        d.Get("external_addresses").(string),
-		InternalAddresses:        d.Get("internal_addresses").(string),
-		SnatDestinationAddresses: d.Get("snat_destination_addresses").(string),
+		ExternalAddresses:        d.Get("external_address").(string),
+		InternalAddresses:        d.Get("internal_address").(string),
+		SnatDestinationAddresses: d.Get("snat_destination_address").(string),
 		Logging:                  d.Get("logging").(bool),
 	}
 
@@ -347,9 +347,9 @@ func getNsxtNatType(d *schema.ResourceData, client *VCDClient) (*types.NsxtNatRu
 func setNsxtNatRuleData(rule *types.NsxtNatRule, d *schema.ResourceData, client *VCDClient) error {
 	_ = d.Set("name", rule.Name)
 	_ = d.Set("description", rule.Description)
-	_ = d.Set("external_addresses", rule.ExternalAddresses)
-	_ = d.Set("internal_addresses", rule.InternalAddresses)
-	_ = d.Set("snat_destination_addresses", rule.SnatDestinationAddresses)
+	_ = d.Set("external_address", rule.ExternalAddresses)
+	_ = d.Set("internal_address", rule.InternalAddresses)
+	_ = d.Set("snat_destination_address", rule.SnatDestinationAddresses)
 	_ = d.Set("logging", rule.Logging)
 	_ = d.Set("enabled", rule.Enabled)
 	if rule.ApplicationPortProfile != nil {
@@ -389,7 +389,7 @@ func dumpNatRulesToScreen(name string, allRules []*govcd.NsxtNatRule) {
 	fmt.Fprintf(stdout, "# Please use ID instead of Name in import path to pick exact rule\n")
 
 	w := tabwriter.NewWriter(stdout, 1, 1, 1, ' ', 0)
-	fmt.Fprintln(w, "ID\tName\tRule Type\tInternal Addresses\tExternal Addresses")
+	fmt.Fprintln(w, "ID\tName\tRule Type\tInternal Address\tExternal Address")
 	for _, rule := range allRules {
 		if rule.NsxtNatRule.Name != name {
 			continue

--- a/vcd/resource_vcd_nsxt_nat_rule.go
+++ b/vcd/resource_vcd_nsxt_nat_rule.go
@@ -1,0 +1,388 @@
+package vcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceVcdNsxtNatRule() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdNsxtNatRuleCreate,
+		ReadContext:   resourceVcdNsxtNatRuleRead,
+		UpdateContext: resourceVcdNsxtNatRuleUpdate,
+		DeleteContext: resourceVcdNsxtNatRuleDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdNsxtNatRuleImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"edge_gateway_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway name in which NAT Rule is located",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of NAT rule",
+			},
+			"rule_type": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "Rule type - one of 'DNAT', 'NO_DNAT', 'SNAT', 'NO_SNAT'",
+				ValidateFunc: validation.StringInSlice([]string{"DNAT", "NO_DNAT", "SNAT", "NO_SNAT"}, false),
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Description of NAT rule",
+			},
+			"external_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IP address or CIDR of external network",
+			},
+			"internal_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
+			},
+			"app_port_profile_id": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Application Port Profile to apply for this rule",
+			},
+			"dnat_external_port": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "For DNAT only. Enter a port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
+			},
+			"snat_destination_addresses": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "For SNAT only. If you want the rule to apply only for traffic to a specific domain, enter an IP address for this domain or an IP address range in CIDR format.",
+			},
+			"logging": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enable logging when this rule is applied",
+			},
+			"enabled": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enables or disables this rule",
+			},
+			"firewall_match": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. Below are valid values.",
+				ValidateFunc: validation.StringInSlice([]string{"MATCH_INTERNAL_ADDRESS", "MATCH_EXTERNAL_ADDRESS", "BYPASS"}, false),
+			},
+			"priority": &schema.Schema{
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "VCD 10.2.2+ If an address has multiple NAT rules, the rule with the highest priority is applied. A lower value means a higher precedence for this rule.",
+			},
+		},
+	}
+}
+
+func resourceVcdNsxtNatRuleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	}
+
+	nsxtNatRule, err := getNsxtNatType(d, vcdClient)
+	if err != nil {
+		return diag.Errorf("error getting NSX-T NAT rule type: %s", err)
+	}
+
+	rule, err := nsxtEdge.CreateNatRule(nsxtNatRule)
+	if err != nil {
+
+		return diag.Errorf("error creating NSX-T NAT rule: %s", err)
+	}
+	d.SetId(rule.NsxtNatRule.ID)
+
+	return resourceVcdNsxtNatRuleRead(ctx, d, meta)
+}
+
+func resourceVcdNsxtNatRuleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	}
+
+	nsxtNatRule, err := getNsxtNatType(d, vcdClient)
+	if err != nil {
+		return diag.Errorf("error getting NSX-T NAT rule type: %s", err)
+	}
+
+	existingRule, err := nsxtEdge.GetNatRuleById(d.Id())
+	if err != nil {
+		return diag.Errorf("unable to find NSX-T NAT rule: %s", err)
+	}
+
+	// Inject ID for update
+	nsxtNatRule.ID = existingRule.NsxtNatRule.ID
+	_, err = existingRule.Update(nsxtNatRule)
+	if err != nil {
+		return diag.Errorf("error updating NSX-T NAT rule: %s", err)
+	}
+
+	return resourceVcdNsxtNatRuleRead(ctx, d, meta)
+}
+
+func resourceVcdNsxtNatRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	}
+
+	existingRule, err := nsxtEdge.GetNatRuleById(d.Id())
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+		}
+		return diag.Errorf("unable to find NSX-T NAT rule: %s", err)
+	}
+
+	err = setNsxtNatRuleData(existingRule.NsxtNatRule, d, vcdClient)
+	if err != nil {
+		return diag.Errorf("error storing NSX-T NAT rule in statefile: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdNsxtNatRuleDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	orgName := d.Get("org").(string)
+	vdcName := d.Get("vdc").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	}
+
+	rule, err := nsxtEdge.GetNatRuleById(d.Id())
+	if err != nil {
+		return diag.Errorf("error finding NSX-T NAT Rule: %s", err)
+	}
+
+	err = rule.Delete()
+	if err != nil {
+		return diag.Errorf("error deleting NSX-T NAT rule: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceVcdNsxtNatRuleImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 4 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.edge_gateway_name.nat_rule_name")
+	}
+	orgName, vdcName, edgeGatewayName, natRuleIdentifier := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
+
+	vcdClient := meta.(*VCDClient)
+	org, err := vcdClient.GetAdminOrg(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Org %s: %s", orgName, err)
+	}
+	vdc, err := org.GetVDCByName(vdcName, false)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find VDC %s: %s", vdcName, err)
+	}
+
+	if !vdc.IsNsxt() {
+		return nil, errors.New("vcd_nsxt_nat_rule is only supported by NSX-T VDCs")
+	}
+
+	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find Edge Gateway '%s': %s", edgeGatewayName, err)
+	}
+
+	natRule, err := edgeGateway.GetNatRuleByName(natRuleIdentifier)
+	if govcd.ContainsNotFound(err) {
+		natRule, err = edgeGateway.GetNatRuleById(natRuleIdentifier)
+	}
+
+	// Error occurred and it is not ErrorEntityNotFound. This means - more than one rule found and we should dump a list
+	// of rules with their IDs so that one can pick ID
+	if err != nil && !govcd.ContainsNotFound(err) {
+		allRules, err2 := edgeGateway.GetAllNatRules(nil)
+		if err2 != nil {
+			return nil, fmt.Errorf("error getting list of all NAT rules: %s", err)
+		}
+		dumpNatRulesToScreen(natRuleIdentifier, allRules)
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to find NAT Rule '%s': %s", natRuleIdentifier, err)
+	}
+
+	_ = d.Set("org", orgName)
+	_ = d.Set("vdc", vdcName)
+	_ = d.Set("edge_gateway_id", edgeGateway.EdgeGateway.ID)
+	d.SetId(natRule.NsxtNatRule.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getNsxtNatType(d *schema.ResourceData, client *VCDClient) (*types.NsxtNatRule, error) {
+	firewallMatch, firewallMatchOk := d.GetOk("firewall_match")
+	priority, priorityOk := d.GetOk("priority")
+
+	// Only supported in VCD 10.2.2+ (API V35.2) and throw immediate error if used with older versions as API error is
+	// opaque
+	if (firewallMatchOk || priorityOk) && client.Client.APIVCDMaxVersionIs("< 35.2") {
+		return nil, fmt.Errorf("firewall_match and priority fields can only be set for VCD 10.2.2+")
+	}
+
+	nsxtNatRule := &types.NsxtNatRule{
+		Name:                     d.Get("name").(string),
+		Description:              d.Get("description").(string),
+		Enabled:                  d.Get("enabled").(bool),
+		RuleType:                 d.Get("rule_type").(string),
+		ExternalAddresses:        d.Get("external_addresses").(string),
+		InternalAddresses:        d.Get("internal_addresses").(string),
+		SnatDestinationAddresses: d.Get("snat_destination_addresses").(string),
+		Logging:                  d.Get("logging").(bool),
+	}
+
+	// DnatExternalPort field was replacement for InternalPort field. When using API < 35.2 InternalPort field should be
+	// used.
+	if client.Client.APIVCDMaxVersionIs("< 35.2") {
+		nsxtNatRule.InternalPort = d.Get("dnat_external_port").(string)
+	} else {
+		nsxtNatRule.DnatExternalPort = d.Get("dnat_external_port").(string)
+	}
+
+	if appPortProf, ok := d.GetOk("app_port_profile_id"); ok {
+		nsxtNatRule.ApplicationPortProfile = &types.OpenApiReference{ID: appPortProf.(string)}
+	}
+
+	if firewallMatchOk {
+		nsxtNatRule.FirewallMatch = firewallMatch.(string)
+	}
+
+	if priorityOk {
+		nsxtNatRule.Priority = takeIntPointer(priority.(int))
+	}
+	return nsxtNatRule, nil
+}
+
+func setNsxtNatRuleData(rule *types.NsxtNatRule, d *schema.ResourceData, client *VCDClient) error {
+	_ = d.Set("name", rule.Name)
+	_ = d.Set("description", rule.Description)
+	_ = d.Set("external_addresses", rule.ExternalAddresses)
+	_ = d.Set("internal_addresses", rule.InternalAddresses)
+	_ = d.Set("snat_destination_addresses", rule.SnatDestinationAddresses)
+	_ = d.Set("logging", rule.Logging)
+	_ = d.Set("enabled", rule.Enabled)
+	_ = d.Set("rule_type", rule.RuleType)
+	if rule.ApplicationPortProfile != nil {
+		_ = d.Set("app_port_profile_id", rule.ApplicationPortProfile.ID)
+	}
+
+	// Some specific changes in API V35.2 (VCD 10.2.2+)
+	if client.Client.APIVCDMaxVersionIs(">= 35.2") {
+		// firewall_match and priority are new fields introduces in VCD 10.2.2
+		_ = d.Set("firewall_match", rule.FirewallMatch)
+		_ = d.Set("priority", rule.Priority)
+		// Before v35.2 the field to use is rule.InternalPort
+		_ = d.Set("dnat_external_port", rule.DnatExternalPort)
+	}
+
+	if client.Client.APIVCDMaxVersionIs("< 35.2") {
+		_ = d.Set("dnat_external_port", rule.InternalPort)
+	}
+
+	return nil
+}
+
+// dumpNatRulesToScreen is a helper for import. NAT rules don't enforce name uniqueness therefore it may be that user
+// specifies a rule with the same name. In that case NAT rule details and their IDs are listed and the one will be able
+// to import by using ID.
+func dumpNatRulesToScreen(name string, allRules []*govcd.NsxtNatRule) {
+	stdout := getTerraformStdout()
+
+	fmt.Fprintf(stdout, "# The following NAT rules with Name '%s' are available\n", name)
+	fmt.Fprintf(stdout, "# Please use ID instead of Name in import path to pick exact rule\n")
+
+	w := tabwriter.NewWriter(stdout, 1, 1, 1, ' ', 0)
+	fmt.Fprintln(w, "ID\tName\tRule Type\tInternal Addresses\tExternal Addresses")
+	for _, rule := range allRules {
+		if rule.NsxtNatRule.Name != name {
+			continue
+		}
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			rule.NsxtNatRule.ID, rule.NsxtNatRule.Name, rule.NsxtNatRule.RuleType, rule.NsxtNatRule.InternalAddresses,
+			rule.NsxtNatRule.ExternalAddresses)
+	}
+
+	w.Flush()
+}

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -1,0 +1,642 @@
+// +build network nsxt ALL functional
+
+package vcd
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText1 := templateFill(testAccNsxtNatDnat, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	params["RuleName"] = "test-dnat-rule"
+	configText2 := templateFill(testAccNsxtNatDnatDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	params["FuncName"] = t.Name() + "-step3"
+	configText3 := templateFill(testAccNsxtNatDnatStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	params["FuncName"] = t.Name() + "-step4"
+	params["RuleName"] = "test-dnat-rule-updated"
+	configText4 := templateFill(testAccNsxtNatDnatStep2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText4)
+
+	params["FuncName"] = t.Name() + "-step5"
+	configText5 := templateFill(testAccNsxtNatDnatStep5, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 5: %s", configText5)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	natRuleId := &testCachedFieldValue{}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtNatRuleDestroy("test-dnat-rule"),
+			testAccCheckNsxtNatRuleDestroy("test-dnat-rule-updated"),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
+					resource.TestMatchResourceAttr("vcd_nsxt_nat_rule.dnat", "edge_gateway_id", regexp.MustCompile(`^urn:vcloud:gateway:`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "name", "test-dnat-rule"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "rule_type", "DNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "description", "description"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_addresses"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_addresses", "11.11.11.2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "logging", "false"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.dnat", "app_port_profile_id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "enabled", "true"),
+					natRuleId.cacheTestResourceFieldValue("vcd_nsxt_nat_rule.dnat", "id"),
+				),
+			},
+			resource.TestStep{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
+					resourceFieldsEqual("vcd_nsxt_nat_rule.dnat", "data.vcd_nsxt_nat_rule.nat", nil),
+				),
+			},
+			resource.TestStep{
+				Config: configText3,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
+					resource.TestMatchResourceAttr("vcd_nsxt_nat_rule.dnat", "edge_gateway_id", regexp.MustCompile(`^urn:vcloud:gateway:`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "name", "test-dnat-rule-updated"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "rule_type", "DNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "description", "updated-description"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_addresses"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "app_port_profile_id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_addresses", "11.11.11.0/32"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "dnat_external_port", "8888"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "enabled", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: configText4,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
+					resourceFieldsEqual("vcd_nsxt_nat_rule.dnat", "data.vcd_nsxt_nat_rule.nat", nil),
+				),
+			},
+			resource.TestStep{
+				Config: configText5,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
+					// Ensure custom created Application Port Profile ID is consumed
+					resource.TestCheckResourceAttrPair("vcd_nsxt_nat_rule.dnat", "app_port_profile_id", "vcd_nsxt_app_port_profile.custom-app", "id"),
+				),
+			},
+			// Try to import by Name
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_nat_rule.dnat",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-dnat-rule-updated"),
+			},
+			// Try to import by rule UUID
+			resource.TestStep{
+				ResourceName: "vcd_nsxt_nat_rule.dnat",
+				ImportState:  true,
+				// Not using pre-built complete ID because ID is not known in advance. This field allows to specify
+				// prefix only and the ID itself is automatically suffixed by Terraform test framework
+				ImportStateIdPrefix: testConfig.VCD.Org + ImportSeparator + testConfig.Nsxt.Vdc + ImportSeparator + testConfig.Nsxt.EdgeGateway + ImportSeparator,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const natRuleDataSourceDefinition = `
+# skip-binary-test: Data Source test
+data "vcd_nsxt_nat_rule" "nat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  name            = "{{.RuleName}}"
+}
+`
+
+const testAccNsxtNatDnat = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "dnat" {
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-dnat-rule"
+  rule_type   = "DNAT"
+  description = "description"
+
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses = "11.11.11.2"
+}
+`
+
+const testAccNsxtNatDnatDS = testAccNsxtNatDnat + natRuleDataSourceDefinition
+
+const testAccNsxtNatDnatStep2 = testAccNsxtSecurityGroupPrereqsEmpty + `
+data "vcd_nsxt_app_port_profile" "custom" {
+  scope = "SYSTEM"
+  name  = "SSH"
+}
+
+resource "vcd_nsxt_nat_rule" "dnat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-dnat-rule-updated"
+  rule_type  = "DNAT"
+  description = "updated-description"
+  
+  # Using primary_ip from edge gateway
+  external_addresses  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses  = "11.11.11.0/32"
+  app_port_profile_id = data.vcd_nsxt_app_port_profile.custom.id
+  
+  enabled = false
+}
+`
+
+const testAccNsxtNatDnatStep2DS = testAccNsxtNatDnatStep2 + natRuleDataSourceDefinition
+
+const testAccNsxtNatDnatStep5 = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_app_port_profile" "custom-app" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  name        = "custom app profile"
+  description = "Application port profile for custom application"
+  scope       = "TENANT"
+  # NAT rules accept only Application Port Profiles with 1 Port
+  app_port {
+    protocol = "TCP"
+    port     = ["2000"]
+  }
+}
+
+
+resource "vcd_nsxt_nat_rule" "dnat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-dnat-rule-updated"
+  rule_type  = "DNAT"
+  description = "updated-description"
+  
+  # Using primary_ip from edge gateway
+  external_addresses  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses  = "11.11.11.0/32"
+  dnat_external_port  = 8888
+  app_port_profile_id = vcd_nsxt_app_port_profile.custom-app.id
+  
+  logging = false
+  enabled = false
+}
+`
+
+func TestAccVcdNsxtNatRuleNoDnat(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccNsxtNatNoDnat, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-no-dnat-rule"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-dnat", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "name", "test-no-dnat-rule"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "rule_type", "NO_DNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "description", ""),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-dnat", "external_addresses"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "internal_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "dnat_external_port", "7777"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_nat_rule.no-dnat",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-no-dnat-rule"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtNatNoDnat = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "no-dnat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name      = "test-no-dnat-rule"
+  rule_type = "NO_DNAT"
+
+  
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  dnat_external_port = 7777
+}
+`
+
+func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText1 := templateFill(testAccNsxtNatSnat, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	params["RuleName"] = "test-snat-rule"
+	configText2 := templateFill(testAccNsxtNatSnatDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	params["FuncName"] = t.Name() + "-step3"
+	configText3 := templateFill(testAccNsxtNatSnat2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	params["FuncName"] = t.Name() + "-step4"
+	params["RuleName"] = "test-snat-rule-updated"
+	configText4 := templateFill(testAccNsxtNatSnat2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText4)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtNatRuleDestroy("test-snat-rule"),
+			testAccCheckNsxtNatRuleDestroy("test-snat-rule-updated"),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
+					resource.TestMatchResourceAttr("vcd_nsxt_nat_rule.snat", "edge_gateway_id", regexp.MustCompile(`^urn:vcloud:gateway:`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "name", "test-snat-rule"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "rule_type", "SNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "description", "description"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_addresses"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_addresses", "11.11.11.2"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.snat", "app_port_profile_id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_addresses", "8.8.8.8"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
+					resourceFieldsEqual("vcd_nsxt_nat_rule.snat", "data.vcd_nsxt_nat_rule.nat", nil),
+				),
+			},
+			resource.TestStep{
+				Config: configText3,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
+					resource.TestMatchResourceAttr("vcd_nsxt_nat_rule.snat", "edge_gateway_id", regexp.MustCompile(`^urn:vcloud:gateway:`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "name", "test-snat-rule-updated"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "rule_type", "SNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "description", ""),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_addresses"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_addresses", "10.10.10.2"),
+					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.snat", "app_port_profile_id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
+				),
+			},
+			resource.TestStep{
+				Config: configText4,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
+					resourceFieldsEqual("vcd_nsxt_nat_rule.snat", "data.vcd_nsxt_nat_rule.nat", nil),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_nat_rule.snat",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-snat-rule-updated"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtNatSnat = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "snat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+	
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-snat-rule"
+  rule_type   = "SNAT"
+  description = "description"
+  
+  # Using primary_ip from edge gateway
+  external_addresses         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses         = "11.11.11.2"
+  snat_destination_addresses = "8.8.8.8"
+}
+`
+const testAccNsxtNatSnatDS = testAccNsxtNatSnat + natRuleDataSourceDefinition
+
+const testAccNsxtNatSnat2 = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "snat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+	
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-snat-rule-updated"
+  rule_type   = "SNAT"
+  description = ""
+  
+  # Using primary_ip from edge gateway
+  external_addresses         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses         = "10.10.10.2"
+  logging = false
+}
+`
+
+const testAccNsxtNatSnat2DS = testAccNsxtNatSnat2 + natRuleDataSourceDefinition
+
+func TestAccVcdNsxtNatRuleNoSnat(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+
+	configText := templateFill(testAccNsxtNatNoSnat, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-no-snat-rule"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-snat", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "name", "test-no-snat-rule"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "description", "description"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "rule_type", "NO_SNAT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "internal_addresses", "11.11.11.0/24"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_nat_rule.no-snat",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-no-snat-rule"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtNatNoSnat = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "no-snat" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-no-snat-rule"
+  rule_type   = "NO_SNAT"
+  description = "description"
+  
+  # Using primary_ip from edge gateway
+  internal_addresses         = "11.11.11.0/24"
+}
+`
+
+// TestAccVcdNsxtNatRuleFirewallMatchPriority explicitly tests support for two new fields introduced in API 35.2 (VCD 10.2.2)
+// firewall_match and priority. For 10.2.2 versions this should work, while for lower versions it should return an error.
+// This test checks both cases - for versions 10.2.2 it expects it working, while for versions < 10.2.2 it expects an error
+func TestAccVcdNsxtNatRuleFirewallMatchPriority(t *testing.T) {
+	preTestChecks(t)
+	skipNoNsxtConfiguration(t)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	// expectError must stay nil for versions > 10.2.2, because we expect it to work. For lower versions - it must have
+	// match the runtime validation error
+	var (
+		expectError       *regexp.Regexp
+		expectImportError *regexp.Regexp
+	)
+	client := createTemporaryVCDConnection()
+	if client.Client.APIVCDMaxVersionIs("< 35.2") {
+		expectError = regexp.MustCompile(`firewall_match and priority fields can only be set for VCD 10.2.2+`)
+		expectImportError = regexp.MustCompile(`unable to find NAT Rule`)
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":           testConfig.VCD.Org,
+		"NsxtVdc":       testConfig.Nsxt.Vdc,
+		"EdgeGw":        testConfig.Nsxt.EdgeGateway,
+		"NetworkName":   t.Name(),
+		"Tags":          "network nsxt",
+		"FirewallMatch": "MATCH_INTERNAL_ADDRESS",
+		"Priority":      "10",
+	}
+
+	configText1 := templateFill(testAccNsxtNatFirewallMatchPriority, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	params["FirewallMatch"] = "MATCH_EXTERNAL_ADDRESS"
+	params["Priority"] = "30"
+	configText2 := templateFill(testAccNsxtNatFirewallMatchPriority, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	params["FuncName"] = t.Name() + "-step3"
+	params["FirewallMatch"] = "BYPASS"
+	params["Priority"] = "0"
+	configText3 := templateFill(testAccNsxtNatFirewallMatchPriority, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-dnat-rule-match-and-priority"),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      configText1,
+				ExpectError: expectError,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat-match", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "name", "test-dnat-rule-match-and-priority"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "firewall_match", "MATCH_INTERNAL_ADDRESS"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "10"),
+				),
+			},
+			resource.TestStep{
+				Config:      configText2,
+				ExpectError: expectError,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat-match", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "name", "test-dnat-rule-match-and-priority"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "firewall_match", "MATCH_EXTERNAL_ADDRESS"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "30"),
+				),
+			},
+			resource.TestStep{
+				Config:      configText3,
+				ExpectError: expectError,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat-match", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "name", "test-dnat-rule-match-and-priority"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "firewall_match", "BYPASS"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "0"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "vcd_nsxt_nat_rule.dnat-match",
+				ExpectError:       expectImportError,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-dnat-rule-match-and-priority"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtNatFirewallMatchPriority = testAccNsxtSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_nat_rule" "dnat-match" {
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-dnat-rule-match-and-priority"
+  rule_type   = "DNAT"
+  description = "description"
+
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses = "11.11.11.2"
+
+  firewall_match = "{{.FirewallMatch}}"
+  priority       = "{{.Priority}}"
+}
+`
+
+func testAccCheckNsxtNatRuleDestroy(natRuleIdentifier string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+		egw, err := conn.GetNsxtEdgeGateway(testConfig.VCD.Org, testConfig.Nsxt.Vdc, testConfig.Nsxt.EdgeGateway)
+		if err != nil {
+			return fmt.Errorf(errorUnableToFindEdgeGateway, testConfig.Nsxt.EdgeGateway)
+		}
+
+		_, errByName := egw.GetNatRuleByName(natRuleIdentifier)
+		_, errById := egw.GetNatRuleById(natRuleIdentifier)
+
+		if errByName == nil {
+			return fmt.Errorf("got no errors for NSX-T NAT rule lookup by Name")
+		}
+
+		if errById == nil {
+			return fmt.Errorf("got no errors for NSX-T NAT rule lookup by ID")
+		}
+
+		return nil
+	}
+}

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -69,11 +69,11 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "name", "test-dnat-rule"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "rule_type", "DNAT"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "description", "description"),
-					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_addresses"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_addresses", "11.11.11.2"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_address"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_address", "11.11.11.2"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "logging", "false"),
 					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.dnat", "app_port_profile_id"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_address", ""),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "enabled", "true"),
 					natRuleId.cacheTestResourceFieldValue("vcd_nsxt_nat_rule.dnat", "id"),
 				),
@@ -93,12 +93,12 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "name", "test-dnat-rule-updated"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "rule_type", "DNAT"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "description", "updated-description"),
-					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_addresses"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "external_address"),
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "app_port_profile_id"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_addresses", "11.11.11.0/32"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "internal_address", "11.11.11.0/32"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "logging", "false"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "dnat_external_port", "8888"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "snat_destination_address", ""),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "enabled", "false"),
 				),
 			},
@@ -161,8 +161,8 @@ resource "vcd_nsxt_nat_rule" "dnat" {
   description = "description"
 
   # Using primary_ip from edge gateway
-  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses = "11.11.11.2"
+  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address = "11.11.11.2"
 }
 `
 
@@ -185,8 +185,8 @@ resource "vcd_nsxt_nat_rule" "dnat" {
   description = "updated-description"
   
   # Using primary_ip from edge gateway
-  external_addresses  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses  = "11.11.11.0/32"
+  external_address  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address  = "11.11.11.0/32"
   dnat_external_port  = 8888
   app_port_profile_id = data.vcd_nsxt_app_port_profile.custom.id
   
@@ -223,8 +223,8 @@ resource "vcd_nsxt_nat_rule" "dnat" {
   description = "updated-description"
   
   # Using primary_ip from edge gateway
-  external_addresses  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses  = "11.11.11.0/32"
+  external_address  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address  = "11.11.11.0/32"
   dnat_external_port  = 8888
   app_port_profile_id = vcd_nsxt_app_port_profile.custom-app.id
   
@@ -266,8 +266,8 @@ func TestAccVcdNsxtNatRuleNoDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "name", "test-no-dnat-rule"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "rule_type", "NO_DNAT"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "description", ""),
-					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-dnat", "external_addresses"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "internal_addresses", ""),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-dnat", "external_address"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "internal_address", ""),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "logging", "false"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "dnat_external_port", "7777"),
 				),
@@ -295,7 +295,7 @@ resource "vcd_nsxt_nat_rule" "no-dnat" {
 
   
   # Using primary_ip from edge gateway
-  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
   dnat_external_port = 7777
 }
 `
@@ -351,10 +351,10 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "name", "test-snat-rule"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "rule_type", "SNAT"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "description", "description"),
-					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_addresses"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_addresses", "11.11.11.2"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_address"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_address", "11.11.11.2"),
 					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.snat", "app_port_profile_id"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_addresses", "8.8.8.8"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_address", "8.8.8.8"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "enabled", "true"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
 				),
@@ -374,10 +374,10 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "name", "test-snat-rule-updated"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "rule_type", "SNAT"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "description", ""),
-					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_addresses"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_addresses", "10.10.10.2"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "external_address"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "internal_address", "10.10.10.0/24"),
 					resource.TestCheckNoResourceAttr("vcd_nsxt_nat_rule.snat", "app_port_profile_id"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_addresses", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "snat_destination_address", ""),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "enabled", "true"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
 				),
@@ -412,9 +412,9 @@ resource "vcd_nsxt_nat_rule" "snat" {
   description = "description"
   
   # Using primary_ip from edge gateway
-  external_addresses         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses         = "11.11.11.2"
-  snat_destination_addresses = "8.8.8.8"
+  external_address         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address         = "11.11.11.2"
+  snat_destination_address = "8.8.8.8"
 }
 `
 const testAccNsxtNatSnatDS = testAccNsxtNatSnat + natRuleDataSourceDefinition
@@ -431,8 +431,8 @@ resource "vcd_nsxt_nat_rule" "snat" {
   description = ""
   
   # Using primary_ip from edge gateway
-  external_addresses         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses         = "10.10.10.2"
+  external_address         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address         = "10.10.10.0/24"
   logging = false
 }
 `
@@ -472,7 +472,7 @@ func TestAccVcdNsxtNatRuleNoSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "name", "test-no-snat-rule"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "description", "description"),
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "rule_type", "NO_SNAT"),
-					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "internal_addresses", "11.11.11.0/24"),
+					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "internal_address", "11.11.11.0/24"),
 				),
 			},
 			resource.TestStep{
@@ -498,7 +498,7 @@ resource "vcd_nsxt_nat_rule" "no-snat" {
   description = "description"
   
   # Using primary_ip from edge gateway
-  internal_addresses         = "11.11.11.0/24"
+  internal_address         = "11.11.11.0/24"
 }
 `
 
@@ -612,8 +612,8 @@ resource "vcd_nsxt_nat_rule" "dnat-match" {
   description = "description"
 
   # Using primary_ip from edge gateway
-  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses = "11.11.11.2"
+  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address = "11.11.11.2"
 
   firewall_match = "{{.FirewallMatch}}"
   priority       = "{{.Priority}}"
@@ -730,8 +730,8 @@ resource "vcd_nsxt_nat_rule" "reflexive" {
   description = "description"
 
   # Using primary_ip from edge gateway
-  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_addresses = "11.11.11.2"
+  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address = "11.11.11.2"
 
   firewall_match = "{{.FirewallMatch}}"
   priority       = "{{.Priority}}"

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -621,6 +621,10 @@ resource "vcd_nsxt_nat_rule" "dnat-match" {
 `
 
 func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
+	if noTestCredentials() {
+		t.Skip("Skipping test run as no credentials are provided and this test needs to lookup VCD version")
+		return
+	}
 	preTestChecks(t)
 	skipNoNsxtConfiguration(t)
 

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -465,9 +465,8 @@ func getComputeStorageProfiles(vcdClient *VCDClient, profile *types.VdcStoragePr
 		storageProfileData["limit"] = vdcStorageProfileDetails.Limit
 		storageProfileData["default"] = vdcStorageProfileDetails.Default
 		storageProfileData["enabled"] = vdcStorageProfileDetails.Enabled
-		if vdcStorageProfileDetails.ProviderVdcStorageProfile != nil {
-			storageProfileData["name"] = vdcStorageProfileDetails.ProviderVdcStorageProfile.Name
-		}
+		storageProfileData["name"] = vdcStorageProfileDetails.Name
+
 		storageProfileData["storage_used_in_mb"] = vdcStorageProfileDetails.StorageUsedMB
 		root = append(root, storageProfileData)
 	}

--- a/website/docs/d/nsxt_nat_rule.html.markdown
+++ b/website/docs/d/nsxt_nat_rule.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_nat_rule"
+sidebar_current: "docs-vcd-data-source-nsxt-nat-rule"
+description: |-
+  Provides a data source to read NSX-T NAT rules. Source NAT (SNAT) rules change the source IP 
+  address from a private to a public IP address. Destination NAT (DNAT) rules change the destination
+  IP address from a public to a private IP address.
+---
+
+# vcd\_nsxt\_nat\_rule
+
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+
+Provides a data source to read NSX-T NAT rules. Source NAT (SNAT) rules change the source IP 
+address from a private to a public IP address. Destination NAT (DNAT) rules change the destination
+IP address from a public to a private IP address.
+
+## Example Usage
+
+```hcl
+data "vcd_nsxt_nat_rule" "dnat-ssh" {
+  org  = "my-org"
+  vdc  = "my-org-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name = "dnat-ssh"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organizations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
+* `name` - (Required)  - Name of existing NAT Rule.
+
+-> Name uniqueness is not enforced in NSX-T NAT rules, but for this data source to work properly
+names should be unique so that they can be distinguished.
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_nat_rule`](/docs/providers/vcd/r/nsxt_nat_rule.html) resource are available.

--- a/website/docs/r/nsxt_ip_set.html.markdown
+++ b/website/docs/r/nsxt_ip_set.html.markdown
@@ -14,8 +14,6 @@ Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 Provides a resource to manage NSX-T IP Set. IP sets are groups of objects to which the firewall rules apply. Combining 
 multiple objects into IP sets helps reduce the total number of firewall rules to be created.
 
-## Specific usage notes
-
 ## Example Usage (IP set with multiple IP address ranges defined)
 
 ```hcl

--- a/website/docs/r/nsxt_nat_rule.html.markdown
+++ b/website/docs/r/nsxt_nat_rule.html.markdown
@@ -135,7 +135,6 @@ The following arguments are supported:
     organization VDC out to an external network or to another organization VDC network.
   * `REFLEXIVE` (VCD 10.3+)  is also known as Stateless NAT. This translates an internal IP to an external IP and vice 
     versa. The number of internal addresses should be exactly the same as that of external addresses.
-
 * `external_addresses` (Optional) IP address or CIDR of external network.
 * `internal_addresses` (Optional) IP address or CIDR of the virtual machines for which you are
   configuring NAT.
@@ -154,17 +153,12 @@ The following arguments are supported:
   is missing **Gateway -> Configure System Logging** right) to enable logging, but API does not
   return error and it is not possible to validate it. `terraform plan` might show difference on
   every update.
-
-
 * `firewall_match` (Optional, VCD 10.2.2+) - You can set a firewall match rule to determine how
   firewall is applied during NAT. One of `MATCH_INTERNAL_ADDRESS`, `MATCH_EXTERNAL_ADDRESS`,
   `BYPASS`
-
   * `MATCH_INTERNAL_ADDRESS` - applies firewall rules to the internal address of a NAT rule
   * `MATCH_EXTERNAL_ADDRESS` - applies firewall rules to the external address of a NAT rule
   * `BYPASS` - skip applying firewall rules to NAT rule
-
-
 * `priority` (Optional, VCD 10.2.2+) - if an address has multiple NAT rules, you can assign these
   rules different priorities to determine the order in which they are applied. A lower value means a
   higher priority for this rule. 

--- a/website/docs/r/nsxt_nat_rule.html.markdown
+++ b/website/docs/r/nsxt_nat_rule.html.markdown
@@ -93,6 +93,24 @@ resource "vcd_nsxt_nat_rule" "no-dnat" {
 }
 ```
 
+## Example Usage 5 (Reflexive NAT rule (Stateless NAT))
+```hcl
+resource "vcd_nsxt_nat_rule" "reflexive" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name      = "test-reflexive"
+  rule_type = "REFLEXIVE"
+
+
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses = "11.11.11.2"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -115,6 +133,8 @@ The following arguments are supported:
     out to an external network or to another organization VDC network.
   * `NO_SNAT` rule prevents the translation of the internal IP address of packets sent from an
     organization VDC out to an external network or to another organization VDC network.
+  * `REFLEXIVE` (VCD 10.3+)  is also known as Stateless NAT. This translates an internal IP to an external IP and vice 
+    versa. The number of internal addresses should be exactly the same as that of external addresses.
 
 * `external_addresses` (Optional) IP address or CIDR of external network.
 * `internal_addresses` (Optional) IP address or CIDR of the virtual machines for which you are

--- a/website/docs/r/nsxt_nat_rule.html.markdown
+++ b/website/docs/r/nsxt_nat_rule.html.markdown
@@ -1,0 +1,188 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_nat_rule"
+sidebar_current: "docs-vcd-resource-nsxt-nat-rule"
+description: |-
+  Provides a resource to manage NSX-T NAT rules. To change the source IP address from a private to a
+  public IP address, you create a source NAT (SNAT) rule. To change the destination IP address from 
+  a public to a private IP address, you create a destination NAT (DNAT) rule.
+---
+
+# vcd\_nsxt\_nat\_rule
+
+Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
+
+Provides a resource to manage NSX-T NAT rules. To change the source IP address from a private to a
+public IP address, you create a source NAT (SNAT) rule. To change the destination IP address from 
+a public to a private IP address, you create a destination NAT (DNAT) rule.
+
+-> When you configure a SNAT or a DNAT rule on an Edge Gateway in the VMware Cloud Director
+environment, you always configure the rule from the perspective of your organization VDC.
+
+## Example Usage 1 (SNAT rule translates to primary Edge Gateway IP for traffic going from 11.11.11.2 to 8.8.8.8)
+
+```hcl
+resource "vcd_nsxt_nat_rule" "snat" {
+  org  = "dainius"
+  vdc  = "nsxt-vdc-dainius"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "SNAT rule"
+  rule_type   = "SNAT"
+  description = "description"
+
+  # Using primary_ip from edge gateway
+  external_addresses         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses         = "11.11.11.2"
+  snat_destination_addresses = "8.8.8.8"
+  logging = true
+}
+```
+
+## Example Usage 2 (Prevent SNAT for internal addresses in subnet 11.11.11.0/24)
+```hcl
+resource "vcd_nsxt_nat_rule" "no-snat" {
+  org  = "dainius"
+  vdc  = "nsxt-vdc-dainius"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-no-snat-rule"
+  rule_type   = "NO_SNAT"
+  description = "description"
+
+  internal_addresses  = "11.11.11.0/24"
+}
+```
+
+## Example Usage 3 (DNAT rule translates Edge Gateway primary IP to internal IP 11.11.11.2)
+```hcl
+resource "vcd_nsxt_nat_rule" "dnat" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name        = "test-dnat-rule"
+  rule_type   = "DNAT"
+  description = "description"
+
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_addresses = "11.11.11.2"
+  logging            = true
+}
+```
+
+## Example Usage 4 (No DNAT rule)
+```hcl
+resource "vcd_nsxt_nat_rule" "no-dnat" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+
+  name      = "test-no-dnat-rule"
+  rule_type = "NO_DNAT"
+
+
+  # Using primary_ip from edge gateway
+  external_addresses = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  dnat_external_port = 7777
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+  `vcd_nsxt_edgegateway` data source
+* `name` - (Required) A name for NAT rule
+* `description` - (Optional) An optional description of the NAT rule
+* `enabled` (Optional) - Enables or disables NAT rule (default `true`)
+* `rule_type` - (Required) One of `DNAT`, `NO_DNAT`, `SNAT`, `NO_SNAT`
+  * `DNAT` rule translates the IP address and optionally the port (using `dnat_external_port`) of
+    packets received by an organization VDC network that are coming from an external network or from
+    another organization VDC network.
+  * `NO_DNAT` rule prevents the translation of the external IP address of packets received by an
+    organization VDC from an external network or from another organization VDC network.
+  * `SNAT` rule translates the source IP address of packets sent from an organization VDC network
+    out to an external network or to another organization VDC network.
+  * `NO_SNAT` rule prevents the translation of the internal IP address of packets sent from an
+    organization VDC out to an external network or to another organization VDC network.
+
+* `external_addresses` (Optional) IP address or CIDR of external network.
+* `internal_addresses` (Optional) IP address or CIDR of the virtual machines for which you are
+  configuring NAT.
+* `app_port_profile_id` (Optional) - Application Port Profile to which to apply the rule. The
+  Application Port Profile includes a port, and a protocol that the incoming traffic uses on the edge
+  gateway to connect to the internal network.  Can be looked up using `vcd_nsxt_app_port_profile`
+  data source or created using `vcd_nsxt_app_port_profile` resource
+* `dnat_external_port` (Optional) - For `DNAT` only. Enter a port into which the DNAT
+  rule is translating for the packets inbound to the virtual machines.
+* `snat_destination_addresses` (Optional) For `SNAT` only. If you want the rule to apply only for
+  traffic to a specific domain, enter an IP address for this domain or an IP address range in CIDR
+  format. If you leave this text box blank, the SNAT rule applies to all destinations outside of the
+  local subnet.
+* `logging` (Optional) - Enable to have the address translation performed by this rule logged
+  (default `false`). **Note** User might lack rights (**Organization Administrator** role by default
+  is missing **Gateway -> Configure System Logging** right) to enable logging, but API does not
+  return error and it is not possible to validate it. `terraform plan` might show difference on
+  every update.
+
+
+* `firewall_match` (Optional, VCD 10.2.2+) - You can set a firewall match rule to determine how
+  firewall is applied during NAT. One of `MATCH_INTERNAL_ADDRESS`, `MATCH_EXTERNAL_ADDRESS`,
+  `BYPASS`
+
+  * `MATCH_INTERNAL_ADDRESS` - applies firewall rules to the internal address of a NAT rule
+  * `MATCH_EXTERNAL_ADDRESS` - applies firewall rules to the external address of a NAT rule
+  * `BYPASS` - skip applying firewall rules to NAT rule
+
+
+* `priority` (Optional, VCD 10.2.2+) - if an address has multiple NAT rules, you can assign these
+  rules different priorities to determine the order in which they are applied. A lower value means a
+  higher priority for this rule. 
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing NAT Rule configuration can be [imported][docs-import] into this resource
+via supplying the full dot separated path for your NAT Rule name or ID. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+Supplying Name
+```
+terraform import vcd_nsxt_nat_rule.imported my-org.my-org-vdc.my-nsxt-edge-gateway.my-nat-rule-name
+```
+
+
+
+-> When there are multiple NAT rules with the same name they will all be listed so that one can pick
+it by ID
+
+```
+$ terraform import vcd_nsxt_nat_rule.dnat my-org.nsxt-vdc.nsxt-gw.dnat1
+
+vcd_nsxt_nat_rule.dnat: Importing from ID "my-org.nsxt-vdc.nsxt-gw.dnat1"...
+# The following NAT rules with Name 'dnat1' are available
+# Please use ID instead of Name in import path to pick exact rule
+ID                                   Name  Rule Type Internal Addresses External Addresses
+04fde766-2cbd-4986-93bb-7f57e59c6b19 dnat1 DNAT      1.1.1.1            10.1.2.139
+f40e3d68-cfa6-42ea-83ed-5571659b3e7b dnat1 DNAT      2.2.2.2            10.1.2.139
+
+$ terraform import vcd_nsxt_nat_rule.imported my-org.my-org-vdc.my-nsxt-edge-gateway.0214a26b-fc30-4202-88e5-7ed551aa6c19
+```
+
+The above would import the `my-nat-rule-name` NAT Rule config settings that are defined
+on NSX-T Edge Gateway `my-nsxt-edge-gateway` which is configured in organization named `my-org` and
+VDC named `my-org-vdc`.

--- a/website/docs/r/nsxt_nat_rule.html.markdown
+++ b/website/docs/r/nsxt_nat_rule.html.markdown
@@ -190,7 +190,7 @@ $ terraform import vcd_nsxt_nat_rule.dnat my-org.nsxt-vdc.nsxt-gw.dnat1
 vcd_nsxt_nat_rule.dnat: Importing from ID "my-org.nsxt-vdc.nsxt-gw.dnat1"...
 # The following NAT rules with Name 'dnat1' are available
 # Please use ID instead of Name in import path to pick exact rule
-ID                                   Name  Rule Type Internal Address External Address
+ID                                   Name  Rule Type Internal Address   External Address
 04fde766-2cbd-4986-93bb-7f57e59c6b19 dnat1 DNAT      1.1.1.1            10.1.2.139
 f40e3d68-cfa6-42ea-83ed-5571659b3e7b dnat1 DNAT      2.2.2.2            10.1.2.139
 

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -160,6 +160,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-app-port-profile") %>>
               <a href="/docs/providers/vcd/d/nsxt_app_port_profile.html">vcd_nsxt_app_port_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-datas-source-nsxt-nat-rule") %>>
+              <a href="/docs/providers/vcd/d/nsxt_nat_rule.html">vcd_nsxt_nat_rule</a>
+            </li>
           </ul>
         </li>
 
@@ -306,6 +309,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-app-port-profile") %>>
               <a href="/docs/providers/vcd/r/nsxt_app_port_profile.html">vcd_nsxt_app_port_profile</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-nat-rule") %>>
+              <a href="/docs/providers/vcd/r/nsxt_nat_rule.html">vcd_nsxt_nat_rule</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Closes #623 
This PR adds NSX-T NAT rule resource and data source. 

Additionally:
* Fixes binary test `vcd.TestAccVcdOrgVdcNsxt.tf` by patching `getComputeStorageProfiles` to put storage profile name from VDC instead of provider VDC (like the patch in govcd - https://github.com/vmware/go-vcloud-director/pull/378/files#diff-b135ff9ceaf8677fa7425e668030203cc93ade5db71ff57ea376b56af2bc0bc4R221)

Note. Acceptance and binary tests passed with `nsxt` tag on 10.0 (without NSX-T), 10.1, 10.2.0, 10.2.2
