### PR TITLE
Send Media reference alongside CreateVM (fix boot image media connection)

### DIFF
--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -2509,8 +2509,8 @@ func addEmptyVm(d *schema.ResourceData, vcdClient *VCDClient, org *govcd.Org, vd
 				NetworkConnectionSection:  recomposeVAppParamsForEmptyVm.CreateItem.NetworkConnectionSection,
 				VmSpecSection:             recomposeVAppParamsForEmptyVm.CreateItem.VmSpecSection,
 				GuestCustomizationSection: recomposeVAppParamsForEmptyVm.CreateItem.GuestCustomizationSection,
-				Media:                     mediaReference,
 			},
+			Media: mediaReference,
 			Xmlns: types.XMLNamespaceVCloud,
 		}
 		newVm, err = vdc.CreateStandaloneVm(&params)


### PR DESCRIPTION
I am hitting a problem with standalone VM creation (via `resource "vcd_vm"`) where the boot image media won't get connected.

This PR fixes it by sending the boot image media reference directly inside the `CreateVmParams` root element. This was tested against VMware Cloud Director version 10.3.0.18295834