### PR TITLE
Rewrite build tags for Go 1.17 with go fmt

### DIFF
--- a/.changes/v3.4.0/706-improvements.md
+++ b/.changes/v3.4.0/706-improvements.md
@@ -1,0 +1,2 @@
+* Align build tags to match go fmt with Go 1.17 [GH-706]
+* Improve `test-tags.sh` script to handle new build tag format [GH-706]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.17
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/scripts/test-tags.sh
+++ b/scripts/test-tags.sh
@@ -17,8 +17,8 @@ then
 fi
 
 start=$(date +%s)
-tags1=$(head -n 1 config_test.go | sed -e 's/^.*build //')
-tags2=$(head -n 1 provider_test.go | sed -e 's/^.*build //')
+tags1=$(head -n 1 config_test.go | sed -e 's/^.*build //;s/|| //g')
+tags2=$(head -n 1 provider_test.go | sed -e 's/^.*build //;s/|| //g')
 tags=$(echo $tags1 $tags2 | tr " " "\n" | sort | uniq| tr "\n" " "; echo) 
 
 echo "=== RUN TagsTest"

--- a/vcd/auth_saml_test.go
+++ b/vcd/auth_saml_test.go
@@ -1,3 +1,4 @@
+//go:build auth || ALL || functional
 // +build auth ALL functional
 
 package vcd

--- a/vcd/auth_test.go
+++ b/vcd/auth_test.go
@@ -1,3 +1,4 @@
+//go:build functional || auth || ALL
 // +build functional auth ALL
 
 package vcd

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1,3 +1,4 @@
+//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbServiceMonitor || lbServerPool || lbAppProfile || lbAppRule || lbVirtualServer || access_control || user || standaloneVm || search || auth || nsxt || role || ALL
 // +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool lbAppProfile lbAppRule lbVirtualServer access_control user standaloneVm search auth nsxt role ALL
 
 package vcd

--- a/vcd/datasource_filter_test.go
+++ b/vcd/datasource_filter_test.go
@@ -1,3 +1,4 @@
+//go:build search || functional || ALL
 // +build search functional ALL
 
 package vcd

--- a/vcd/datasource_nsxt_manager_test.go
+++ b/vcd/datasource_nsxt_manager_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || nsxt || functional
 // +build ALL nsxt functional
 
 package vcd

--- a/vcd/datasource_nsxt_tier0_router_test.go
+++ b/vcd/datasource_nsxt_tier0_router_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || nsxt || functional
 // +build ALL nsxt functional
 
 package vcd

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || functional
 // +build ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_catalog_item_test.go
+++ b/vcd/datasource_vcd_catalog_item_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_catalog_media_test.go
+++ b/vcd/datasource_vcd_catalog_media_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_external_network_v2_test.go
+++ b/vcd/datasource_vcd_external_network_v2_test.go
@@ -1,4 +1,5 @@
-// +build functional network extnetwork  ALL
+//go:build functional || network || extnetwork || ALL
+// +build functional network extnetwork ALL
 
 package vcd
 

--- a/vcd/datasource_vcd_independent_disk_test.go
+++ b/vcd/datasource_vcd_independent_disk_test.go
@@ -1,3 +1,4 @@
+//go:build disk || ALL || functional
 // +build disk ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_network_isolated_v2_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_network_routed_v2_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_network_test.go
+++ b/vcd/datasource_vcd_network_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_edge_cluster_test.go
+++ b/vcd/datasource_vcd_nsxt_edge_cluster_test.go
@@ -1,3 +1,4 @@
+//go:build functional || nsxt || ALL
 // +build functional nsxt ALL
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_test.go
@@ -1,3 +1,4 @@
+//go:build functional || gateway || nsxt || ALL
 // +build functional gateway nsxt ALL
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_network_imported_test.go
+++ b/vcd/datasource_vcd_nsxt_network_imported_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_nsxt_security_group_test.go
+++ b/vcd/datasource_vcd_nsxt_security_group_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -1,3 +1,4 @@
+//go:build org || ALL || functional
 // +build org ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || ALL || functional
 // +build vdc ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || functional
 // +build ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_resource_schema_test.go
+++ b/vcd/datasource_vcd_resource_schema_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || functional
 // +build ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_rights_container_test.go
+++ b/vcd/datasource_vcd_rights_container_test.go
@@ -1,3 +1,4 @@
+//go:build role || ALL || functional
 // +build role ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_vapp_network_test.go
+++ b/vcd/datasource_vcd_vapp_network_test.go
@@ -1,3 +1,4 @@
+//go:build vm || ALL || functional
 // +build vm ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_vapp_org_network_test.go
+++ b/vcd/datasource_vcd_vapp_org_network_test.go
@@ -1,3 +1,4 @@
+//go:build vm || ALL || functional
 // +build vm ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_vapp_test.go
+++ b/vcd/datasource_vcd_vapp_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -1,3 +1,4 @@
+//go:build vm || ALL || functional
 // +build vm ALL functional
 
 package vcd

--- a/vcd/datasource_vcenter_test.go
+++ b/vcd/datasource_vcenter_test.go
@@ -1,3 +1,4 @@
+//go:build ALL || functional
 // +build ALL functional
 
 package vcd

--- a/vcd/openapi_common_test.go
+++ b/vcd/openapi_common_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || nsxt || ALL || functional
 // +build vdc nsxt ALL functional
 
 package vcd

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -1,3 +1,4 @@
+//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbAppProfile || lbAppRule || lbServiceMonitor || lbServerPool || lbVirtualServer || user || access_control || standaloneVm || search || auth || nsxt || role || ALL
 // +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbAppProfile lbAppRule lbServiceMonitor lbServerPool lbVirtualServer user access_control standaloneVm search auth nsxt role ALL
 
 package vcd

--- a/vcd/provider_unit_test.go
+++ b/vcd/provider_unit_test.go
@@ -1,3 +1,4 @@
+//go:build unit || ALL
 // +build unit ALL
 
 package vcd

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || ALL || functional
 // +build gateway ALL functional
 
 package vcd

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || ALL || functional
 // +build gateway ALL functional
 
 package vcd

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || ALL || functional
 // +build gateway ALL functional
 
 package vcd

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -1,3 +1,4 @@
+//go:build functional || network || extnetwork || ALL
 // +build functional network extnetwork ALL
 
 package vcd

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -1,3 +1,4 @@
+//go:build functional || network || extnetwork || nsxt || ALL
 // +build functional network extnetwork nsxt ALL
 
 package vcd

--- a/vcd/resource_vcd_global_role_test.go
+++ b/vcd/resource_vcd_global_role_test.go
@@ -1,3 +1,4 @@
+//go:build role || ALL || functional
 // +build role ALL functional
 
 package vcd

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -1,3 +1,4 @@
+//go:build disk || ALL || functional
 // +build disk ALL functional
 
 package vcd

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -1,3 +1,4 @@
+//go:build catalog || ALL || functional
 // +build catalog ALL functional
 
 package vcd

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -1,3 +1,4 @@
+//go:build nsxv || gateway || ALL || functional
 // +build nsxv gateway ALL functional
 
 package vcd

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || lb || lbAppProfile || ALL || functional
 // +build gateway lb lbAppProfile ALL functional
 
 package vcd

--- a/vcd/resource_vcd_lb_app_rule_test.go
+++ b/vcd/resource_vcd_lb_app_rule_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || lb || lbAppRule || ALL || functional
 // +build gateway lb lbAppRule ALL functional
 
 package vcd

--- a/vcd/resource_vcd_lb_server_pool_test.go
+++ b/vcd/resource_vcd_lb_server_pool_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || lb || lbServerPool || ALL || functional
 // +build gateway lb lbServerPool ALL functional
 
 package vcd

--- a/vcd/resource_vcd_lb_service_monitor_test.go
+++ b/vcd/resource_vcd_lb_service_monitor_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || lb || lbServiceMonitor || ALL || functional
 // +build gateway lb lbServiceMonitor ALL functional
 
 package vcd

--- a/vcd/resource_vcd_lb_virtual_server_test.go
+++ b/vcd/resource_vcd_lb_virtual_server_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || lb || lbVirtualServer || ALL || functional
 // +build gateway lb lbVirtualServer ALL functional
 
 package vcd

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_network_isolated_v2_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_network_routed_v2_test.go
+++ b/vcd/resource_vcd_network_routed_v2_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -1,3 +1,4 @@
+//go:build network || ALL || functional
 // +build network ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/resource_vcd_nsxt_app_port_profile_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || nsxt || ALL || functional
 // +build gateway nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_firewall_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_ip_set_test.go
+++ b/vcd/resource_vcd_nsxt_ip_set_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_network_imported_test.go
+++ b/vcd/resource_vcd_nsxt_network_imported_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -1,3 +1,4 @@
+//go:build network || nsxt || ALL || functional
 // +build network nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -1,3 +1,4 @@
+//go:build (vm || nsxt || standaloneVm || ALL || functional) && !skipStandaloneVm
 // +build vm nsxt standaloneVm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_nsxt_vapp_raw_test.go
+++ b/vcd/resource_vcd_nsxt_vapp_raw_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || nsxt || ALL || functional
 // +build vapp vm nsxt ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxv_dhcp_relay_test.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || ALL || functional
 // +build gateway ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || nat || ALL || functional
 // +build gateway nat ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || firewall || ALL || functional
 // +build gateway firewall ALL functional
 
 package vcd

--- a/vcd/resource_vcd_nsxv_snat_test.go
+++ b/vcd/resource_vcd_nsxv_snat_test.go
@@ -1,3 +1,4 @@
+//go:build gateway || nat || ALL || functional
 // +build gateway nat ALL functional
 
 package vcd

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -1,3 +1,4 @@
+//go:build user || functional || ALL
 // +build user functional ALL
 
 package vcd

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -1,3 +1,4 @@
+//go:build org || ALL || functional
 // +build org ALL functional
 
 package vcd

--- a/vcd/resource_vcd_org_user_test.go
+++ b/vcd/resource_vcd_org_user_test.go
@@ -1,3 +1,4 @@
+//go:build user || functional || ALL
 // +build user functional ALL
 
 package vcd

--- a/vcd/resource_vcd_org_vdc_nsxt_test.go
+++ b/vcd/resource_vcd_org_vdc_nsxt_test.go
@@ -1,3 +1,4 @@
+//go:build nsxt || vdc || ALL || functional
 // +build nsxt vdc ALL functional
 
 package vcd

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || ALL || functional
 // +build vdc ALL functional
 
 package vcd

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || ALL || functional
 // +build vdc ALL functional
 
 package vcd

--- a/vcd/resource_vcd_rights_bundle_test.go
+++ b/vcd/resource_vcd_rights_bundle_test.go
@@ -1,3 +1,4 @@
+//go:build role || ALL || functional
 // +build role ALL functional
 
 package vcd

--- a/vcd/resource_vcd_role_test.go
+++ b/vcd/resource_vcd_role_test.go
@@ -1,3 +1,4 @@
+//go:build role || ALL || functional
 // +build role ALL functional
 
 package vcd

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -1,3 +1,4 @@
+//go:build (vm || standaloneVm || ALL || functional) && !skipStandaloneVm
 // +build vm standaloneVm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || functional || access_control || ALL
 // +build vapp functional access_control ALL
 
 package vcd

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_firewall_rules_test.go
+++ b/vcd/resource_vcd_vapp_firewall_rules_test.go
@@ -1,3 +1,4 @@
+//go:build functional || vapp || ALL
 // +build functional vapp ALL
 
 package vcd

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_nat_rules_test.go
+++ b/vcd/resource_vcd_vapp_nat_rules_test.go
@@ -1,3 +1,4 @@
+//go:build functional || vapp || ALL
 // +build functional vapp ALL
 
 package vcd

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -1,3 +1,4 @@
+//go:build multinetwork || functional
 // +build multinetwork functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -1,3 +1,4 @@
+//go:build network || vapp || ALL || functional
 // +build network vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_org_network_test.go
+++ b/vcd/resource_vcd_vapp_org_network_test.go
@@ -1,3 +1,4 @@
+//go:build network || vapp || ALL || functional
 // +build network vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_properties_test.go
+++ b/vcd/resource_vcd_vapp_properties_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || ALL || functional
 // +build vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -1,3 +1,4 @@
+//go:build multivm
 // +build multivm
 
 package vcd

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || ALL || functional
 // +build vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_static_routing_test.go
+++ b/vcd/resource_vcd_vapp_static_routing_test.go
@@ -1,3 +1,4 @@
+//go:build functional || vapp || ALL
 // +build functional vapp ALL
 
 package vcd

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || ALL || functional
 // +build vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_update_test.go
+++ b/vcd/resource_vcd_vapp_update_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || ALL || functional
 // +build vapp ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vapp_vm_capabilities_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || catalog || ALL || functional
 // +build vapp vm catalog ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -1,3 +1,4 @@
+//go:build multivm || functional
 // +build multivm functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vm_affinity_rule_test.go
+++ b/vcd/resource_vcd_vm_affinity_rule_test.go
@@ -1,3 +1,4 @@
+//go:build vm || functional || affinity || ALL
 // +build vm functional affinity ALL
 
 package vcd

--- a/vcd/resource_vcd_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vm_capabilities_test.go
@@ -1,3 +1,4 @@
+//go:build (vm || standaloneVm || ALL || functional) && !skipStandaloneVm
 // +build vm standaloneVm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vm_dhcp_wait_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vm_hw_virtualization_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || ALL || functional
 // +build vapp vm ALL functional
 
 package vcd

--- a/vcd/resource_vcd_vm_properties_test.go
+++ b/vcd/resource_vcd_vm_properties_test.go
@@ -1,3 +1,4 @@
+//go:build (standaloneVm || vm || ALL || functional) && !skipStandaloneVm
 // +build standaloneVm vm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_shrink_cpu_test.go
+++ b/vcd/resource_vcd_vm_shrink_cpu_test.go
@@ -1,3 +1,4 @@
+//go:build (vm || standaloneVm || ALL || functional) && !skipStandaloneVm
 // +build vm standaloneVm ALL functional
 // +build !skipStandaloneVm
 

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -1,3 +1,4 @@
+//go:build vdc || ALL || functional
 // +build vdc ALL functional
 
 package vcd

--- a/vcd/terraform_binary_test.go
+++ b/vcd/terraform_binary_test.go
@@ -1,3 +1,4 @@
+//go:build binary
 // +build binary
 
 package vcd

--- a/vcd/testcheck_funcs_test.go
+++ b/vcd/testcheck_funcs_test.go
@@ -1,3 +1,4 @@
+//go:build vapp || vm || user || nsxt || extnetwork || network || gateway || catalog || standaloneVm || ALL || functional
 // +build vapp vm user nsxt extnetwork network gateway catalog standaloneVm ALL functional
 
 package vcd


### PR DESCRIPTION
Go 1.17 introduced changes to how build tags are defined. `gofmt` automatically fixes that and this PR is just to make sure we are 1.17 compatible so that `make build` works.

Additionally it tunes `sed` command in `test-tags.sh` so that it gathers all tags and ignores or `||` sign in new build tag format.