### PR TITLE
Pre 3.3.0 fixes

### DIFF
--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1571,6 +1571,6 @@ func skipTestForVcdExactVersion(t *testing.T, exactSkipVersion, skipReason strin
 		t.Fatalf("could not process versions")
 	}
 	if vcdVersion.Version.Equal(expectedVersion) {
-		t.Skipf("skipping test because for VCD version %s because %s", exactSkipVersion, skipReason)
+		t.Skipf("skipping test on VCD version %s because %s", exactSkipVersion, skipReason)
 	}
 }

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -24,6 +24,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -1552,4 +1554,23 @@ func addToTestRunList(testName, fileType string) error {
 // ignore tests in such case
 func noTestCredentials() bool {
 	return testConfig.Provider.User == ""
+}
+
+// skipTestForVcdExactVersion allows to skip tests for specific VCD version
+// exactSkipVersion must match exact VCD version (e.g. 10.2.2.17855680)
+func skipTestForVcdExactVersion(t *testing.T, exactSkipVersion, skipReason string) {
+	vcdClient := createTemporaryVCDConnection()
+
+	vcdVersion, err := vcdClient.Client.GetVcdFullVersion()
+	if err != nil {
+		t.Fatalf("Could not determine VCD version")
+	}
+
+	expectedVersion, err := version.NewVersion(exactSkipVersion)
+	if err != nil {
+		t.Fatalf("could not process versions")
+	}
+	if vcdVersion.Version.Equal(expectedVersion) {
+		t.Skipf("skipping test because for VCD version %s because %s", exactSkipVersion, skipReason)
+	}
 }

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -621,11 +621,11 @@ resource "vcd_nsxt_nat_rule" "dnat-match" {
 `
 
 func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
+	preTestChecks(t)
 	if noTestCredentials() {
 		t.Skip("Skipping test run as no credentials are provided and this test needs to lookup VCD version")
 		return
 	}
-	preTestChecks(t)
 	skipNoNsxtConfiguration(t)
 
 	// expectError must stay nil for versions > 10.3.0, because we expect it to work. For lower versions - it must have

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -17,17 +17,22 @@ func init() {
 }
 
 // TestAccVcdNsxtStandaloneVmTemplate tests NSX-T Routed network DHCP pools, static pools and manual IP assignment
+// Note. This test triggers a bug in 10.2.2.17855680 and fails. Because of this reason it is skipped on exactly this
+// version.
 func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 	preTestChecks(t)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
+	if noTestCredentials() {
+		t.Skip("Skipping test run as no credentials are provided and this test needs to lookup VCD version")
 		return
 	}
+	skipNoNsxtConfiguration(t)
 
 	vcdClient := createTemporaryVCDConnection()
 	if !vcdClient.Client.IsSysAdmin {
 		t.Skip(t.Name() + " only System Administrator can create Imported networks")
 	}
+
+	skipTestForVcdExactVersion(t, "10.2.2.17855680", "removal of standalone VM with NICs fails")
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.Nsxt.EdgeGateway == "" {
 		t.Skip("Either NSX-T VDC or Edge Gateway not defined")
@@ -67,6 +72,7 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 	}
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -247,6 +247,8 @@ resource "vcd_network_isolated_v2" "net-test" {
     start_address = "110.10.102.2"
     end_address   = "110.10.102.20"
   }
+
+  depends_on = [vcd_network_routed_v2.{{.NetworkName}}]
 }
 
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
@@ -279,6 +281,8 @@ resource "vcd_nsxt_network_imported" "imported-test" {
     start_address = "12.12.2.10"
     end_address   = "12.12.2.15"
   }
+
+  depends_on = [vcd_network_isolated_v2.net-test]
 }
 
 resource "vcd_independent_disk" "{{.diskResourceName}}" {


### PR DESCRIPTION
* VCD 10.2.2.17855680 has a bug where standalone VM removal fails with attacheds NICs. This PR adds explicit skip for this particular version and a convenience function `func skipTestForVcdExactVersion(t *testing.T, exactSkipVersion, skipReason string)`
* Conditionally set rule logging in  `TestAccVcdNsxtFirewall` based on whether the user is sysadmin or not