### PR TITLE
Add support for bus_type nvme

### DIFF
--- a/.changes/v3.4.0/680-improvements.md
+++ b/.changes/v3.4.0/680-improvements.md
@@ -1,0 +1,1 @@
+* Add support for disk controller type nvme [GH-680]

--- a/vcd/datasource_vcd_vapp_vm.go
+++ b/vcd/datasource_vcd_vapp_vm.go
@@ -185,7 +185,7 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 				"bus_type": {
 					Type:        schema.TypeString,
 					Computed:    true,
-					Description: "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata",
+					Description: "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata, nvme",
 				},
 				"size_in_mb": {
 					Type:        schema.TypeInt,

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -290,8 +290,8 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 					Type:         schema.TypeString,
 					Required:     true,
 					ForceNew:     true,
-					ValidateFunc: validation.StringInSlice([]string{"ide", "parallel", "sas", "paravirtual", "sata"}, false),
-					Description:  "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata",
+					ValidateFunc: validation.StringInSlice([]string{"ide", "parallel", "sas", "paravirtual", "sata", "nvme"}, false),
+					Description:  "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata, nvme",
 				},
 				"size_in_mb": {
 					Type:        schema.TypeInt,
@@ -338,7 +338,7 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 				"bus_type": {
 					Type:        schema.TypeString,
 					Computed:    true,
-					Description: "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata",
+					Description: "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata, nvme",
 				},
 				"size_in_mb": {
 					Type:        schema.TypeInt,

--- a/vcd/resource_vcd_vm_internal_disk.go
+++ b/vcd/resource_vcd_vm_internal_disk.go
@@ -50,8 +50,8 @@ func resourceVmInternalDisk() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"ide", "parallel", "sas", "paravirtual", "sata"}, false),
-				Description:  "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata",
+				ValidateFunc: validation.StringInSlice([]string{"ide", "parallel", "sas", "paravirtual", "sata", "nvme"}, false),
+				Description:  "The type of disk controller. Possible values: ide, parallel( LSI Logic Parallel SCSI), sas(LSI Logic SAS (SCSI)), paravirtual(Paravirtual (SCSI)), sata, nvme",
 			},
 			"size_in_mb": {
 				Type:        schema.TypeInt,
@@ -103,6 +103,7 @@ var internalDiskBusTypes = map[string]string{
 	"sas":         "4",
 	"paravirtual": "5",
 	"sata":        "6",
+	"nvme":        "7",
 }
 var internalDiskBusTypesFromValues = map[string]string{
 	"1": "ide",
@@ -110,6 +111,7 @@ var internalDiskBusTypesFromValues = map[string]string{
 	"4": "sas",
 	"5": "paravirtual",
 	"6": "sata",
+	"7": "nvme",
 }
 
 // resourceVmInternalDiskCreate creates an internal disk for VM

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -5,9 +5,10 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -361,5 +362,83 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
   unit_number     = "0"
   storage_profile = "{{.StorageProfileName}}"
   allow_vm_reboot = "true"
+}
+`
+
+// TestAccVcdVmInternalDiskNvme explicitly tests NVMe disk support.
+// It was introduced in VCD 10.2.1 and cannot be tested in earlier versions
+func TestAccVcdVmInternalDiskNvme(t *testing.T) {
+	preTestChecks(t)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	// NVM devices are in VCD starting with version 10.2.1
+	client := createTemporaryVCDConnection()
+	if client.Client.APIVCDMaxVersionIs("< 35.1") {
+		t.Skip("NVMe drive support was only introduced in VCD 10.2.1")
+	}
+
+	var params = StringMap{
+		"Org":      testConfig.VCD.Org,
+		"Vdc":      testConfig.VCD.Vdc,
+		"FuncName": "TestVappVmDS",
+		"Tags":     "vm",
+		"BusType":  "nvme",
+		"VmName":   t.Name() + "-vm",
+	}
+	configTextNvme := templateFill(sourceTestVmInternalDiskOrgVdcAndVMNvme, params)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testAccCheckVcdStandaloneVmDestroy(params["VmName"].(string), params["Org"].(string), params["Vdc"].(string)),
+		),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configTextNvme,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_vm.nvme", "id"),
+					resource.TestCheckResourceAttrSet("vcd_vm_internal_disk.nvme", "id"),
+					resource.TestCheckResourceAttr("vcd_vm_internal_disk.nvme", "bus_type", "nvme"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const sourceTestVmInternalDiskOrgVdcAndVMNvme = `
+resource "vcd_vm" "nvme" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  power_on  = false
+  name      = "{{.VmName}}"
+  memory    = 512
+  cpus      = 2
+  cpu_cores = 1
+
+  os_type          = "windows9Server64Guest"
+  hardware_version = "vmx-18"
+  computer_name    = "compName"
+}
+
+resource "vcd_vm_internal_disk" "nvme" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  vapp_name       = vcd_vm.nvme.vapp_name
+  vm_name         = vcd_vm.nvme.name
+  bus_type        = "nvme"
+  size_in_mb      = "100"
+  bus_number      = "1"
+  unit_number     = "0"
+  allow_vm_reboot = "false"
+
+  depends_on = [vcd_vm.nvme]
 }
 `

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -360,7 +360,7 @@ Changes are ignored on update. This part isn't reread on refresh. To manage inte
  
 ~> **Note:** Managing disks in VM is possible only when VDC fast provisioned is disabled.
 
-* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`. 
+* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`.
 * `size_in_mb` - (Required) The size of the disk in MB. 
 * `bus_number` - (Required) The number of the SCSI or IDE controller itself.
 * `unit_number` - (Required) The device number on the SCSI or IDE controller of the disk.
@@ -549,7 +549,7 @@ The following additional attributes are exported:
 ## Internal disk
 
 * `disk_id` - (*v2.7+*) Specifies a unique identifier for this disk in the scope of the corresponding VM.
-* `bus_type` - (*v2.7+*) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`. 
+* `bus_type` - (*v2.7+*) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`.
 * `size_in_mb` - (*v2.7+*) The size of the disk in MB. 
 * `bus_number` - (*v2.7+*) The number of the SCSI or IDE controller itself.
 * `unit_number` - (*v2.7+*) The device number on the SCSI or IDE controller of the disk.

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -360,7 +360,7 @@ Changes are ignored on update. This part isn't reread on refresh. To manage inte
  
 ~> **Note:** Managing disks in VM is possible only when VDC fast provisioned is disabled.
 
-* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`.
+* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`. **Note** `nvme` is supported in VCD 10.2.1+
 * `size_in_mb` - (Required) The size of the disk in MB. 
 * `bus_number` - (Required) The number of the SCSI or IDE controller itself.
 * `unit_number` - (Required) The device number on the SCSI or IDE controller of the disk.

--- a/website/docs/r/vm_internal_disk.html.markdown
+++ b/website/docs/r/vm_internal_disk.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `vapp_name` - (Required) The vAPP this VM internal disk belongs to.
 * `vm_name` - (Required) VM in vAPP in which internal disk is created.
 * `allow_vm_reboot` - (Optional) Powers off VM when changing any attribute of an IDE disk or unit/bus number of other disk types, after the change is complete VM is powered back on. Without this setting enabled, such changes on a powered-on VM would fail. Defaults to false.
-* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`.
+* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`. **Note** `nvme` is supported in VCD 10.2.1+
 * `size_in_mb` - (Required) The size of the disk in MB. 
 * `bus_number` - (Required) The number of the SCSI or IDE controller itself.
 * `unit_number` - (Required) The device number on the SCSI or IDE controller of the disk.

--- a/website/docs/r/vm_internal_disk.html.markdown
+++ b/website/docs/r/vm_internal_disk.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `vapp_name` - (Required) The vAPP this VM internal disk belongs to.
 * `vm_name` - (Required) VM in vAPP in which internal disk is created.
 * `allow_vm_reboot` - (Optional) Powers off VM when changing any attribute of an IDE disk or unit/bus number of other disk types, after the change is complete VM is powered back on. Without this setting enabled, such changes on a powered-on VM would fail. Defaults to false.
-* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`. 
+* `bus_type` - (Required) The type of disk controller. Possible values: `ide`, `parallel`( LSI Logic Parallel SCSI), `sas`(LSI Logic SAS (SCSI)), `paravirtual`(Paravirtual (SCSI)), `sata`, `nvme`.
 * `size_in_mb` - (Required) The size of the disk in MB. 
 * `bus_number` - (Required) The number of the SCSI or IDE controller itself.
 * `unit_number` - (Required) The device number on the SCSI or IDE controller of the disk.


### PR DESCRIPTION
We're using nvme for our disks and need support to resize them in our deployment.

Right not that is not supported, but this fix should make it work.
It works for us.