### PR TITLE
Add support for NSX-T segment backed networks in 10.3

### DIFF
--- a/.changes/v3.4.0/711-improvements.md
+++ b/.changes/v3.4.0/711-improvements.md
@@ -1,0 +1,1 @@
+* **Resource** and **Data source** `vcd_external_network_v2` support NSX-T Segment backed network [GH-711]

--- a/.changes/v3.4.0/YYY-improvements.md
+++ b/.changes/v3.4.0/YYY-improvements.md
@@ -1,0 +1,1 @@
+* **Resource** and **Data source** `vcd_external_network_v2` support NSX-T Segment backed network [GH-YYY]

--- a/.changes/v3.4.0/YYY-improvements.md
+++ b/.changes/v3.4.0/YYY-improvements.md
@@ -1,1 +1,0 @@
-* **Resource** and **Data source** `vcd_external_network_v2` support NSX-T Segment backed network [GH-YYY]

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.13.0-alpha.2
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210920121657-110e8c0e3896

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.13.0-alpha.2
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f h1:K91hFSZz0mVeRN0nsKrFyd3FKl6af35eQ1sDxOdz9Ks=
+github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
@@ -311,8 +313,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.13.0-alpha.2 h1:hWPbJg2gbnElC7CH6mhiSFd+3qz/f/Apt5hWHCdXdB8=
-github.com/vmware/go-vcloud-director/v2 v2.13.0-alpha.2/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f h1:K91hFSZz0mVeRN0nsKrFyd3FKl6af35eQ1sDxOdz9Ks=
-github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210915061619-faf5992f7e4f/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
+github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210920121657-110e8c0e3896 h1:D9FCtnVjx3yrpBvCOoDJUEBCobz096crahr5nBF0JR0=
+github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20210920121657-110e8c0e3896/go.mod h1:poaOwg7CoXO4m9Pv4TVhMpNF1wQQwKzxpdGYTfjzajs=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -592,10 +592,14 @@ do
     then
         major_from=$(echo $from_version | tr -d 'v' | tr '.' ' '| awk '{print $1}')
         minor_from=$(echo $from_version | tr -d 'v' | tr '.' ' '| awk '{print $2}')
+        patch_from=$(echo $from_version | tr -d 'v' | tr '.' ' '| awk '{print $3}')
         major_to=$(echo $to_version | tr -d 'v' | tr '.' ' '| awk '{print $1}')
         minor_to=$(echo $to_version | tr -d 'v' | tr '.' ' '| awk '{print $2}')
+        patch_to=$(echo $to_version | tr -d 'v' | tr '.' ' '| awk '{print $3}')
         short_from="${major_from}.${minor_from}"
         short_to="${major_to}.${minor_to}"
+        long_from="${major_from}.${minor_from}.${patch_from}"
+        long_to="${major_to}.${minor_to}.${patch_to}"
     fi
 
     for phase in ${operations[*]}
@@ -608,7 +612,7 @@ do
                     sed  -i -e '/^\s*version *=/d' config.tf
 
                     # recreate versions.tf with "short_from" version
-                    add_versions_config "versions.tf" "${PWD}" "${short_from}"
+                    add_versions_config "versions.tf" "${PWD}" "${long_from}"
 
                     run terraform init
                     run terraform version
@@ -638,7 +642,7 @@ do
                     if [ -n "$upgrading" ]
                     then
                         # recreate versions.tf with "short_to" version
-                        add_versions_config "versions.tf" "${PWD}" "${short_to}"
+                        add_versions_config "versions.tf" "${PWD}" "${long_to}"
                         run terraform init -upgrade
                         run terraform version
                     fi

--- a/scripts/test-upgrade.sh
+++ b/scripts/test-upgrade.sh
@@ -114,8 +114,10 @@ else
     fi
 
     # Creates the plugin and the test scripts with the older release
+    echo "#!/usr/bin/env bash" > scripts/gofmtcheck.sh
     make test-binary-prepare
     check_exit_code "error preparing binary tests"
+    git checkout master scripts/gofmtcheck.sh
 
     # Back to the current version
     git checkout $branch

--- a/vcd/datasource_vcd_external_network_v2.go
+++ b/vcd/datasource_vcd_external_network_v2.go
@@ -60,7 +60,12 @@ func datasourceVcdExternalNetworkV2() *schema.Resource {
 						"nsxt_tier0_router_id": &schema.Schema{
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "ID of NSX-T Tier-0 router",
+							Description: "ID of NSX-T Tier-0 router (for T0 gateway backed external network)",
+						},
+						"nsxt_segment_name": &schema.Schema{
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of NSX-T segment (for NSX-T segment backed external network)",
 						},
 					},
 				},
@@ -82,5 +87,5 @@ func datasourceVcdExternalNetworkV2Read(d *schema.ResourceData, meta interface{}
 
 	d.SetId(extNet.ExternalNetwork.ID)
 
-	return setExternalNetworkV2Data(d, extNet.ExternalNetwork)
+	return setExternalNetworkV2Data(d, extNet.ExternalNetwork, vcdClient)
 }

--- a/vcd/resource_vcd_external_network_v2.go
+++ b/vcd/resource_vcd_external_network_v2.go
@@ -369,8 +369,8 @@ func getExternalNetworkV2BackingType(vcdClient *VCDClient, d *schema.ResourceDat
 			}
 
 			backing := types.ExternalNetworkV2Backing{
-				BackingID:   nsxvNetworkStrings["portgroup_id"],
-				BackingType: pgType,
+				BackingID:        nsxvNetworkStrings["portgroup_id"],
+				BackingTypeValue: pgType,
 				NetworkProvider: types.NetworkProvider{
 					ID: nsxvNetworkStrings["vcenter_id"],
 				},

--- a/vcd/resource_vcd_external_network_v2.go
+++ b/vcd/resource_vcd_external_network_v2.go
@@ -167,7 +167,7 @@ func resourceVcdExternalNetworkV2() *schema.Resource {
 				ExactlyOneOf: []string{"vsphere_network", "nsxt_network"},
 				MaxItems:     1,
 				ForceNew:     true,
-				Description:  "Reference to NSX-T Tier-0 router or Segment and manager",
+				Description:  "Reference to NSX-T Tier-0 router or segment and manager",
 				Elem:         networkV2NsxtNetwork,
 			},
 		},

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -504,6 +504,11 @@ func TestAccVcdExternalNetworkV2NsxtSegmentUnsupported(t *testing.T) {
 	configText := templateFill(skipBinaryConfig, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
@@ -833,3 +838,173 @@ func testAccCheckExternalNetworkDestroyV2(name string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+// TestAccVcdExternalNetworkV2NsxtSegmentIntegration attempts to test creation of NSX-T backed segment and also an NSX-T
+// Org direct network resource (the only possible while implementing this feature)
+func TestAccVcdExternalNetworkV2NsxtSegmentIntegration(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	skipNoNsxtConfiguration(t)
+	vcdClient := createTemporaryVCDConnection()
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	startAddress := "192.168.30.51"
+	endAddress := "192.168.30.62"
+	description := "Test External Network"
+	var params = StringMap{
+		"NsxtManager":         testConfig.Nsxt.Manager,
+		"NsxtSegment":         testConfig.Nsxt.NsxtImportSegment,
+		"NsxtVdc":             testConfig.Nsxt.Vdc,
+		"ExternalNetworkName": t.Name(),
+		"Type":                testConfig.Networking.ExternalNetworkPortGroupType,
+		"PortGroup":           testConfig.Networking.ExternalNetworkPortGroup,
+		"Vcenter":             testConfig.Networking.Vcenter,
+		"StartAddress":        startAddress,
+		"EndAddress":          endAddress,
+		"Description":         description,
+		"Gateway":             "192.168.30.49",
+		"Netmask":             "24",
+		"Tags":                "network extnetwork nsxt",
+	}
+
+	configText := templateFill(testAccCheckVcdExternalNetworkV2NsxtSegmentIntegration, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+	params["FuncName"] = t.Name() + "-step2"
+	configText1 := templateFill(testAccCheckVcdExternalNetworkV2NsxtSegmentIntegrationDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	resourceName := "vcd_external_network_v2.ext-net-nsxt"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "vsphere_network.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_scope.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*", map[string]string{
+						"dns1":          "",
+						"dns2":          "",
+						"dns_suffix":    "",
+						"enabled":       "false",
+						"gateway":       "192.168.30.49",
+						"prefix_length": "24",
+					}),
+
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "192.168.30.51",
+						"end_address":   "192.168.30.62",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*", map[string]string{
+						"dns1":          "",
+						"dns2":          "",
+						"dns_suffix":    "",
+						"enabled":       "true",
+						"gateway":       "14.14.14.1",
+						"prefix_length": "24",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "14.14.14.20",
+						"end_address":   "14.14.14.25",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "14.14.14.10",
+						"end_address":   "14.14.14.15",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "nsxt_network.0.nsxt_manager_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "nsxt_network.0.nsxt_segment_name"),
+				),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual("data.vcd_external_network_v2.ext-net-nsxt", "vcd_external_network_v2.ext-net-nsxt", nil),
+					// Field count differs because data source has `filter` field
+					resourceFieldsEqual("data.vcd_network_direct.net", "vcd_network_direct.net", []string{"%"}),
+				),
+			},
+		},
+	})
+
+	postTestChecks(t)
+}
+
+const testAccCheckVcdExternalNetworkV2NsxtSegmentIntegration = `
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManager}}"
+}
+
+resource "vcd_external_network_v2" "ext-net-nsxt" {
+  name        = "{{.ExternalNetworkName}}"
+  description = "{{.Description}}"
+
+  nsxt_network {
+    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name = "{{.NsxtSegment}}"
+  }
+
+  ip_scope {
+    enabled       = false
+    gateway       = "{{.Gateway}}"
+    prefix_length = "{{.Netmask}}"
+
+    static_ip_pool {
+      start_address = "{{.StartAddress}}"
+      end_address   = "{{.EndAddress}}"
+    }
+  }
+
+  ip_scope {
+    gateway       = "14.14.14.1"
+    prefix_length = "24"
+
+    static_ip_pool {
+      start_address = "14.14.14.10"
+      end_address   = "14.14.14.15"
+    }
+    
+    static_ip_pool {
+      start_address = "14.14.14.20"
+      end_address   = "14.14.14.25"
+    }
+  }
+}
+
+resource "vcd_network_direct" "net" {
+  vdc = "{{.NsxtVdc}}"
+
+  name             = "direct-net"
+  external_network = vcd_external_network_v2.ext-net-nsxt.name
+
+  depends_on = [vcd_external_network_v2.ext-net-nsxt]
+}
+`
+
+const testAccCheckVcdExternalNetworkV2NsxtSegmentIntegrationDS = testAccCheckVcdExternalNetworkV2NsxtSegmentIntegration + `
+# skip-binary-test: Data Source test 
+data "vcd_external_network_v2" "ext-net-nsxt" {
+  name = vcd_external_network_v2.ext-net-nsxt.name
+}
+
+data "vcd_network_direct" "net" {
+  vdc = "{{.NsxtVdc}}"
+
+  name = vcd_network_direct.net.name
+}
+`

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -31,7 +31,7 @@ func TestAccVcdExternalNetworkV2NsxtVrf(t *testing.T) {
 	postTestChecks(t)
 }
 
-func TestAccVcdExternalNetworkV2Nsxt(t *testing.T) {
+func TestAccVcdExternalNetworkV2NsxtT0Router(t *testing.T) {
 	preTestChecks(t)
 	testAccVcdExternalNetworkV2Nsxt(t, testConfig.Nsxt.Tier0router)
 	postTestChecks(t)
@@ -47,7 +47,7 @@ func testAccVcdExternalNetworkV2Nsxt(t *testing.T, nsxtTier0Router string) {
 	skipNoNsxtConfiguration(t)
 	vcdClient := createTemporaryVCDConnection()
 	if vcdClient.Client.APIVCDMaxVersionIs("< 33.0") {
-		t.Skip(t.Name() + " requires at least API v33.0 (vCD 10+)")
+		t.Skip(t.Name() + " requires at least API v33.0 (VCD 10+)")
 	}
 
 	startAddress := "192.168.30.51"
@@ -220,6 +220,7 @@ output "nsxt-tier0-router" {
   value = tolist(vcd_external_network_v2.ext-net-nsxt.nsxt_network)[0].nsxt_tier0_router_id
 }
 `
+
 const testAccCheckVcdExternalNetworkV2NsxtStep1 = testAccCheckVcdExternalNetworkV2NsxtDS + `
 # skip-binary-test: only for updates
 resource "vcd_external_network_v2" "ext-net-nsxt" {
@@ -265,7 +266,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 
 	vcdClient := createTemporaryVCDConnection()
 	if vcdClient.Client.APIVCDMaxVersionIs("< 33.0") {
-		t.Skip(t.Name() + " requires at least API v33.0 (vCD 10+)")
+		t.Skip(t.Name() + " requires at least API v33.0 (VCD 10+)")
 	}
 
 	description := "Test External Network"
@@ -462,6 +463,303 @@ output "vcenter-id" {
 
 output "portgroup-id" {
   value = tolist(vcd_external_network_v2.ext-net-nsxv.vsphere_network)[0].portgroup_id
+}
+`
+
+func TestAccVcdExternalNetworkV2NsxtSegment(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	skipNoNsxtConfiguration(t)
+	vcdClient := createTemporaryVCDConnection()
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	startAddress := "192.168.30.51"
+	endAddress := "192.168.30.62"
+	description := "Test External Network"
+	var params = StringMap{
+		"NsxtManager":         testConfig.Nsxt.Manager,
+		"NsxtSegment":         testConfig.Nsxt.NsxtImportSegment,
+		"ExternalNetworkName": t.Name(),
+		"Type":                testConfig.Networking.ExternalNetworkPortGroupType,
+		"PortGroup":           testConfig.Networking.ExternalNetworkPortGroup,
+		"Vcenter":             testConfig.Networking.Vcenter,
+		"StartAddress":        startAddress,
+		"EndAddress":          endAddress,
+		"Description":         description,
+		"Gateway":             "192.168.30.49",
+		"Netmask":             "24",
+		"Tags":                "network extnetwork nsxt",
+	}
+
+	params["FuncName"] = t.Name()
+	configText := templateFill(testAccCheckVcdExternalNetworkV2NsxtSegment, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	params["FuncName"] = t.Name() + "step1"
+	configText1 := templateFill(testAccCheckVcdExternalNetworkV2NsxtSegmentStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	resourceName := "vcd_external_network_v2.ext-net-nsxt"
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "vsphere_network.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_scope.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*", map[string]string{
+						"dns1":          "",
+						"dns2":          "",
+						"dns_suffix":    "",
+						"enabled":       "false",
+						"gateway":       "192.168.30.49",
+						"prefix_length": "24",
+					}),
+
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "192.168.30.51",
+						"end_address":   "192.168.30.62",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*", map[string]string{
+						"dns1":          "",
+						"dns2":          "",
+						"dns_suffix":    "",
+						"enabled":       "true",
+						"gateway":       "14.14.14.1",
+						"prefix_length": "24",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "14.14.14.20",
+						"end_address":   "14.14.14.25",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "14.14.14.10",
+						"end_address":   "14.14.14.15",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+				),
+			},
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdTopHierarchy(t.Name()),
+			},
+			resource.TestStep{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "vsphere_network.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_scope.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*", map[string]string{
+						"dns1":          "",
+						"dns2":          "",
+						"dns_suffix":    "",
+						"enabled":       "true",
+						"gateway":       "192.168.30.49",
+						"prefix_length": "24",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "ip_scope.*.static_ip_pool.*", map[string]string{
+						"start_address": "192.168.30.51",
+						"end_address":   "192.168.30.62",
+					}),
+					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
+				),
+			},
+		},
+	})
+
+	postTestChecks(t)
+}
+
+const testAccCheckVcdExternalNetworkV2NsxtSegment = `
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManager}}"
+}
+
+resource "vcd_external_network_v2" "ext-net-nsxt" {
+  name        = "{{.ExternalNetworkName}}"
+  description = "{{.Description}}"
+
+  nsxt_network {
+    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name = "{{.NsxtSegment}}"
+  }
+
+  ip_scope {
+    enabled       = false
+    gateway       = "{{.Gateway}}"
+    prefix_length = "{{.Netmask}}"
+
+    static_ip_pool {
+      start_address = "{{.StartAddress}}"
+      end_address   = "{{.EndAddress}}"
+    }
+  }
+
+  ip_scope {
+    gateway       = "14.14.14.1"
+    prefix_length = "24"
+
+    static_ip_pool {
+      start_address = "14.14.14.10"
+      end_address   = "14.14.14.15"
+    }
+    
+    static_ip_pool {
+      start_address = "14.14.14.20"
+      end_address   = "14.14.14.25"
+    }
+  }
+}
+`
+
+const testAccCheckVcdExternalNetworkV2NsxtSegmentStep2 = `
+# skip-binary-test: only for updates
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManager}}"
+}
+
+resource "vcd_external_network_v2" "ext-net-nsxt" {
+  name        = "{{.ExternalNetworkName}}"
+  description = "{{.Description}}"
+
+  nsxt_network {
+    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name = "{{.NsxtSegment}}"
+  }
+
+  ip_scope {
+    enabled       = true
+    gateway       = "{{.Gateway}}"
+    prefix_length = "{{.Netmask}}"
+
+    static_ip_pool {
+      start_address = "{{.StartAddress}}"
+      end_address   = "{{.EndAddress}}"
+    }
+  }
+}
+`
+
+func TestAccVcdExternalNetworkV2NsxtConfigError(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	skipNoNsxtConfiguration(t)
+	vcdClient := createTemporaryVCDConnection()
+	if vcdClient.Client.APIVCDMaxVersionIs("< 33.0") {
+		t.Skip(t.Name() + " requires at least API v33.0 (VCD 10.1+)")
+	}
+
+	startAddress := "192.168.30.51"
+	endAddress := "192.168.30.62"
+	description := "Test External Network"
+	var params = StringMap{
+		"NsxtManager":         testConfig.Nsxt.Manager,
+		"NsxtSegment":         testConfig.Nsxt.NsxtImportSegment,
+		"NsxtTier0Router":     testConfig.Nsxt.Tier0router,
+		"ExternalNetworkName": t.Name(),
+		"Type":                testConfig.Networking.ExternalNetworkPortGroupType,
+		"PortGroup":           testConfig.Networking.ExternalNetworkPortGroup,
+		"Vcenter":             testConfig.Networking.Vcenter,
+		"StartAddress":        startAddress,
+		"EndAddress":          endAddress,
+		"Description":         description,
+		"Gateway":             "192.168.30.49",
+		"Netmask":             "24",
+		"Tags":                "network extnetwork nsxt",
+	}
+
+	params["FuncName"] = t.Name()
+	configText := templateFill(testAccCheckVcdExternalNetworkV2NsxtConfigError, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      configText,
+				ExpectError: regexp.MustCompile(`Invalid combination of arguments`),
+			},
+		},
+	})
+
+	postTestChecks(t)
+}
+
+const testAccCheckVcdExternalNetworkV2NsxtConfigError = `
+# skip-binary-test: fails on purpose
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManager}}"
+}
+
+data "vcd_nsxt_tier0_router" "router" {
+  name            = "{{.NsxtTier0Router}}"
+  nsxt_manager_id = data.vcd_nsxt_manager.main.id
+}
+
+resource "vcd_external_network_v2" "ext-net-nsxt" {
+  name        = "{{.ExternalNetworkName}}"
+  description = "{{.Description}}"
+
+  nsxt_network {
+    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name = "{{.NsxtSegment}}"
+    nsxt_tier0_router_id = data.vcd_nsxt_tier0_router.router.id
+  }
+
+  ip_scope {
+    enabled       = false
+    gateway       = "{{.Gateway}}"
+    prefix_length = "{{.Netmask}}"
+
+    static_ip_pool {
+      start_address = "{{.StartAddress}}"
+      end_address   = "{{.EndAddress}}"
+    }
+  }
+
+  ip_scope {
+    gateway       = "14.14.14.1"
+    prefix_length = "24"
+
+    static_ip_pool {
+      start_address = "14.14.14.10"
+      end_address   = "14.14.14.15"
+    }
+    
+    static_ip_pool {
+      start_address = "14.14.14.20"
+      end_address   = "14.14.14.25"
+    }
+  }
 }
 `
 

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -67,6 +68,8 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 	}
 
 	configText := templateFill(testAccCheckVcdNsxtStandaloneVm_basic, params)
+	params["FuncName"] = t.Name() + "-step2"
+	configText2 := templateFill(testAccCheckVcdNsxtStandaloneVm_basicCleanup, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -125,6 +128,15 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 				// "network_dhcp_wait_seconds" is a user setting and cannot be imported
 				ImportStateVerifyIgnore: []string{"template_name", "catalog_name",
 					"accept_all_eulas", "power_on", "computer_name", "prevent_update_power_off", "network.1.ip", "network_dhcp_wait_seconds"},
+			},
+			// This step ensures that VM and disk are removed, but networks are left
+			resource.TestStep{
+				Config: configText2,
+			},
+			// This step gives 10-second sleep timer so that cleanup bug is not hit in VCD 10.3
+			resource.TestStep{
+				Config:    configText2,
+				PreConfig: func() { time.Sleep(10 * time.Second) },
 			},
 		},
 	})
@@ -216,6 +228,7 @@ func TestAccVcdNsxtStandaloneEmptyVm(t *testing.T) {
 }
 
 const testAccCheckVcdNsxtStandaloneVm_basic = `
+# skip-binary-test: removing NSX-T Org networks right after standalone VM fails in 10.3
 data "vcd_nsxt_edgegateway" "existing" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
@@ -234,6 +247,8 @@ resource "vcd_network_routed_v2" "{{.NetworkName}}" {
     start_address = "10.10.102.2"
     end_address   = "10.10.102.200"
   }
+
+  depends_on = [vcd_nsxt_network_imported.imported-test]
 }
 
 resource "vcd_network_isolated_v2" "net-test" {
@@ -248,8 +263,6 @@ resource "vcd_network_isolated_v2" "net-test" {
     start_address = "110.10.102.2"
     end_address   = "110.10.102.20"
   }
-
-  depends_on = [vcd_nsxt_network_imported.imported-test]
 }
 
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
@@ -283,7 +296,7 @@ resource "vcd_nsxt_network_imported" "imported-test" {
     end_address   = "12.12.2.15"
   }
 
-  depends_on = [vcd_network_routed_v2.{{.NetworkName}}]
+  depends_on = [vcd_network_isolated_v2.net-test]
 }
 
 resource "vcd_independent_disk" "{{.diskResourceName}}" {
@@ -294,6 +307,9 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   bus_type        = "{{.busType}}"
   bus_sub_type    = "{{.busSubType}}"
   storage_profile = "{{.storageProfileName}}"
+
+  depends_on = [vcd_network_routed_v2.{{.NetworkName}}, vcd_network_isolated_v2.net-test, 
+                vcd_nsxt_network_imported.imported-test]
 }
 
 resource "vcd_vm" "{{.VmName}}" {
@@ -354,8 +370,7 @@ resource "vcd_vm" "{{.VmName}}" {
     unit_number = 0
   }
 
-  depends_on = [vcd_network_routed_v2.{{.NetworkName}}, vcd_network_isolated_v2.net-test, 
-                vcd_nsxt_network_imported.imported-test]
+  depends_on = [vcd_independent_disk.{{.diskResourceName}}]
 }
 
 output "disk" {
@@ -371,6 +386,78 @@ output "vm" {
   value = vcd_vm.{{.VmName}}
   
   sensitive = true
+}
+`
+
+const testAccCheckVcdNsxtStandaloneVm_basicCleanup = `
+data "vcd_nsxt_edgegateway" "existing" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.EdgeGateway}}"
+}
+
+resource "vcd_network_routed_v2" "{{.NetworkName}}" {
+  name            = "{{.NetworkName}}"
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  gateway         = "10.10.102.1"
+  prefix_length   = 24
+
+  static_ip_pool {
+    start_address = "10.10.102.2"
+    end_address   = "10.10.102.200"
+  }
+
+  depends_on = [vcd_nsxt_network_imported.imported-test]
+}
+
+resource "vcd_network_isolated_v2" "net-test" {
+  name            = "{{.NetworkName}}-isolated"
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  
+  gateway         = "110.10.102.1"
+  prefix_length   = 26
+
+  static_ip_pool {
+    start_address = "110.10.102.2"
+    end_address   = "110.10.102.20"
+  }
+}
+
+resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  
+  org_network_id  = vcd_network_routed_v2.{{.NetworkName}}.id
+
+  pool {
+    start_address = "10.10.102.210"
+    end_address   = "10.10.102.220"
+  }
+
+  pool {
+    start_address = "10.10.102.230"
+    end_address   = "10.10.102.240"
+  }
+}
+
+resource "vcd_nsxt_network_imported" "imported-test" {
+  name            = "{{.NetworkName}}-imported"
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  gateway         = "12.12.2.1"
+  prefix_length   = 24
+
+  nsxt_logical_switch_name = "{{.ImportSegment}}"
+
+  static_ip_pool {
+    start_address = "12.12.2.10"
+    end_address   = "12.12.2.15"
+  }
+
+  depends_on = [vcd_network_isolated_v2.net-test]
 }
 `
 

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -249,7 +249,7 @@ resource "vcd_network_isolated_v2" "net-test" {
     end_address   = "110.10.102.20"
   }
 
-  depends_on = [vcd_network_routed_v2.{{.NetworkName}}]
+  depends_on = [vcd_nsxt_network_imported.imported-test]
 }
 
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
@@ -283,7 +283,7 @@ resource "vcd_nsxt_network_imported" "imported-test" {
     end_address   = "12.12.2.15"
   }
 
-  depends_on = [vcd_network_isolated_v2.net-test]
+  depends_on = [vcd_network_routed_v2.{{.NetworkName}}]
 }
 
 resource "vcd_independent_disk" "{{.diskResourceName}}" {

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -222,7 +222,7 @@ resource "vcd_vm_sizing_policy" "minSize2" {
 
   cpu {
     shares                = "886"
-    limit_in_mhz          = "2400"
+    limit_in_mhz          = "12375"
     count                 = "9"
     speed_in_mhz          = "2500"
     cores_per_socket      = "3"
@@ -237,7 +237,7 @@ resource "vcd_vm_sizing_policy" "minSize3" {
 
   cpu {
     shares                = "886"
-    limit_in_mhz          = "2400"
+    limit_in_mhz          = "12375"
     count                 = "9"
     speed_in_mhz          = "2500"
     cores_per_socket      = "3"
@@ -309,7 +309,7 @@ resource "vcd_vm_sizing_policy" "minSize2" {
 
   cpu {
     shares                = "886"
-    limit_in_mhz          = "2400"
+    limit_in_mhz          = "12375"
     count                 = "9"
     speed_in_mhz          = "2500"
     cores_per_socket      = "3"
@@ -324,7 +324,7 @@ resource "vcd_vm_sizing_policy" "minSize3" {
 
   cpu {
     shares                = "886"
-    limit_in_mhz          = "2400"
+    limit_in_mhz          = "12375"
     count                 = "9"
     speed_in_mhz          = "2500"
     cores_per_socket      = "3"

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -29,7 +29,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 		"Description": "TestAccVcdVmSizingPolicyDescription",
 
 		"CpuShare":       "886",
-		"CpuLimit":       "2400",
+		"CpuLimit":       "12375",
 		"CpuCount":       "9",
 		"CpuSpeed":       "2500",
 		"CoresPerSocket": "3",

--- a/website/docs/r/external_network_v2.html.markdown
+++ b/website/docs/r/external_network_v2.html.markdown
@@ -70,7 +70,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt-t0" {
 }
 ```
 
-## Example Usage (NSX-T segment backed external network [only VCD 10.3+])
+## Example Usage (NSX-T Segment backed External Network with a Direct Org VDC network [only VCD 10.3+])
 
 ```hcl
 data "vcd_nsxt_manager" "main" {
@@ -112,6 +112,15 @@ resource "vcd_external_network_v2" "ext-net-nsxt-segment" {
       end_address   = "14.14.14.25"
     }
   }
+}
+
+resource "vcd_network_direct" "net" {
+  vdc = "nsxt-vdc"
+
+  name             = "direct-net"
+  external_network = vcd_external_network_v2.ext-net-nsxt-segment.name
+
+  depends_on = [vcd_external_network_v2.ext-net-nsxt]
 }
 ```
 

--- a/website/docs/r/external_network_v2.html.markdown
+++ b/website/docs/r/external_network_v2.html.markdown
@@ -20,7 +20,7 @@ requires at least VCD *10.0+*. It supports both NSX-T and NSX-V backed networks 
 
 Supported in provider *v3.0+*.
 
-## Example Usage (NSX-T backed external network)
+## Example Usage (NSX-T Tier 0 router backed external network)
 
 ```hcl
 data "vcd_nsxt_manager" "main" {
@@ -32,9 +32,9 @@ data "vcd_nsxt_tier0_router" "router" {
   nsxt_manager_id = data.vcd_nsxt_manager.main.id
 }
 
-resource "vcd_external_network_v2" "ext-net-nsxt" {
+resource "vcd_external_network_v2" "ext-net-nsxt-t0" {
   name        = "nsxt-external-network"
-  description = "First NSX-T backed network"
+  description = "First NSX-T Tier 0 router backed network"
 
   nsxt_network {
     nsxt_manager_id      = data.vcd_nsxt_manager.main.id
@@ -62,6 +62,51 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
       end_address   = "14.14.14.15"
     }
 
+    static_ip_pool {
+      start_address = "14.14.14.20"
+      end_address   = "14.14.14.25"
+    }
+  }
+}
+```
+
+## Example Usage (NSX-T segment backed external network [only VCD 10.3+])
+
+```hcl
+data "vcd_nsxt_manager" "main" {
+  name = "nsxManager"
+}
+
+resource "vcd_external_network_v2" "ext-net-nsxt-segment" {
+  name        = "nsxt-external-network"
+  description = "First NSX-T segment backed network"
+
+  nsxt_network {
+    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name = "existing-nsxt-segment-
+  }
+
+  ip_scope {
+    enabled       = false
+    gateway       = "88.88.88.1"
+    prefix_length = "24"
+
+    static_ip_pool {
+      start_address = "88.88.88.88"
+      end_address   = "88.88.88.100"
+    }
+  }
+
+  ip_scope {
+    # enabled       = true # by default
+    gateway       = "14.14.14.1"
+    prefix_length = "24"
+
+    static_ip_pool {
+      start_address = "14.14.14.10"
+      end_address   = "14.14.14.15"
+    }
+    
     static_ip_pool {
       start_address = "14.14.14.20"
       end_address   = "14.14.14.25"
@@ -142,8 +187,10 @@ The following arguments are supported:
 ## NSX-T Network
 
 * `nsxt_manager_id` - (Required) NSX-T manager ID. Can be looked up using [`vcd_nsxt_manager`](/docs/providers/vcd/d/nsxt_manager.html) data source.
-* `nsxt_tier0_router_id` - (Required) NSX-T Tier-0 router ID. Can be looked up using
+* `nsxt_tier0_router_id` - (Optional) NSX-T Tier-0 router ID. Can be looked up using
   [`vcd_nsxt_tier0_router`](/docs/providers/vcd/d/nsxt_tier0_router.html) data source.
+* `nsxt_segment_name` - (Optional; *v3.4+*; *VCD 10.3+*) Existing NSX-T segment name. **Note** due to API limitations this
+value will not be read on refresh.
 
 ## Importing
 

--- a/website/docs/r/external_network_v2.html.markdown
+++ b/website/docs/r/external_network_v2.html.markdown
@@ -83,7 +83,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt-segment" {
 
   nsxt_network {
     nsxt_manager_id   = data.vcd_nsxt_manager.main.id
-    nsxt_segment_name = "existing-nsxt-segment-
+    nsxt_segment_name = "existing-nsxt-segment"
   }
 
   ip_scope {
@@ -189,8 +189,7 @@ The following arguments are supported:
 * `nsxt_manager_id` - (Required) NSX-T manager ID. Can be looked up using [`vcd_nsxt_manager`](/docs/providers/vcd/d/nsxt_manager.html) data source.
 * `nsxt_tier0_router_id` - (Optional) NSX-T Tier-0 router ID. Can be looked up using
   [`vcd_nsxt_tier0_router`](/docs/providers/vcd/d/nsxt_tier0_router.html) data source.
-* `nsxt_segment_name` - (Optional; *v3.4+*; *VCD 10.3+*) Existing NSX-T segment name. **Note** due to API limitations this
-value will not be read on refresh.
+* `nsxt_segment_name` - (Optional; *v3.4+*; *VCD 10.3+*) Existing NSX-T segment name.
 
 ## Importing
 

--- a/website/docs/r/external_network_v2.html.markdown
+++ b/website/docs/r/external_network_v2.html.markdown
@@ -20,7 +20,7 @@ requires at least VCD *10.0+*. It supports both NSX-T and NSX-V backed networks 
 
 Supported in provider *v3.0+*.
 
-## Example Usage (NSX-T Tier 0 router backed external network)
+## Example Usage (NSX-T Tier 0 Router backed External Network)
 
 ```hcl
 data "vcd_nsxt_manager" "main" {
@@ -71,6 +71,10 @@ resource "vcd_external_network_v2" "ext-net-nsxt-t0" {
 ```
 
 ## Example Usage (NSX-T Segment backed External Network with a Direct Org VDC network [only VCD 10.3+])
+
+-> NSX-T **Segment backed External Network** is similar to **Imported Org VDC network**. The difference is that
+**External Network can consume one NSX-T Segment and then many VDCs can use it by using NSX-T Direct Network**, 
+while Org VDC Imported network directly requires one NSX-T Segment
 
 ```hcl
 data "vcd_nsxt_manager" "main" {


### PR DESCRIPTION
VCD 10.3 introduces new type of NSX-T External network - Segment backed external network. This PR adds support for this feature and adds related tests.

Additionally there is some fine tuning done for upgrade tests due to Go 1.17 and last version having non 0  patch version (3.3.1).