### PR TITLE
Primary NIC in VM can be removed cold way only

### DIFF
--- a/.changes/v3.4.0/716-bug-fixes.md
+++ b/.changes/v3.4.0/716-bug-fixes.md
@@ -1,1 +1,1 @@
-* Primary NIC for `vcd_vapp_vm` and `vcd_vapp` is done in cold fashion [GH-716]
+* Primary NIC removal for `vcd_vapp_vm` and `vcd_vapp` is done in cold fashion [GH-716]

--- a/.changes/v3.4.0/716-bug-fixes.md
+++ b/.changes/v3.4.0/716-bug-fixes.md
@@ -1,0 +1,1 @@
+* Primary NIC for `vcd_vapp_vm` and `vcd_vapp` is done in cold fashion [GH-716]

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -15,8 +15,8 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 	var (
 		vapp        govcd.VApp
 		vm          govcd.VM
-		netVappName string = t.Name()
-		netVmName1  string = t.Name() + "VM"
+		netVappName = t.Name()
+		netVmName1  = t.Name() + "VM"
 	)
 
 	var params = StringMap{


### PR DESCRIPTION
Latest versions of VCD 10.2.2.1 and 10.3 do not allow to hot remove Primary NIC from a powered on VM and it requires a power off. `vcd_vapp_vm` and `vcd_vm` still try to hot remove a NIC and this returns an error.
This PR patches VM update so that Primary NIC removal is done in cold fashion (powers off VM).

This test `TestAccVcdVAppVmMultiNIC` triggers the problem before patch.