### PR TITLE
Improve bug reporting interface

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a later match takes
+# precedence,  @lvirbalas, @dataclouder, and @Didainius will be requested for review when someone
+# opens a pull request.
+*       @lvirbalas @dataclouder @Didainius

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -28,7 +28,7 @@ without modules. It will help us to respond and replicate the problem quicker. I
 some HCL error while doing so.
 
 For bigger configs you may use [Gist(s)](https://gist.github.com) or a service like Dropbox and
-share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
+share a link to the ZIP file.
 ```
 
 ### Debug Output
@@ -64,8 +64,8 @@ Please list the steps required to reproduce the issue, for example:
 1. `terraform apply`
 
 ### Important Factoids
-Are there anything atypical about your accounts that we should know?
+Is there anything atypical about your accounts that we should know?
 
 ### References
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:
-- GH-1234
+- Issue #0000

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,22 +1,34 @@
-Hi there,
+---
+name: Bug Report
+about: If something isn't working as expected.
 
-Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved for bug reports and feature requests. For general usage questions, please see: https://www.terraform.io/community.html.
+---
+
+Hello,
+
+Thank you for opening an issue. Please note that we try to keep the Terraform issue tracker reserved
+for bug reports and feature requests. For general usage questions, please see:
+https://www.terraform.io/community.html.
 
 ### Terraform Version
 Run `terraform -v` to show the version. If you are not running the latest version of Terraform, please upgrade because your issue may have already been fixed.
 
 ### Affected Resource(s)
 Please list the resources as a list, for example:
-- opc_instance
-- opc_storage_volume
+- vcd_vapp_vm
+- vcd_network_routed_v2
 
 If this issue appears to affect multiple resources, it may be an issue with Terraform's core, so please mention this.
 
 ### Terraform Configuration Files
+
 ```hcl
-# Copy-paste your Terraform configurations here - for large Terraform configs,
-# please use a service like Dropbox and share a link to the ZIP file. For
-# security, you can also encrypt the files using our GPG public key.
+Copy-paste your Terraform configurations here. Please **shrink HCL replicating the bug to minimum** 
+without modules. It will help us to respond and replicate the problem quicker. It may also uncover
+some HCL error while doing so.
+
+For bigger configs you may use [Gist(s)](https://gist.github.com) or a service like Dropbox and
+share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
 ```
 
 ### Debug Output
@@ -52,7 +64,7 @@ Please list the steps required to reproduce the issue, for example:
 1. `terraform apply`
 
 ### Important Factoids
-Are there anything atypical about your accounts that we should know? For example: Running in EC2 Classic? Custom version of OpenStack? Tight ACLs?
+Are there anything atypical about your accounts that we should know?
 
 ### References
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here? For example:

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -63,6 +63,9 @@ What actually happened?
 Please list the steps required to reproduce the issue, for example:
 1. `terraform apply`
 
+### User Access rights 
+Information about user used. Role and/or more exact rights if it is customized.
+
 ### Important Factoids
 Is there anything atypical about your accounts that we should know?
 

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,49 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and might want to implement myself 🙂)!
+labels: enhancement
+---
+
+<!--- Please keep this note for the community --->
+
+### Community Note
+
+* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
+* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
+* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+
+<!--- Thank you for keeping this note for the community --->
+
+### Description
+
+<!--- Please leave a helpful description of the feature request here. --->
+
+### New or Affected Resource(s)
+
+<!--- Please list the new or affected resources and data sources. --->
+
+* vcd_XXX
+
+### Potential Terraform Configuration
+
+<!--- Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code --->
+
+```hcl
+Copy-paste your Terraform configurations here. Please **shrink HCL replicating the bug to minimum** 
+without modules. It will help us to respond and replicate the problem quicker. It may also uncover
+some HCL error while doing so.
+
+For bigger configs you may use [Gist(s)](https://gist.github.com) or a service like Dropbox and
+share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
+```
+
+### References
+
+<!---
+Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
+
+Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:
+
+--->
+
+* #0000

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -24,7 +24,7 @@ labels: enhancement
 
 * vcd_XXX
 
-### Potential Terraform Configuration
+### Terraform Configuration (if it applies)
 
 <!--- Information about code formatting: https://help.github.com/articles/basic-writing-and-formatting-syntax/#quoting-code --->
 
@@ -34,7 +34,7 @@ without modules. It will help us to respond and replicate the problem quicker. I
 some HCL error while doing so.
 
 For bigger configs you may use [Gist(s)](https://gist.github.com) or a service like Dropbox and
-share a link to the ZIP file. For security, you can also encrypt the files using our GPG public key.
+share a link to the ZIP file.
 ```
 
 ### References
@@ -46,4 +46,4 @@ Are there any other GitHub issues (open or closed) or pull requests that should 
 
 --->
 
-* #0000
+* Issue #0000

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Terraform Core Bug Reports and Feature Requests
+    url: https://github.com/hashicorp/terraform/issues/new/choose
+    about: Terraform Core, which handles the Terraform configuration language, CLI commands, and resource dependency graph, has its own codebase. Bug reports and feature requests for those pieces of functionality should be directed to that repository.
+  - name: Terraform Language or Workflow Questions
+    url: https://discuss.hashicorp.com/c/terraform-core
+    about: Please ask and answer language or workflow related questions through the Terraform Core Community Forum.


### PR DESCRIPTION
This PR tries to improve on our bug reporting interface.

* Adds `CODEOWNERS` which will add default reviewers to all open issues/PRs

* When clicking a "new issue" it will present such  table of actions:
<img width="1241" alt="image" src="https://user-images.githubusercontent.com/15804230/135807947-e811dc7d-caad-4577-8cc9-31ce3d9ac19c.png">

* The bug report issue gets a highlight that we ask for a "shrunk HCL" replicating the bug. This should ease troubleshooting as digging into big modules is not straight forward.