### PR TITLE
Prevent invalid space in the base64 encoded authentication string in the token scripts specific for Linux

### DIFF
--- a/.changes/v3.4.0/708-improvements.md
+++ b/.changes/v3.4.0/708-improvements.md
@@ -1,0 +1,1 @@
+* Prevent invalid space in the base64 encoded authentication string in the token scripts specific for Linux [GH-708]

--- a/scripts/get_token.sh
+++ b/scripts/get_token.sh
@@ -13,7 +13,15 @@ then
     exit 1
 fi
 
-auth=$(echo -n "$user@$org:$password" |base64)
+options=""
+os=$(uname -s)
+is_linux=$(echo "$os" | grep -i linux)
+if [ -n "$is_linux" ]
+then
+  options="-w 0"
+fi
+
+auth=$(echo -n "$user@$org:$password" |base64 $options)
 
 curl -I -k --header "Accept: application/*;version=32.0" \
     --header "Authorization: Basic $auth" \

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -258,7 +258,15 @@ function make_token {
     echo "missing url from configuration file. Can't retrieve token"
     exit 1
   fi
-  auth=$(echo -n "$user@$sysorg:$password" |base64)
+
+  options=""
+  os=$(uname -s)
+  is_linux=$(echo "$os" | grep -i linux)
+  if [ -n "$is_linux" ]
+  then
+    options="-w 0"
+  fi
+  auth=$(echo -n "$user@$sysorg:$password" |base64 $options)
 
   echo "# Connecting to $url ($sysorg)"
   curl --silent --head --insecure \

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -173,7 +173,15 @@ then
     exit 1
 fi
 
-auth=$(echo -n "$user@$org:$password" | base64)
+options=""
+os=$(uname -s)
+is_linux=$(echo "$os" | grep -i linux)
+if [ -n "$is_linux" ]
+then
+  options="-w 0"
+fi
+
+auth=$(echo -n "$user@$org:$password" |base64 $options)
 
 curl -I -k --header "Accept: application/*;version=32.0" \
     --header "Authorization: Basic $auth" \


### PR DESCRIPTION
If the auth string "$user@$org:$password" gets above 76
characters, the GNU coreutils base64 utility on Linux
adds a space into the string, causing invalid
authentication string.

Because different base64 implementation do have different parameters
there is no easy way to dinguish between.

Explain script:

user=long
password=thisisaverylongpasswordandcausesbase64startaddaspaceafteradefaultof76
org=myorg
IP=myip

echo;echo "Causes an empty space in the variable"
echo "$user@$org:$password"
auth=$(echo -n "$user@$org:$password" |base64)
echo $auth

echo;echo "Base64 -w 0 (on Linux) fixes it"
options=""
os=$(uname -s)
is_linux=$(echo "$os" | grep -i linux)
if [ -n "$is_linux" ]
then
  options="-w 0"
fi
echo "$user@$org:$password"
auth=$(echo -n "$user@$org:$password" |base64 $options)
echo $auth

echo;echo "OpenSSL base64 fixes it (on probably MacOS and Linux)"
echo "$user@$org:$password"
auth=$(echo -n "$user@$org:$password" | openssl base64 -A)
echo $auth

Signed-off-by: Gabriel Mainberger <gabriel.mainberger@vshn.net>