### PR TITLE
Fix 'make test-binary-validate' command and all HCL errors

### DIFF
--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -188,9 +188,15 @@ function validate_script {
     terraform init > init.out 2>&1
     exit_code=$?
     check_exit_code init.out
+    
     terraform validate > validate.out 2>&1
     exit_code=$?
     check_exit_code validate.out
+    
+    terraform fmt -check > fmt.out 2>&1 || echo "error in ${1}"
+    exit_code=$?
+    #check_exit_code fmt.out
+
     cd - > /dev/null
     rm -rf vtmp
 }

--- a/scripts/test-binary.sh
+++ b/scripts/test-binary.sh
@@ -195,7 +195,7 @@ function validate_script {
     
     terraform fmt -check > fmt.out 2>&1 || echo "error in ${1}"
     exit_code=$?
-    #check_exit_code fmt.out
+    check_exit_code fmt.out
 
     cd - > /dev/null
     rm -rf vtmp

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -290,8 +290,8 @@ provider "vcd" {
   allow_unverified_ssl = "{{.AllowInsecure}}"
   max_retry_timeout    = {{.MaxRetryTimeout}}
   #version             = "~> {{.VersionRequired}}"
-  logging              = {{.Logging}}
-  logging_file         = "{{.LoggingFile}}"
+  logging      = {{.Logging}}
+  logging_file = "{{.LoggingFile}}"
 }
 `
 )

--- a/vcd/datasource_vcd_catalog_item_test.go
+++ b/vcd/datasource_vcd_catalog_item_test.go
@@ -120,7 +120,7 @@ resource "vcd_catalog_item" "{{.NewCatalogItem}}" {
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    catalogItem_metadata = "catalogItem Metadata"
+    catalogItem_metadata  = "catalogItem Metadata"
     catalogItem_metadata2 = "catalogItem Metadata2"
   }
 }

--- a/vcd/datasource_vcd_catalog_media_test.go
+++ b/vcd/datasource_vcd_catalog_media_test.go
@@ -95,7 +95,7 @@ resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    catalogMedia_metadata = "catalogMedia Metadata"
+    catalogMedia_metadata  = "catalogMedia Metadata"
     catalogMedia_metadata2 = "catalogMedia Metadata2"
   }
 }

--- a/vcd/datasource_vcd_catalog_media_test.go
+++ b/vcd/datasource_vcd_catalog_media_test.go
@@ -84,7 +84,7 @@ func catalogMediaDestroyed(catalog, mediaName string) resource.TestCheckFunc {
 }
 
 const testAccCheckVcdCatalogMediaDS = `
-resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+resource "vcd_catalog_media" "{{.CatalogMediaName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 

--- a/vcd/datasource_vcd_independent_disk_test.go
+++ b/vcd/datasource_vcd_independent_disk_test.go
@@ -152,15 +152,15 @@ data "vcd_independent_disk" "{{.datasourceNameWithId}}" {
 }
 
 output "iops" {
-  value      = data.vcd_independent_disk.{{.datasourceNameWithId}}.iops
+  value = data.vcd_independent_disk.{{.datasourceNameWithId}}.iops
 }
 output "owner_name" {
-  value      = data.vcd_independent_disk.{{.datasourceNameWithId}}.owner_name
+  value = data.vcd_independent_disk.{{.datasourceNameWithId}}.owner_name
 }
 output "datastore_name" {
-  value      = data.vcd_independent_disk.{{.datasourceNameWithId}}.datastore_name
+  value = data.vcd_independent_disk.{{.datasourceNameWithId}}.datastore_name
 }
 output "is_attached" {
-  value      = data.vcd_independent_disk.{{.datasourceNameWithId}}.is_attached
+  value = data.vcd_independent_disk.{{.datasourceNameWithId}}.is_attached
 }
 `

--- a/vcd/datasource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_test.go
@@ -129,7 +129,7 @@ data "vcd_nsxt_tier0_router" "router" {
 }
 
 resource "vcd_external_network_v2" "ext-net-nsxt" {
-  name        = "test-nsxt-external-network"
+  name = "test-nsxt-external-network"
 
   nsxt_network {
     nsxt_manager_id      = data.vcd_nsxt_manager.main.id
@@ -194,53 +194,53 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
 
 
 resource "vcd_nsxt_edgegateway" "nsxt-edge" {
-  org                     = "{{.Org}}"
-  vdc                     = "{{.NsxtVdc}}"
-  name                    = "{{.NsxtEdgeGatewayVcd}}"
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+  name = "{{.NsxtEdgeGatewayVcd}}"
 
   external_network_id = vcd_external_network_v2.ext-net-nsxt.id
 
   subnet {
-     gateway       = "88.88.88.1"
-     prefix_length = "24"
+    gateway       = "88.88.88.1"
+    prefix_length = "24"
 
-     allocated_ips {
-       start_address = "88.88.88.91"
-       end_address   = "88.88.88.92"
-     }
+    allocated_ips {
+      start_address = "88.88.88.91"
+      end_address   = "88.88.88.92"
+    }
 
-     allocated_ips {
-       start_address = "88.88.88.94"
-       end_address   = "88.88.88.95"
-     }
+    allocated_ips {
+      start_address = "88.88.88.94"
+      end_address   = "88.88.88.95"
+    }
 
-     allocated_ips {
-       start_address = "88.88.88.97"
-       end_address   = "88.88.88.98"
-     }
+    allocated_ips {
+      start_address = "88.88.88.97"
+      end_address   = "88.88.88.98"
+    }
   }
 
   subnet {
-     gateway       = "99.99.99.1"
-     prefix_length = "25"
-	 # primary_ip should fall into defined "allocated_ips" as otherwise next apply will report additional range of
-	 # "allocated_ips" with the range containing single "primary_ip" and will cause non-empty plan.
-     primary_ip    = "99.99.99.23"
+    gateway       = "99.99.99.1"
+    prefix_length = "25"
+    # primary_ip should fall into defined "allocated_ips" as otherwise next apply will report additional range of
+    # "allocated_ips" with the range containing single "primary_ip" and will cause non-empty plan.
+    primary_ip = "99.99.99.23"
 
-     allocated_ips {
-       start_address = "99.99.99.22"
-       end_address   = "99.99.99.24"
-     }
+    allocated_ips {
+      start_address = "99.99.99.22"
+      end_address   = "99.99.99.24"
+    }
   }
 
   subnet {
-     gateway       = "77.77.77.1"
-     prefix_length = "26"
+    gateway       = "77.77.77.1"
+    prefix_length = "26"
 
-     allocated_ips {
-       start_address = "77.77.77.10"
-       end_address   = "77.77.77.12"
-	 }
+    allocated_ips {
+      start_address = "77.77.77.10"
+      end_address   = "77.77.77.12"
+    }
   }
 }
 `

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -102,7 +102,7 @@ resource "vcd_org" "{{.OrgName2}}" {
   delay_after_power_on_seconds = data.vcd_org.{{.OrgName1}}.delay_after_power_on_seconds
   delete_force                 = "true"
   delete_recursive             = "true"
- vapp_lease {
+  vapp_lease {
     maximum_runtime_lease_in_sec          = data.vcd_org.{{.OrgName1}}.vapp_lease.0.maximum_runtime_lease_in_sec
     power_off_on_runtime_lease_expiration = data.vcd_org.{{.OrgName1}}.vapp_lease.0.power_off_on_runtime_lease_expiration
     maximum_storage_lease_in_sec          = data.vcd_org.{{.OrgName1}}.vapp_lease.0.maximum_storage_lease_in_sec

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -109,8 +109,8 @@ resource "vcd_org" "{{.OrgName2}}" {
     delete_on_storage_lease_expiration    = data.vcd_org.{{.OrgName1}}.vapp_lease.0.delete_on_storage_lease_expiration
   }
   vapp_template_lease {
-    maximum_storage_lease_in_sec          = data.vcd_org.{{.OrgName1}}.vapp_template_lease.0.maximum_storage_lease_in_sec
-    delete_on_storage_lease_expiration    = data.vcd_org.{{.OrgName1}}.vapp_template_lease.0.delete_on_storage_lease_expiration
+    maximum_storage_lease_in_sec       = data.vcd_org.{{.OrgName1}}.vapp_template_lease.0.maximum_storage_lease_in_sec
+    delete_on_storage_lease_expiration = data.vcd_org.{{.OrgName1}}.vapp_template_lease.0.delete_on_storage_lease_expiration
   }
 }
 `

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -174,13 +174,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 
   compute_capacity {
     cpu {
-     allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].allocated
-     limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].limit
+      allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].allocated
+      limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].limit
     }
 
     memory {
-     allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].allocated
-     limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].limit
+      allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].allocated
+      limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].limit
     }
   }
 
@@ -218,13 +218,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 
   compute_capacity {
     cpu {
-     allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].allocated
-     limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].limit
+      allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].allocated
+      limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].cpu[0].limit
     }
 
     memory {
-     allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].allocated
-     limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].limit
+      allocated = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].allocated
+      limit     = data.vcd_org_vdc.existingVdc.compute_capacity[0].memory[0].limit
     }
   }
 

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -164,7 +164,7 @@ data "vcd_org_vdc" "existingVdc" {
   name = "{{.ExistingVdcName}}"
 }
 
-resource "vcd_org_vdc" "{{.VdcName}}" { 
+resource "vcd_org_vdc" "{{.VdcName}}" {
   name = "{{.VdcName}}"
   org  = "{{.OrgName}}"
 

--- a/vcd/datasource_vcd_vapp_network_test.go
+++ b/vcd/datasource_vcd_vapp_network_test.go
@@ -154,7 +154,6 @@ resource "vcd_vapp_network" "createdVappNetwork" {
   org_network_name      = vcd_network_routed.{{.orgNetwork}}.name
   retain_ip_mac_enabled = "{{.retainIpMacEnabled}}"
 }
- 
 
 data "vcd_vapp_network" "network-ds" {
   name       = vcd_vapp_network.createdVappNetwork.name
@@ -163,22 +162,22 @@ data "vcd_vapp_network" "network-ds" {
 }
 
 output "netmask" {
-  value = data.vcd_vapp_network.network-ds.netmask 
+  value = data.vcd_vapp_network.network-ds.netmask
 }
 output "description" {
-  value = data.vcd_vapp_network.network-ds.description 
+  value = data.vcd_vapp_network.network-ds.description
 }
 output "gateway" {
-  value = data.vcd_vapp_network.network-ds.gateway 
+  value = data.vcd_vapp_network.network-ds.gateway
 }
 output "dns1" {
-  value = data.vcd_vapp_network.network-ds.dns1 
+  value = data.vcd_vapp_network.network-ds.dns1
 }
 output "dns2" {
-  value = data.vcd_vapp_network.network-ds.dns2 
+  value = data.vcd_vapp_network.network-ds.dns2
 }
 output "dnsSuffix" {
-  value = data.vcd_vapp_network.network-ds.dns_suffix 
+  value = data.vcd_vapp_network.network-ds.dns_suffix
 }
 output "guestVlanAllowed" {
   value = data.vcd_vapp_network.network-ds.guest_vlan_allowed

--- a/vcd/datasource_vcd_vapp_network_test.go
+++ b/vcd/datasource_vcd_vapp_network_test.go
@@ -5,8 +5,9 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
@@ -156,47 +157,47 @@ resource "vcd_vapp_network" "createdVappNetwork" {
  
 
 data "vcd_vapp_network" "network-ds" {
-  name       =  vcd_vapp_network.createdVappNetwork.name
+  name       = vcd_vapp_network.createdVappNetwork.name
   vapp_name  = "{{.vappName}}"
-  depends_on =  [vcd_vapp_network.createdVappNetwork]
+  depends_on = [vcd_vapp_network.createdVappNetwork]
 }
 
 output "netmask" {
   value = data.vcd_vapp_network.network-ds.netmask 
-} 
+}
 output "description" {
   value = data.vcd_vapp_network.network-ds.description 
-} 
+}
 output "gateway" {
   value = data.vcd_vapp_network.network-ds.gateway 
-} 
+}
 output "dns1" {
   value = data.vcd_vapp_network.network-ds.dns1 
-} 
+}
 output "dns2" {
   value = data.vcd_vapp_network.network-ds.dns2 
-} 
+}
 output "dnsSuffix" {
   value = data.vcd_vapp_network.network-ds.dns_suffix 
-} 
+}
 output "guestVlanAllowed" {
   value = data.vcd_vapp_network.network-ds.guest_vlan_allowed
-} 
+}
 output "dhcpStartAddress" {
-  value  = tolist(data.vcd_vapp_network.network-ds.dhcp_pool)[0].start_address
+  value = tolist(data.vcd_vapp_network.network-ds.dhcp_pool)[0].start_address
 }
 output "dhcpEndAddress" {
-  value  = tolist(data.vcd_vapp_network.network-ds.dhcp_pool)[0].end_address
+  value = tolist(data.vcd_vapp_network.network-ds.dhcp_pool)[0].end_address
 }
 output "staticIpPoolStartAddress" {
-  value  = tolist(data.vcd_vapp_network.network-ds.static_ip_pool)[0].start_address
+  value = tolist(data.vcd_vapp_network.network-ds.static_ip_pool)[0].start_address
 }
 output "staticIpPoolEndAddress" {
-  value  = tolist(data.vcd_vapp_network.network-ds.static_ip_pool)[0].end_address
+  value = tolist(data.vcd_vapp_network.network-ds.static_ip_pool)[0].end_address
 }
 output "orgNetwork" {
   value = data.vcd_vapp_network.network-ds.org_network_name
-} 
+}
 output "retain_ip_mac_enabled" {
   value = data.vcd_vapp_network.network-ds.retain_ip_mac_enabled
 }

--- a/vcd/datasource_vcd_vapp_org_network_test.go
+++ b/vcd/datasource_vcd_vapp_org_network_test.go
@@ -84,10 +84,10 @@ resource "vcd_network_routed" "{{.orgNetwork}}" {
 }
 
 resource "vcd_vapp_org_network" "createVappOrgNetwork" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.vappName}}.name
-  org_network_name   = vcd_network_routed.{{.orgNetwork}}.name
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.vappName}}.name
+  org_network_name = vcd_network_routed.{{.orgNetwork}}.name
   
   is_fenced = "{{.isFenced}}"
 
@@ -97,10 +97,10 @@ resource "vcd_vapp_org_network" "createVappOrgNetwork" {
 data "vcd_vapp_org_network" "network-ds" {
   vapp_name        = "{{.vappName}}"
   org_network_name = vcd_vapp_org_network.createVappOrgNetwork.org_network_name
-  depends_on 	   = [vcd_vapp_org_network.createVappOrgNetwork]
+  depends_on       = [vcd_vapp_org_network.createVappOrgNetwork]
 }
 
 output "retain_ip_mac_enabled" {
   value = data.vcd_vapp_org_network.network-ds.retain_ip_mac_enabled
-}  
+}
 `

--- a/vcd/datasource_vcd_vapp_org_network_test.go
+++ b/vcd/datasource_vcd_vapp_org_network_test.go
@@ -88,7 +88,7 @@ resource "vcd_vapp_org_network" "createVappOrgNetwork" {
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.vappName}}.name
   org_network_name = vcd_network_routed.{{.orgNetwork}}.name
-  
+
   is_fenced = "{{.isFenced}}"
 
   retain_ip_mac_enabled = "{{.retainIpMacEnabled}}"

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -76,10 +76,10 @@ resource "vcd_vapp_vm" "web1" {
 }
 
 data "vcd_vapp_vm" "vm-ds" {
-  name             = vcd_vapp_vm.web1.name
-  vapp_name        = vcd_vapp.web.name
-  org              = "{{.Org}}"
-  vdc              = "{{.VDC}}"
-  depends_on       = [vcd_vapp_vm.web1]
+  name       = vcd_vapp_vm.web1.name
+  vapp_name  = vcd_vapp.web.name
+  org        = "{{.Org}}"
+  vdc        = "{{.VDC}}"
+  depends_on = [vcd_vapp_vm.web1]
 }
 `

--- a/vcd/datasource_vcenter_test.go
+++ b/vcd/datasource_vcenter_test.go
@@ -48,6 +48,6 @@ func TestAccVcdVcenter(t *testing.T) {
 
 const datasourceTestVcenter = `
 data "vcd_vcenter" "vc" {
-	name = "{{.Vcenter}}"
-  }
+  name = "{{.Vcenter}}"
+}
 `

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -344,12 +344,12 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   delete_force             = true
   delete_recursive         = true
 
-{{if .FlexElasticValueUpdate}}
-  {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValueUpdate}}
+{{if .FlexElasticValue}}
+  {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValue}}
 {{end}}
 
-{{if .FlexMemoryOverheadValueUpdate}}
-  {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
+{{if .FlexMemoryOverheadValue}}
+  {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValue}}
 {{end}}
 }
 `

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -383,9 +383,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     default = true
   }
 
-{{if .SecondStorageProfile}}
-  {{.SecondStorageProfile}}
-{{end}}
+{{if .SecondStorageProfile}}{{.SecondStorageProfile}}{{end}}
 
   metadata = {
     vdc_metadata  = "VDC Metadata"

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -377,7 +377,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     default = true
   }
 
-  {{.SecondStorageProfile}}
+ {{.SecondStorageProfile}}
 
   metadata = {
     vdc_metadata  = "VDC Metadata"

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -383,7 +383,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     default = true
   }
 
-{{if .FlexElasticKey}}
+{{if .SecondStorageProfile}}
   {{.SecondStorageProfile}}
 {{end}}
 

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -344,11 +344,11 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   delete_force             = true
   delete_recursive         = true
 
-{{if .FlexElasticKey}}
+{{if .FlexElasticValueUpdate}}
   {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValueUpdate}}
 {{end}}
 
-{{if .FlexMemoryOverheadKey}}
+{{if .FlexMemoryOverheadValueUpdate}}
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
 {{end}}
 }
@@ -384,7 +384,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
 {{if .FlexElasticKey}}
- {{.SecondStorageProfile}}
+  {{.SecondStorageProfile}}
 {{end}}
 
   metadata = {
@@ -400,11 +400,11 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   delete_force             = false
   delete_recursive         = false
 
-  {{if .FlexElasticKey}}
+{{if .FlexElasticValueUpdate}}
   {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValueUpdate}}
 {{end}}
 
-{{if .FlexMemoryOverheadKey}}
+{{if .FlexMemoryOverheadValueUpdate}}
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
 {{end}}
 }

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -338,13 +338,19 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     vdc_metadata = "VDC Metadata"
   }
 
-  enabled                    = true
-  enable_thin_provisioning   = true
-  enable_fast_provisioning   = true
-  delete_force               = true
-  delete_recursive           = true
-  {{.FlexElasticKey}}        {{.equalsChar}} {{.FlexElasticValue}}
-  {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValue}}
+  enabled                  = true
+  enable_thin_provisioning = true
+  enable_fast_provisioning = true
+  delete_force             = true
+  delete_recursive         = true
+
+{{if .FlexElasticKey}}
+  {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValueUpdate}}
+{{end}}
+
+{{if .FlexMemoryOverheadKey}}
+  {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
+{{end}}
 }
 `
 
@@ -377,7 +383,9 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     default = true
   }
 
+{{if .FlexElasticKey}}
  {{.SecondStorageProfile}}
+{{end}}
 
   metadata = {
     vdc_metadata  = "VDC Metadata"
@@ -392,8 +400,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   delete_force             = false
   delete_recursive         = false
 
-  {{.FlexElasticKey}}        {{.equalsChar}} {{.FlexElasticValueUpdate}}
+  {{if .FlexElasticKey}}
+  {{.FlexElasticKey}} {{.equalsChar}} {{.FlexElasticValueUpdate}}
+{{end}}
+
+{{if .FlexMemoryOverheadKey}}
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
+{{end}}
 }
 `
 

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -384,13 +384,14 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
     vdc_metadata2 = "VDC Metadata2"
   }
 
-  cpu_guaranteed             = {{.CpuGuaranteed}}
-  memory_guaranteed          = {{.MemoryGuaranteed}}
-  enabled                    = false
-  enable_thin_provisioning   = false
-  enable_fast_provisioning   = false
-  delete_force               = false
-  delete_recursive           = false
+  cpu_guaranteed           = {{.CpuGuaranteed}}
+  memory_guaranteed        = {{.MemoryGuaranteed}}
+  enabled                  = false
+  enable_thin_provisioning = false
+  enable_fast_provisioning = false
+  delete_force             = false
+  delete_recursive         = false
+
   {{.FlexElasticKey}}        {{.equalsChar}} {{.FlexElasticValueUpdate}}
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValueUpdate}}
 }

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -187,7 +187,7 @@ const testAccCheckVcdCatalogItemUpdate = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    catalogItem_metadata = "catalogItem Metadata v2"
+    catalogItem_metadata  = "catalogItem Metadata v2"
     catalogItem_metadata2 = "catalogItem Metadata2 v2"
     catalogItem_metadata3 = "catalogItem Metadata3"
   }

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -158,7 +158,7 @@ func testAccCheckCatalogItemDestroy(s *terraform.State) error {
 }
 
 const testAccCheckVcdCatalogItemBasic = `
-  resource "vcd_catalog_item" "{{.CatalogItemName}}" {
+resource "vcd_catalog_item" "{{.CatalogItemName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 
@@ -169,14 +169,14 @@ const testAccCheckVcdCatalogItemBasic = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    catalogItem_metadata = "catalogItem Metadata"
+    catalogItem_metadata  = "catalogItem Metadata"
     catalogItem_metadata2 = "catalogItem Metadata2"
   }
 }
 `
 
 const testAccCheckVcdCatalogItemUpdate = `
-  resource "vcd_catalog_item" "{{.CatalogItemName}}" {
+resource "vcd_catalog_item" "{{.CatalogItemName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -183,7 +183,7 @@ const testAccCheckVcdCatalogMediaBasic = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    mediaItem_metadata = "mediaItem Metadata"
+    mediaItem_metadata  = "mediaItem Metadata"
     mediaItem_metadata2 = "mediaItem Metadata2"
   }
 }
@@ -229,7 +229,7 @@ const testAccCheckVcdCatalogMediaUpdate = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
-    mediaItem_metadata = "mediaItem Metadata v2"
+    mediaItem_metadata  = "mediaItem Metadata v2"
     mediaItem_metadata2 = "mediaItem Metadata2 v2"
     mediaItem_metadata3 = "mediaItem Metadata3"
   }

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -172,7 +172,7 @@ func testAccCheckCatalogMediaDestroy(s *terraform.State) error {
 }
 
 const testAccCheckVcdCatalogMediaBasic = `
-resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+resource "vcd_catalog_media" "{{.CatalogMediaName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 
@@ -218,7 +218,7 @@ output "storage_profile_name" {
 }`
 
 const testAccCheckVcdCatalogMediaUpdate = `
-resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+resource "vcd_catalog_media" "{{.CatalogMediaName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -172,7 +172,7 @@ func testAccCheckCatalogMediaDestroy(s *terraform.State) error {
 }
 
 const testAccCheckVcdCatalogMediaBasic = `
-  resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 
@@ -189,36 +189,36 @@ const testAccCheckVcdCatalogMediaBasic = `
 }
 
 output "creation_date" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.creation_date
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.creation_date
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "is_iso" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.is_iso
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.is_iso
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "owner_name" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.owner_name
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.owner_name
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "is_published" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.is_published
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.is_published
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "size" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.size
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.size
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "status" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.status
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.status
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }
 output "storage_profile_name" {
-  value = vcd_catalog_media.{{.CatalogMediaName}}.storage_profile_name
+  value      = vcd_catalog_media.{{.CatalogMediaName}}.storage_profile_name
   depends_on = [vcd_catalog_media.{{.CatalogMediaName}}]
 }`
 
 const testAccCheckVcdCatalogMediaUpdate = `
-  resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -210,14 +210,14 @@ resource "vcd_catalog" "test-catalog" {
   name        = "{{.CatalogName}}"
   description = "{{.Description}}"
 
-  delete_force      = "true"
-  delete_recursive  = "true"
+  delete_force     = "true"
+  delete_recursive = "true"
 }
 `
 
 const testAccCheckVcdCatalogStep1 = `
 data "vcd_storage_profile" "sp" {
-	name = "{{.StorageProfile}}"
+  name = "{{.StorageProfile}}"
 }
 
 resource "vcd_catalog" "test-catalog" {
@@ -227,8 +227,8 @@ resource "vcd_catalog" "test-catalog" {
   description        = "{{.Description}}"
   storage_profile_id = data.vcd_storage_profile.sp.id
 
-  delete_force      = "true"
-  delete_recursive  = "true"
+  delete_force     = "true"
+  delete_recursive = "true"
 }
 `
 

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -205,7 +205,7 @@ func testAccCheckCatalogDestroy(s *terraform.State) error {
 
 const testAccCheckVcdCatalog = `
 resource "vcd_catalog" "test-catalog" {
-  org = "{{.Org}}" 
+  org = "{{.Org}}"
   
   name        = "{{.CatalogName}}"
   description = "{{.Description}}"
@@ -221,7 +221,7 @@ data "vcd_storage_profile" "sp" {
 }
 
 resource "vcd_catalog" "test-catalog" {
-  org = "{{.Org}}" 
+  org = "{{.Org}}"
   
   name               = "{{.CatalogName}}"
   description        = "{{.Description}}"

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -206,7 +206,7 @@ func testAccCheckCatalogDestroy(s *terraform.State) error {
 const testAccCheckVcdCatalog = `
 resource "vcd_catalog" "test-catalog" {
   org = "{{.Org}}"
-  
+
   name        = "{{.CatalogName}}"
   description = "{{.Description}}"
 
@@ -222,7 +222,7 @@ data "vcd_storage_profile" "sp" {
 
 resource "vcd_catalog" "test-catalog" {
   org = "{{.Org}}"
-  
+
   name               = "{{.CatalogName}}"
   description        = "{{.Description}}"
   storage_profile_id = data.vcd_storage_profile.sp.id

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -365,8 +365,8 @@ resource "vcd_edgegateway_settings" "{{.EgwSettings}}" {
   edge_gateway_id         = data.vcd_edgegateway.egw.id
   lb_enabled              = {{.LbEnabled}}
   lb_acceleration_enabled = {{.LbAccelerationEnabled}}
-  lb_logging_enabled      = {{.LbLoggingEnabled}}       # only set if provider user is system administrator
-  lb_loglevel             = "{{.LbLogLevel}}"           # only set if provider user is system administrator
+  lb_logging_enabled      = {{.LbLoggingEnabled}}  # only set if provider user is system administrator
+  lb_loglevel             = "{{.LbLogLevel}}"      # only set if provider user is system administrator
 
   fw_enabled                      = {{.FwEnabled}}
   fw_default_rule_logging_enabled = {{.FwRuleEnabled}}

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -365,8 +365,9 @@ resource "vcd_edgegateway_settings" "{{.EgwSettings}}" {
   edge_gateway_id         = data.vcd_edgegateway.egw.id
   lb_enabled              = {{.LbEnabled}}
   lb_acceleration_enabled = {{.LbAccelerationEnabled}}
-  lb_logging_enabled      = {{.LbLoggingEnabled}}  # only set if provider user is system administrator
-  lb_loglevel             = "{{.LbLogLevel}}"      # only set if provider user is system administrator
+  # only set logging settings if provider user is system administrator
+  lb_logging_enabled = {{.LbLoggingEnabled}}
+  lb_loglevel        = "{{.LbLogLevel}}"
 
   fw_enabled                      = {{.FwEnabled}}
   fw_default_rule_logging_enabled = {{.FwRuleEnabled}}

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -296,11 +296,11 @@ resource "vcd_external_network" "{{.NewExternalNetwork}}" {
   }
 
   ip_scope {
-    gateway      = "192.168.30.49"
-    netmask      = "255.255.255.240"
-    dns1         = "192.168.0.164"
-    dns2         = "192.168.0.196"
-    dns_suffix   = "company.biz"
+    gateway    = "192.168.30.49"
+    netmask    = "255.255.255.240"
+    dns1       = "192.168.0.164"
+    dns2       = "192.168.0.196"
+    dns_suffix = "company.biz"
 
     static_ip_pool {
       start_address = "192.168.30.51"

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -23,6 +23,11 @@ var (
 
 func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_basic"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -45,10 +50,7 @@ func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 		"Vcenter":               testConfig.Networking.Vcenter,
 	}
 	configText := templateFill(testAccEdgeGatewayBasic, params)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
+
 	if !usingSysAdmin() {
 		t.Skip("Edge Gateway tests require system admin privileges")
 		return
@@ -79,6 +81,11 @@ func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 
 func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_basic"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -100,10 +107,7 @@ func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 		"Vcenter":               testConfig.Networking.Vcenter,
 	}
 	configText := templateFill(testAccEdgeGatewayBasic, params)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
+
 	if !usingSysAdmin() {
 		t.Skip("Edge gateway tests requires system admin privileges")
 		return
@@ -164,6 +168,10 @@ func testAccCheckVcdEdgeGatewayDestroy(edgeName string) resource.TestCheckFunc {
 
 func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_networks"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -188,11 +196,6 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 
 	params["FuncName"] = t.Name() + "-step2"
 	configText1 := templateFill(testAccEdgeGatewayNetworks2, params)
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 
 	if !usingSysAdmin() {
 		t.Skip("Edge gateway tests requires system admin privileges")
@@ -493,6 +496,10 @@ resource "vcd_edgegateway" "egw" {
 // networks.
 func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	var (
 		edgeGatewayVcdName    string = "test_edge_gateway_networks"
 		newExternalNetwork    string = "TestExternalNetwork"
@@ -514,11 +521,6 @@ func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
 		"Vcenter":               testConfig.Networking.Vcenter,
 	}
 	configText := templateFill(testAccEdgeGatewayParallel, params)
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 
 	if !usingSysAdmin() {
 		t.Skip("Edge gateway tests requires system admin privileges")

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -456,34 +456,34 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 
 const testAccEdgeGatewayRateLimits = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	name          = "edge-with-rate-limits"
-	configuration = "compact" 
+  name          = "edge-with-rate-limits"
+  configuration = "compact" 
 
-	external_network {
-	  name = vcd_external_network.{{.NewExternalNetwork}}.name
-	  enable_rate_limit   = {{.EnableRateLimit}}
-	  incoming_rate_limit = {{.IncomingRateLimit}}
-	  outgoing_rate_limit = {{.OutgoingRateLimit}}
+  external_network {
+    name                = vcd_external_network.{{.NewExternalNetwork}}.name
+    enable_rate_limit   = {{.EnableRateLimit}}
+    incoming_rate_limit = {{.IncomingRateLimit}}
+    outgoing_rate_limit = {{.OutgoingRateLimit}}
   
-	  subnet {
-		gateway               = "192.168.30.49"
-		netmask               = "255.255.255.240"
-		use_for_default_route = true
+    subnet {
+      gateway               = "192.168.30.49"
+      netmask               = "255.255.255.240"
+      use_for_default_route = true
 
-		suballocate_pool {
-			start_address = "192.168.30.53"
-			end_address   = "192.168.30.55"
-		}
+      suballocate_pool {
+      	start_address = "192.168.30.53"
+      	end_address   = "192.168.30.55"
+      }
 
-		suballocate_pool {
-			start_address = "192.168.30.58"
-			end_address   = "192.168.30.60"
-		}
-	  }
+      suballocate_pool {
+      	start_address = "192.168.30.58"
+      	end_address   = "192.168.30.60"
+      }
 	}
+  }
 }
 `
 
@@ -561,11 +561,11 @@ resource "vcd_external_network" "{{.NewExternalNetwork}}" {
   }
 
   ip_scope {
-    gateway      = "192.168.30.49"
-    netmask      = "255.255.255.240"
-    dns1         = "192.168.0.164"
-    dns2         = "192.168.0.196"
-    dns_suffix   = "company.biz"
+    gateway    = "192.168.30.49"
+    netmask    = "255.255.255.240"
+    dns1       = "192.168.0.164"
+    dns2       = "192.168.0.196"
+    dns_suffix = "company.biz"
 
     static_ip_pool {
       start_address = "192.168.30.51"
@@ -574,11 +574,11 @@ resource "vcd_external_network" "{{.NewExternalNetwork}}" {
   }
   
 #  ip_scope {
-# 	gateway      = "192.168.40.149"
-# 	netmask      = "255.255.255.0"
-# 	dns1         = "192.168.0.164"
-# 	dns2         = "192.168.0.196"
-# 	dns_suffix   = "company.biz"
+# 	gateway    = "192.168.40.149"
+# 	netmask    = "255.255.255.0"
+# 	dns1       = "192.168.0.164"
+# 	dns2       = "192.168.0.196"
+# 	dns_suffix = "company.biz"
 
 # 	static_ip_pool {
 # 	  start_address = "192.168.40.151"
@@ -613,57 +613,56 @@ resource "vcd_edgegateway" "{{.EdgeGateway}}" {
 
 const testAccEdgeGatewayNetworks = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	org                     = "{{.Org}}"
-	vdc                     = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	name                    = "edge-with-complex-networks"
-	description             = "new edge gateway"
-	configuration           = "compact"
+  name          = "edge-with-complex-networks"
+  description   = "new edge gateway"
+  configuration = "compact"
   
-    # can be only true when system setting Allow FIPS Mode is enabled
-	fips_mode_enabled               = false
-	use_default_route_for_dns_relay = true
-	distributed_routing             = false
+  # can be only true when system setting Allow FIPS Mode is enabled
+  fips_mode_enabled               = false
+  use_default_route_for_dns_relay = true
+  distributed_routing             = false
 
-    lb_enabled              = "true"
-    lb_acceleration_enabled = "true"
-    lb_logging_enabled      = "true"
-    lb_loglevel             = "critical"
+  lb_enabled              = "true"
+  lb_acceleration_enabled = "true"
+  lb_logging_enabled      = "true"
+  lb_loglevel             = "critical"
 
-    fw_enabled                      = "true"
-    fw_default_rule_logging_enabled = "true"
-    fw_default_rule_action          = "accept"
+  fw_enabled                      = "true"
+  fw_default_rule_logging_enabled = "true"
+  fw_default_rule_action          = "accept"
 
-	external_network {
-	  name = vcd_external_network.{{.NewExternalNetwork}}.name
+  external_network {
+    name = vcd_external_network.{{.NewExternalNetwork}}.name
   
-	  subnet {
-		ip_address = "192.168.30.51"
-		gateway = "192.168.30.49"
-		netmask = "255.255.255.240"
-		use_for_default_route = true
+    subnet {
+  	  ip_address            = "192.168.30.51"
+  	  gateway               = "192.168.30.49"
+  	  netmask               = "255.255.255.240"
+  	  use_for_default_route = true
 
-		suballocate_pool {
-			start_address = "192.168.30.53"
-			end_address   = "192.168.30.55"
-		}
+  	  suballocate_pool {
+  	    start_address = "192.168.30.53"
+  	    end_address   = "192.168.30.55"
+  	  }
+  	  suballocate_pool {
+  	    start_address = "192.168.30.58"
+  	    end_address   = "192.168.30.60"
+  	  }
+    }
+  }
 
-		suballocate_pool {
-			start_address = "192.168.30.58"
-			end_address   = "192.168.30.60"
-		}
-	  }
-	}
+  # Attach to existing external network
+  external_network {
+    name = data.vcd_external_network.ds-network.name
 
-	# Attach to existing external network
-	external_network {
-	  name = data.vcd_external_network.ds-network.name
-
-		subnet {
-			# ip_address is skipped here on purpose to get dynamic IP
-			use_for_default_route = false
-			gateway = data.vcd_external_network.ds-network.ip_scope[0].gateway
-			netmask = data.vcd_external_network.ds-network.ip_scope[0].netmask
+    subnet {
+      # ip_address is skipped here on purpose to get dynamic IP
+      use_for_default_route = false
+      gateway               = data.vcd_external_network.ds-network.ip_scope[0].gateway
+      netmask               = data.vcd_external_network.ds-network.ip_scope[0].netmask
 	}
   }
 }
@@ -671,7 +670,7 @@ resource "vcd_edgegateway" "egw" {
 data "vcd_edgegateway" "egw" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
-	
+
   name       = vcd_edgegateway.egw.name
   depends_on = [vcd_edgegateway.egw]
 }
@@ -679,45 +678,45 @@ data "vcd_edgegateway" "egw" {
 # Use data source of existing external network to get needed gateway and netmask
 # for subnet participation details
 data "vcd_external_network" "ds-network" {
-	name = "{{.ExternalNetwork}}"
+  name = "{{.ExternalNetwork}}"
 }
 `
 
 const testAccEdgeGatewayNetworks2 = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	name          = "simple-edge-with-complex-networks"
-	configuration = "compact"
+  name          = "simple-edge-with-complex-networks"
+  configuration = "compact"
 
-	external_network {
-	  name = vcd_external_network.{{.NewExternalNetwork}}.name
-	  subnet {
+  external_network {
+    name = vcd_external_network.{{.NewExternalNetwork}}.name
+    subnet {
 		gateway               = "192.168.30.49"
 		netmask               = "255.255.255.240"
 		use_for_default_route = true
-	  }
-	}
+    }
+  }
 }
 `
 
 const testAccEdgeGatewayParallel = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	count = 2
+  count = 2
 
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	name          = "parallel-${count.index}"
-	configuration = "compact"
+  name          = "parallel-${count.index}"
+  configuration = "compact"
 
-	external_network {
-	  name = vcd_external_network.{{.NewExternalNetwork}}.name
-	  subnet {
-		gateway = "192.168.30.49"
-		netmask = "255.255.255.240"
-	  }
-	}
+  external_network {
+    name = vcd_external_network.{{.NewExternalNetwork}}.name
+    subnet {
+      gateway = "192.168.30.49"
+      netmask = "255.255.255.240"
+    }
+  }
 }
 `

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -460,27 +460,27 @@ resource "vcd_edgegateway" "egw" {
   vdc = "{{.Vdc}}"
 
   name          = "edge-with-rate-limits"
-  configuration = "compact" 
+  configuration = "compact"
 
   external_network {
     name                = vcd_external_network.{{.NewExternalNetwork}}.name
     enable_rate_limit   = {{.EnableRateLimit}}
     incoming_rate_limit = {{.IncomingRateLimit}}
     outgoing_rate_limit = {{.OutgoingRateLimit}}
-  
+
     subnet {
       gateway               = "192.168.30.49"
       netmask               = "255.255.255.240"
       use_for_default_route = true
 
       suballocate_pool {
-      	start_address = "192.168.30.53"
-      	end_address   = "192.168.30.55"
+        start_address = "192.168.30.53"
+        end_address   = "192.168.30.55"
       }
 
       suballocate_pool {
-      	start_address = "192.168.30.58"
-      	end_address   = "192.168.30.60"
+        start_address = "192.168.30.58"
+        end_address   = "192.168.30.60"
       }
 	}
   }
@@ -572,19 +572,19 @@ resource "vcd_external_network" "{{.NewExternalNetwork}}" {
       end_address   = "192.168.30.62"
     }
   }
-  
-#  ip_scope {
-# 	gateway    = "192.168.40.149"
-# 	netmask    = "255.255.255.0"
-# 	dns1       = "192.168.0.164"
-# 	dns2       = "192.168.0.196"
-# 	dns_suffix = "company.biz"
 
-# 	static_ip_pool {
-# 	  start_address = "192.168.40.151"
-# 	  end_address   = "192.168.40.162"
-# 	}
-#   }
+  #  ip_scope {
+  # 	gateway    = "192.168.40.149"
+  # 	netmask    = "255.255.255.0"
+  # 	dns1       = "192.168.0.164"
+  # 	dns2       = "192.168.0.196"
+  # 	dns_suffix = "company.biz"
+
+  # 	static_ip_pool {
+  # 	  start_address = "192.168.40.151"
+  # 	  end_address   = "192.168.40.162"
+  # 	}
+  #   }
 
   retain_net_info_across_deployments = "false"
 }
@@ -636,12 +636,12 @@ resource "vcd_edgegateway" "egw" {
 
   external_network {
     name = vcd_external_network.{{.NewExternalNetwork}}.name
-  
+
     subnet {
-  	  ip_address            = "192.168.30.51"
-  	  gateway               = "192.168.30.49"
-  	  netmask               = "255.255.255.240"
-  	  use_for_default_route = true
+      ip_address            = "192.168.30.51"
+      gateway               = "192.168.30.49"
+      netmask               = "255.255.255.240"
+      use_for_default_route = true
 
   	  suballocate_pool {
   	    start_address = "192.168.30.53"
@@ -693,9 +693,9 @@ resource "vcd_edgegateway" "egw" {
   external_network {
     name = vcd_external_network.{{.NewExternalNetwork}}.name
     subnet {
-		gateway               = "192.168.30.49"
-		netmask               = "255.255.255.240"
-		use_for_default_route = true
+      gateway               = "192.168.30.49"
+      netmask               = "255.255.255.240"
+      use_for_default_route = true
     }
   }
 }

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -456,11 +456,11 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 
 const testAccEdgeGatewayRateLimits = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	org                     = "{{.Org}}"
-	vdc                     = "{{.Vdc}}"
+	org = "{{.Org}}"
+	vdc = "{{.Vdc}}"
 
-	name                    = "edge-with-rate-limits"
-	configuration           = "compact" 
+	name          = "edge-with-rate-limits"
+	configuration = "compact" 
 
 	external_network {
 	  name = vcd_external_network.{{.NewExternalNetwork}}.name
@@ -469,8 +469,8 @@ resource "vcd_edgegateway" "egw" {
 	  outgoing_rate_limit = {{.OutgoingRateLimit}}
   
 	  subnet {
-		gateway = "192.168.30.49"
-		netmask = "255.255.255.240"
+		gateway               = "192.168.30.49"
+		netmask               = "255.255.255.240"
 		use_for_default_route = true
 
 		suballocate_pool {
@@ -592,19 +592,19 @@ resource "vcd_external_network" "{{.NewExternalNetwork}}" {
 
 const testAccEdgeGatewayBasic = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "{{.EdgeGateway}}" {
-  org                     = "{{.Org}}"
-  vdc                     = "{{.Vdc}}"
-  name                    = "{{.EdgeGatewayVcd}}"
-  description             = "Description"
-  configuration           = "compact"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  name          = "{{.EdgeGatewayVcd}}"
+  description   = "Description"
+  configuration = "compact"
 
   external_network {
      name = vcd_external_network.{{.NewExternalNetwork}}.name
    
      subnet {
-		ip_address = "192.168.30.51"
-		gateway = "192.168.30.49"
-		netmask = "255.255.255.240"
+		ip_address            = "192.168.30.51"
+		gateway               = "192.168.30.49"
+		netmask               = "255.255.255.240"
 		use_for_default_route = true
 	}
   }
@@ -672,7 +672,7 @@ data "vcd_edgegateway" "egw" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 	
-  name = vcd_edgegateway.egw.name
+  name       = vcd_edgegateway.egw.name
   depends_on = [vcd_edgegateway.egw]
 }
 
@@ -685,17 +685,17 @@ data "vcd_external_network" "ds-network" {
 
 const testAccEdgeGatewayNetworks2 = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
-	org                     = "{{.Org}}"
-	vdc                     = "{{.Vdc}}"
+	org = "{{.Org}}"
+	vdc = "{{.Vdc}}"
 
-	name                    = "simple-edge-with-complex-networks"
-	configuration           = "compact"
+	name          = "simple-edge-with-complex-networks"
+	configuration = "compact"
 
 	external_network {
 	  name = vcd_external_network.{{.NewExternalNetwork}}.name
 	  subnet {
-		gateway = "192.168.30.49"
-		netmask = "255.255.255.240"
+		gateway               = "192.168.30.49"
+		netmask               = "255.255.255.240"
 		use_for_default_route = true
 	  }
 	}
@@ -706,11 +706,11 @@ const testAccEdgeGatewayParallel = testAccEdgeGatewayComplexNetwork + `
 resource "vcd_edgegateway" "egw" {
 	count = 2
 
-	org                     = "{{.Org}}"
-	vdc                     = "{{.Vdc}}"
+	org = "{{.Org}}"
+	vdc = "{{.Vdc}}"
 
-	name                    = "parallel-${count.index}"
-	configuration           = "compact"
+	name          = "parallel-${count.index}"
+	configuration = "compact"
 
 	external_network {
 	  name = vcd_external_network.{{.NewExternalNetwork}}.name

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -606,7 +606,7 @@ resource "vcd_edgegateway" "{{.EdgeGateway}}" {
       gateway               = "192.168.30.49"
       netmask               = "255.255.255.240"
       use_for_default_route = true
-	}
+    }
   }
 }
 `
@@ -619,7 +619,7 @@ resource "vcd_edgegateway" "egw" {
   name          = "edge-with-complex-networks"
   description   = "new edge gateway"
   configuration = "compact"
-  
+
   # can be only true when system setting Allow FIPS Mode is enabled
   fips_mode_enabled               = false
   use_default_route_for_dns_relay = true

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -482,7 +482,7 @@ resource "vcd_edgegateway" "egw" {
         start_address = "192.168.30.58"
         end_address   = "192.168.30.60"
       }
-	}
+    }
   }
 }
 `
@@ -599,13 +599,13 @@ resource "vcd_edgegateway" "{{.EdgeGateway}}" {
   configuration = "compact"
 
   external_network {
-     name = vcd_external_network.{{.NewExternalNetwork}}.name
-   
-     subnet {
-		ip_address            = "192.168.30.51"
-		gateway               = "192.168.30.49"
-		netmask               = "255.255.255.240"
-		use_for_default_route = true
+    name = vcd_external_network.{{.NewExternalNetwork}}.name
+
+    subnet {
+      ip_address            = "192.168.30.51"
+      gateway               = "192.168.30.49"
+      netmask               = "255.255.255.240"
+      use_for_default_route = true
 	}
   }
 }
@@ -643,14 +643,14 @@ resource "vcd_edgegateway" "egw" {
       netmask               = "255.255.255.240"
       use_for_default_route = true
 
-  	  suballocate_pool {
-  	    start_address = "192.168.30.53"
-  	    end_address   = "192.168.30.55"
-  	  }
-  	  suballocate_pool {
-  	    start_address = "192.168.30.58"
-  	    end_address   = "192.168.30.60"
-  	  }
+      suballocate_pool {
+        start_address = "192.168.30.53"
+        end_address   = "192.168.30.55"
+      }
+      suballocate_pool {
+        start_address = "192.168.30.58"
+        end_address   = "192.168.30.60"
+      }
     }
   }
 
@@ -663,7 +663,7 @@ resource "vcd_edgegateway" "egw" {
       use_for_default_route = false
       gateway               = data.vcd_external_network.ds-network.ip_scope[0].gateway
       netmask               = data.vcd_external_network.ds-network.ip_scope[0].netmask
-	}
+    }
   }
 }
 

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -153,11 +153,11 @@ resource "vcd_external_network" "{{.ExternalNetworkName}}" {
   }
 
   ip_scope {
-    gateway      = "{{.Gateway}}"
-    netmask      = "{{.Netmask}}"
-    dns1         = "{{.Dns1}}"
-    dns2         = "{{.Dns2}}"
-    dns_suffix   = "company.biz"
+    gateway    = "{{.Gateway}}"
+    netmask    = "{{.Netmask}}"
+    dns1       = "{{.Dns1}}"
+    dns2       = "{{.Dns2}}"
+    dns_suffix = "company.biz"
 
     static_ip_pool {
       start_address = "{{.StartAddress}}"

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -204,7 +204,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
       start_address = "14.14.14.10"
       end_address   = "14.14.14.15"
     }
-    
+
     static_ip_pool {
       start_address = "14.14.14.20"
       end_address   = "14.14.14.25"
@@ -788,8 +788,8 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
   description = "{{.Description}}"
 
   nsxt_network {
-    nsxt_manager_id   = data.vcd_nsxt_manager.main.id
-    nsxt_segment_name = "{{.NsxtSegment}}"
+    nsxt_manager_id      = data.vcd_nsxt_manager.main.id
+    nsxt_segment_name    = "{{.NsxtSegment}}"
     nsxt_tier0_router_id = data.vcd_nsxt_tier0_router.router.id
   }
 

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -681,7 +681,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
       start_address = "14.14.14.10"
       end_address   = "14.14.14.15"
     }
-    
+
     static_ip_pool {
       start_address = "14.14.14.20"
       end_address   = "14.14.14.25"
@@ -812,7 +812,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
       start_address = "14.14.14.10"
       end_address   = "14.14.14.15"
     }
-    
+
     static_ip_pool {
       start_address = "14.14.14.20"
       end_address   = "14.14.14.25"
@@ -978,7 +978,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
       start_address = "14.14.14.10"
       end_address   = "14.14.14.15"
     }
-    
+
     static_ip_pool {
       start_address = "14.14.14.20"
       end_address   = "14.14.14.25"

--- a/vcd/resource_vcd_global_role_test.go
+++ b/vcd/resource_vcd_global_role_test.go
@@ -135,7 +135,7 @@ resource "vcd_global_role" "{{.GlobalRoleName}}" {
     "vApp Template / Media: View",
   ]
   publish_to_all_tenants = false
-  tenants                = [ "{{.Tenant}}" ]
+  tenants                = ["{{.Tenant}}"]
 }
 `
 

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -5,9 +5,10 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"regexp"
 	"testing"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -176,7 +177,7 @@ resource "vcd_independent_disk" "{{.ResourceName}}" {
 
 const testAccCheckVcdIndependentDiskWithoutOptionals = `
 resource "vcd_independent_disk" "{{.secondResourceName}}" {
-  name            = "{{.secondName}}"
-  size_in_mb      = "{{.size}}"
+  name       = "{{.secondName}}"
+  size_in_mb = "{{.size}}"
 }
 `

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -181,16 +181,16 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
 }
 
 resource "vcd_vapp" "{{.VappName}}" {
-  name       = "{{.VappName}}"
-  org        = "{{.Org}}"
-  vdc        = "{{.Vdc}}"
+  name = "{{.VappName}}"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -190,7 +190,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VappName}}.name
-  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -143,8 +143,8 @@ func testAccCheckVcdIpSetDestroy(resource, ipSetName string) resource.TestCheckF
 
 const testAccVcdIpSet = `
 resource "vcd_nsxv_ip_set" "test-ipset" {
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
+  org= "{{.Org}}"
+  vdc= "{{.Vdc}}"
 
   name         = "{{.IpSetName}}"
   description  = "test-ip-set-description"
@@ -152,49 +152,49 @@ resource "vcd_nsxv_ip_set" "test-ipset" {
 }
 
 data "vcd_nsxv_ip_set" "test-ipset" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-  
-	name         = vcd_nsxv_ip_set.test-ipset.name
-	depends_on   = [vcd_nsxv_ip_set.test-ipset]
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  name       = vcd_nsxv_ip_set.test-ipset.name
+  depends_on = [vcd_nsxv_ip_set.test-ipset]
 }
 `
 
 const testAccVcdIpSetUpdate = `
 resource "vcd_nsxv_ip_set" "test-ipset" {
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
   name         = "{{.IpSetName}}"
   description  = "test-ip-set-changed-description"
-  ip_addresses = ["10.10.10.1","11.11.11.1"]
+  ip_addresses = ["10.10.10.1", "11.11.11.1"]
 }
 
 data "vcd_nsxv_ip_set" "test-ipset" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-  
-	name         = vcd_nsxv_ip_set.test-ipset.name
-	depends_on   = [vcd_nsxv_ip_set.test-ipset]
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"  
+
+  name       = vcd_nsxv_ip_set.test-ipset.name
+  depends_on = [vcd_nsxv_ip_set.test-ipset]
 }
 `
 
 const testAccVcdIpSetUpdate2 = `
 resource "vcd_nsxv_ip_set" "test-ipset" {
-  org          = "{{.Org}}"
-  vdc          = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
   name                   = "{{.IpSetName}}"
   is_inheritance_allowed = false
   description            = "test-ip-set-changed-description"
-  ip_addresses           = ["1.1.1.1/24","10.10.10.100-10.10.10.110"]
+  ip_addresses           = ["1.1.1.1/24", "10.10.10.100-10.10.10.110"]
 }
 
 data "vcd_nsxv_ip_set" "test-ipset" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-  
-	name         = vcd_nsxv_ip_set.test-ipset.name
-	depends_on   = [vcd_nsxv_ip_set.test-ipset]
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  name       = vcd_nsxv_ip_set.test-ipset.name
+  depends_on = [vcd_nsxv_ip_set.test-ipset]
 }
 `

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -143,12 +143,12 @@ func testAccCheckVcdIpSetDestroy(resource, ipSetName string) resource.TestCheckF
 
 const testAccVcdIpSet = `
 resource "vcd_nsxv_ip_set" "test-ipset" {
-  org= "{{.Org}}"
-  vdc= "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
   name         = "{{.IpSetName}}"
   description  = "test-ip-set-description"
-  ip_addresses = ["192.168.1.1","192.168.2.1"]
+  ip_addresses = ["192.168.1.1", "192.168.2.1"]
 }
 
 data "vcd_nsxv_ip_set" "test-ipset" {
@@ -172,7 +172,7 @@ resource "vcd_nsxv_ip_set" "test-ipset" {
 
 data "vcd_nsxv_ip_set" "test-ipset" {
   org = "{{.Org}}"
-  vdc = "{{.Vdc}}"  
+  vdc = "{{.Vdc}}"
 
   name       = vcd_nsxv_ip_set.test-ipset.name
   depends_on = [vcd_nsxv_ip_set.test-ipset]

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -210,47 +210,47 @@ func testAccCheckVcdLBAppProfileDestroy(appProfileName string) resource.TestChec
 
 const testAccVcdLBAppProfile_TCP = `
 resource "vcd_lb_app_profile" "test" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-  
-	name           = "{{.AppProfileName}}"
-	type           = "{{.Type}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
 
-	enable_ssl_passthrough         = "false"
-	insert_x_forwarded_http_header = "false"
-	enable_pool_side_ssl           = "false"
+  name = "{{.AppProfileName}}"
+  type = "{{.Type}}"
+
+  enable_ssl_passthrough         = "false"
+  insert_x_forwarded_http_header = "false"
+  enable_pool_side_ssl           = "false"
 }
 
 data "vcd_lb_app_profile" "test" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name         = vcd_lb_app_profile.test.name
-	depends_on   = [vcd_lb_app_profile.test]
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = vcd_lb_app_profile.test.name
+  depends_on   = [vcd_lb_app_profile.test]
 }
 `
 
 const testAccVcdLBAppProfile_UDP = `
 resource "vcd_lb_app_profile" "test" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
   
-	name           = "{{.AppProfileName}}"
-	type           = "{{.Type}}"
+  name           = "{{.AppProfileName}}"
+  type           = "{{.Type}}"
 
-	enable_ssl_passthrough         = "true"
-	insert_x_forwarded_http_header = "true"
-	enable_pool_side_ssl           = "true"
+  enable_ssl_passthrough         = "true"
+  insert_x_forwarded_http_header = "true"
+  enable_pool_side_ssl           = "true"
 }
 
 data "vcd_lb_app_profile" "test" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name         = vcd_lb_app_profile.test.name
-	depends_on   = [vcd_lb_app_profile.test]
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = vcd_lb_app_profile.test.name
+  depends_on   = [vcd_lb_app_profile.test]
 }
 `
 
@@ -290,7 +290,7 @@ resource "vcd_lb_app_profile" "test" {
 
   http_redirect_url     = ""
   persistence_mechanism = "sourceip"
-  expiration = "17"
+  expiration            = "17"
 }
 
 data "vcd_lb_app_profile" "test" {
@@ -311,8 +311,8 @@ resource "vcd_lb_app_profile" "test" {
   name = "{{.AppProfileName}}"
   type = "{{.Type}}"
 
-  persistence_mechanism = "sourceip"
-  expiration = 0
+  persistence_mechanism          = "sourceip"
+  expiration                     = 0
   enable_ssl_passthrough         = "true"
   enable_pool_side_ssl           = "true"
   insert_x_forwarded_http_header = "true"

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -236,7 +236,7 @@ resource "vcd_lb_app_profile" "test" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
-  
+
   name = "{{.AppProfileName}}"
   type = "{{.Type}}"
 

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -237,8 +237,8 @@ resource "vcd_lb_app_profile" "test" {
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
   
-  name           = "{{.AppProfileName}}"
-  type           = "{{.Type}}"
+  name = "{{.AppProfileName}}"
+  type = "{{.Type}}"
 
   enable_ssl_passthrough         = "true"
   insert_x_forwarded_http_header = "true"
@@ -276,7 +276,7 @@ data "vcd_lb_app_profile" "test" {
   edge_gateway = "{{.EdgeGateway}}"
   name         = vcd_lb_app_profile.test.name
   depends_on   = [vcd_lb_app_profile.test]
-}  
+}
 `
 
 const testAccVcdLBAppProfile_HTTP_SourceIP = `

--- a/vcd/resource_vcd_lb_app_rule_test.go
+++ b/vcd/resource_vcd_lb_app_rule_test.go
@@ -149,7 +149,7 @@ resource "vcd_lb_app_rule" "test" {
   name   = "{{.AppRuleName}}"
   script = "{{.SingleLineScript}}"
 }
-  
+
 data "vcd_lb_app_rule" "test" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
@@ -168,7 +168,7 @@ resource "vcd_lb_app_rule" "test" {
   name   = "{{.AppRuleName}}"
   script = {{.MultilineScript}}
 }
-  
+
 data "vcd_lb_app_rule" "test" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
@@ -197,5 +197,4 @@ data "vcd_lb_app_rule" "test" {
   name         = vcd_lb_app_rule.test.name
   depends_on   = [vcd_lb_app_rule.test]
 }
-
 `

--- a/vcd/resource_vcd_lb_app_rule_test.go
+++ b/vcd/resource_vcd_lb_app_rule_test.go
@@ -156,7 +156,7 @@ data "vcd_lb_app_rule" "test" {
   edge_gateway = "{{.EdgeGateway}}"
   name         = vcd_lb_app_rule.test.name
   depends_on   = [vcd_lb_app_rule.test]
-}  
+}
 `
 
 const testAccVcdLBAppRule_MultiLine = `
@@ -175,7 +175,7 @@ data "vcd_lb_app_rule" "test" {
   edge_gateway = "{{.EdgeGateway}}"
   name         = vcd_lb_app_rule.test.name
   depends_on   = [vcd_lb_app_rule.test]
-} 
+}
 `
 
 const testAccVcdLBAppRule_FailMultiLine = `

--- a/vcd/resource_vcd_lb_server_pool_test.go
+++ b/vcd/resource_vcd_lb_server_pool_test.go
@@ -239,140 +239,140 @@ func testAccCheckVcdLbServerPoolDestroy(serverPoolName string) resource.TestChec
 
 const testAccVcdLbServerPool_Basic = `
 resource "vcd_lb_server_pool" "server-pool" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-  
-	name                = "{{.ServerPoolName}}"
-	algorithm           = "round-robin"
-	enable_transparency = "{{.EnableTransparency}}"
-  
-	member {
-	  condition       = "enabled"
-	  name            = "member1"
-	  ip_address      = "1.1.1.1"
-	  port            = 8443
-	  monitor_port    = 9000
-	  weight          = 1
-	  min_connections = 0
-	  max_connections = 100
-	}
-  
-	member {
-	  condition       = "drain"
-	  name            = "member2"
-	  ip_address      = "2.2.2.2"
-	  port            = 7000
-	  monitor_port    = 4000
-	  weight          = 2
-	  min_connections = 6
-	  max_connections = 8
-	}
-  
-	member {
-	  condition       = "disabled"
-	  name            = "member3"
-	  ip_address      = "3.3.3.3"
-	  port            = 3333
-	  monitor_port    = 4444
-	  weight          = 6
-	  min_connections = 3
-	  max_connections = 3
-	}
-  
-	member {
-	  condition    = "disabled"
-	  name         = "member4"
-	  ip_address   = "4.4.4.4"
-	  port         = 3333
-	  monitor_port = 4444
-	  weight       = 6
-	}
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+
+  name                = "{{.ServerPoolName}}"
+  algorithm           = "round-robin"
+  enable_transparency = "{{.EnableTransparency}}"
+
+  member {
+    condition       = "enabled"
+    name            = "member1"
+    ip_address      = "1.1.1.1"
+    port            = 8443
+    monitor_port    = 9000
+    weight          = 1
+    min_connections = 0
+    max_connections = 100
   }
-  
-  data "vcd_lb_server_pool" "ds-lb-server-pool" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name         = vcd_lb_server_pool.server-pool.name
-	depends_on   = [vcd_lb_server_pool.server-pool]
-  }  
+
+  member {
+    condition       = "drain"
+    name            = "member2"
+    ip_address      = "2.2.2.2"
+    port            = 7000
+    monitor_port    = 4000
+    weight          = 2
+    min_connections = 6
+    max_connections = 8
+  }
+
+  member {
+    condition       = "disabled"
+    name            = "member3"
+    ip_address      = "3.3.3.3"
+    port            = 3333
+    monitor_port    = 4444
+    weight          = 6
+    min_connections = 3
+    max_connections = 3
+  }
+
+  member {
+    condition    = "disabled"
+    name         = "member4"
+    ip_address   = "4.4.4.4"
+    port         = 3333
+    monitor_port = 4444
+    weight       = 6
+  }
+}
+
+data "vcd_lb_server_pool" "ds-lb-server-pool" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = vcd_lb_server_pool.server-pool.name
+  depends_on   = [vcd_lb_server_pool.server-pool]
+}
 `
 
 const testAccVcdLbServerPool_Algorithm = `
 resource "vcd_lb_service_monitor" "test-monitor" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-  
-	name        = "test-monitor"
-	type        = "tcp"
-	interval    = 10
-	timeout     = 15
-	max_retries = 3
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+
+  name        = "test-monitor"
+  type        = "tcp"
+  interval    = 10
+  timeout     = 15
+  max_retries = 3
+}
+
+resource "vcd_lb_server_pool" "server-pool" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+
+  name                 = "{{.ServerPoolName}}"
+  description          = "description"
+  algorithm            = "httpheader"
+  algorithm_parameters = "headerName=host"
+  enable_transparency  = "{{.EnableTransparency}}"
+
+  monitor_id = vcd_lb_service_monitor.test-monitor.id
+
+  member {
+    condition       = "drain"
+    name            = "member1"
+    ip_address      = "1.1.1.1"
+    port            = 8443
+    monitor_port    = 9000
+    weight          = 1
+    min_connections = 0
+    max_connections = 100
   }
-  
-  resource "vcd_lb_server_pool" "server-pool" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-  
-	name                 = "{{.ServerPoolName}}"
-	description          = "description"
-	algorithm            = "httpheader"
-	algorithm_parameters = "headerName=host"
-	enable_transparency  = "{{.EnableTransparency}}"
-  
-	monitor_id = vcd_lb_service_monitor.test-monitor.id
-  
-	member {
-	  condition       = "drain"
-	  name            = "member1"
-	  ip_address      = "1.1.1.1"
-	  port            = 8443
-	  monitor_port    = 9000
-	  weight          = 1
-	  min_connections = 0
-	  max_connections = 100
-	}
-  
-	member {
-	  condition       = "drain"
-	  name            = "member2"
-	  ip_address      = "2.2.2.2"
-	  port            = 7000
-	  monitor_port    = 4444
-	  weight          = 2
-	  min_connections = 6
-	  max_connections = 8
-	}
-  
-	member {
-	  condition       = "enabled"
-	  name            = "member3"
-	  ip_address      = "3.3.3.3"
-	  port            = 3333
-	  monitor_port    = 4444
-	  weight          = 6
-	  min_connections = 3
-	  max_connections = 3
-	}
-  
-	member {
-	  condition    = "enabled"
-	  name         = "member44"
-	  ip_address   = "6.6.6.6"
-	  port         = 33333
-	  monitor_port = 44444
-	  weight       = 1
-	}
+
+  member {
+    condition       = "drain"
+    name            = "member2"
+    ip_address      = "2.2.2.2"
+    port            = 7000
+    monitor_port    = 4444
+    weight          = 2
+    min_connections = 6
+    max_connections = 8
   }
-  
-  data "vcd_lb_server_pool" "ds-lb-server-pool" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name         = vcd_lb_server_pool.server-pool.name
-	depends_on   = [vcd_lb_server_pool.server-pool]
-  }  
+
+  member {
+    condition       = "enabled"
+    name            = "member3"
+    ip_address      = "3.3.3.3"
+    port            = 3333
+    monitor_port    = 4444
+    weight          = 6
+    min_connections = 3
+    max_connections = 3
+  }
+
+  member {
+    condition    = "enabled"
+    name         = "member44"
+    ip_address   = "6.6.6.6"
+    port         = 33333
+    monitor_port = 44444
+    weight       = 1
+  }
+}
+
+data "vcd_lb_server_pool" "ds-lb-server-pool" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = vcd_lb_server_pool.server-pool.name
+  depends_on   = [vcd_lb_server_pool.server-pool]
+}
 `

--- a/vcd/resource_vcd_lb_virtual_server_test.go
+++ b/vcd/resource_vcd_lb_virtual_server_test.go
@@ -17,6 +17,10 @@ import (
 
 func TestAccVcdLbVirtualServer(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 	// String map to fill the template
 	var params = StringMap{
 		"Org":               testConfig.VCD.Org,
@@ -34,11 +38,6 @@ func TestAccVcdLbVirtualServer(t *testing.T) {
 	params["VirtualServerName"] = t.Name() + "-step2"
 	configText2 := templateFill(testAccVcdLbVirtualServer_step2, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 
 	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: testAccProviders,

--- a/vcd/resource_vcd_network_isolated_v2_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_test.go
@@ -65,8 +65,8 @@ resource "vcd_network_isolated_v2" "net1" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
   name = "{{.NetworkName}}"
-  
-  description = "NSX-V isolated network test OpenAPI" 
+
+  description = "NSX-V isolated network test OpenAPI"
   is_shared   = true
 
   gateway       = "1.1.1.1"

--- a/vcd/resource_vcd_network_isolated_v2_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_test.go
@@ -73,8 +73,8 @@ resource "vcd_network_isolated_v2" "net1" {
   prefix_length = 24
 
   static_ip_pool {
-	start_address = "1.1.1.10"
-	end_address   = "1.1.1.20"
+    start_address = "1.1.1.10"
+    end_address   = "1.1.1.20"
   }
 }
 `

--- a/vcd/resource_vcd_network_routed_v2_test.go
+++ b/vcd/resource_vcd_network_routed_v2_test.go
@@ -132,21 +132,21 @@ data "vcd_edgegateway" "existing" {
 }
 
 resource "vcd_network_routed_v2" "net1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.Vdc}}"
-  name = "{{.NetworkName}}"
+  org         = "{{.Org}}"
+  vdc         = "{{.Vdc}}"
+  name        = "{{.NetworkName}}"
   description = "NSX-V routed network test OpenAPI"
 
   interface_type = "{{.InterfaceType}}"
 
   edge_gateway_id = data.vcd_edgegateway.existing.id
-  
+
   gateway       = "1.1.1.1"
   prefix_length = 24
 
 
   static_ip_pool {
-	start_address = "1.1.1.10"
+    start_address = "1.1.1.10"
     end_address   = "1.1.1.20"
   }
 }

--- a/vcd/resource_vcd_network_routed_v2_test.go
+++ b/vcd/resource_vcd_network_routed_v2_test.go
@@ -141,14 +141,13 @@ resource "vcd_network_routed_v2" "net1" {
 
   edge_gateway_id = data.vcd_edgegateway.existing.id
   
-  gateway = "1.1.1.1"
+  gateway       = "1.1.1.1"
   prefix_length = 24
 
 
   static_ip_pool {
 	start_address = "1.1.1.10"
-    end_address = "1.1.1.20"
+    end_address   = "1.1.1.20"
   }
-  
 }
 `

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -1097,9 +1097,9 @@ resource "vcd_network_routed" "{{.ResourceName}}" {
   interface_type = "{{.InterfaceType}}"
 
   dhcp_pool {
-    start_address      = "{{.StartDhcpIpAddress}}"
-    end_address        = "{{.EndDhcpIpAddress}}"
-    max_lease_time     = "{{.MaxLeaseTime}}"
+    start_address  = "{{.StartDhcpIpAddress}}"
+    end_address    = "{{.EndDhcpIpAddress}}"
+    max_lease_time = "{{.MaxLeaseTime}}"
   }
 }
 `

--- a/vcd/resource_vcd_nsxt_alb_cloud_test.go
+++ b/vcd/resource_vcd_nsxt_alb_cloud_test.go
@@ -133,7 +133,7 @@ resource "vcd_nsxt_alb_cloud" "first" {
 
 const testAccVcdNsxtAlbCloudStep2 = testAccVcdNsxtAlbCloudPrereqs + `
 resource "vcd_nsxt_alb_cloud" "first" {
-  name        = "nsxt-cloud-renamed"
+  name = "nsxt-cloud-renamed"
 
   controller_id       = vcd_nsxt_alb_controller.first.id
   importable_cloud_id = data.vcd_nsxt_alb_importable_cloud.cld.id
@@ -144,7 +144,7 @@ resource "vcd_nsxt_alb_cloud" "first" {
 const testAccVcdNsxtAlbCloudStep4DS = testAccVcdNsxtAlbCloudStep2 + `
 # skip-binary-test: Data Source test
 data "vcd_nsxt_alb_cloud" "first" {
-  name          = vcd_nsxt_alb_cloud.first.name
+  name = vcd_nsxt_alb_cloud.first.name
 }
 `
 

--- a/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
@@ -238,7 +238,7 @@ resource "vcd_nsxt_alb_service_engine_group" "first" {
   alb_cloud_id                         = vcd_nsxt_alb_cloud.first.id
   importable_service_engine_group_name = "Default-Group"
   reservation_model                    = "SHARED"
-  
+
   # TODO: This feature remains not fully tested as it will impact some of the attributes, but only when tenant
   # operations are available. It will be possible to explicitly check that Sync worked. Now this test ensures it does
   # not break code. 

--- a/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
@@ -222,7 +222,7 @@ resource "vcd_nsxt_alb_service_engine_group" "first" {
   alb_cloud_id                         = vcd_nsxt_alb_cloud.first.id
   importable_service_engine_group_name = "Default-Group"
   reservation_model                    = "SHARED"
-  
+
   # TODO: This feature remains not fully tested as it will impact some of the attributes, but only when tenant
   # operations are available. It will be possible to explicitly check that Sync worked. Now this test ensures it does
   # not break code.

--- a/vcd/resource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/resource_vcd_nsxt_alb_settings_test.go
@@ -182,13 +182,13 @@ data "vcd_nsxt_edgegateway" "existing" {
 }
 
 resource "vcd_nsxt_alb_settings" "test" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id               = data.vcd_nsxt_edgegateway.existing.id
   is_active                     = true
   service_network_specification = "82.10.10.1/25"
-  
+
   # This dependency is required to make sure that provider part of operations is done
   depends_on = [vcd_nsxt_alb_service_engine_group.first]
 }

--- a/vcd/resource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/resource_vcd_nsxt_alb_settings_test.go
@@ -155,15 +155,15 @@ resource "vcd_nsxt_alb_service_engine_group" "first" {
 
 const testAccVcdNsxtAlbGeneralSettings = testAccVcdNsxtAlbProviderPrereqs + `
 data "vcd_nsxt_edgegateway" "existing" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name = "{{.EdgeGw}}"
 }
 
 resource "vcd_nsxt_alb_settings" "test" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
   is_active       = {{.IsActive}}
@@ -175,8 +175,8 @@ resource "vcd_nsxt_alb_settings" "test" {
 
 const testAccVcdNsxtAlbGeneralSettingsCustomService = testAccVcdNsxtAlbProviderPrereqs + `
 data "vcd_nsxt_edgegateway" "existing" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name = "{{.EdgeGw}}"
 }

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -120,18 +120,18 @@ data "vcd_external_network_v2" "existing-extnet" {
 
 const testAccNsxtEdgeGateway = testAccNsxtEdgeGatewayDataSources + `
 resource "vcd_nsxt_edgegateway" "nsxt-edge" {
-  org                     = "{{.Org}}"
-  vdc                     = "{{.NsxtVdc}}"
-  name                    = "{{.NsxtEdgeGatewayVcd}}"
-  description             = "Description"
+  org         = "{{.Org}}"
+  vdc         = "{{.NsxtVdc}}"
+  name        = "{{.NsxtEdgeGatewayVcd}}"
+  description = "Description"
 
   external_network_id = data.vcd_external_network_v2.existing-extnet.id
 
   subnet {
-     gateway               = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
-     prefix_length         = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
+     gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
+     prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
 
-     primary_ip            = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+     primary_ip = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
      allocated_ips {
        start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
        end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
@@ -142,19 +142,19 @@ resource "vcd_nsxt_edgegateway" "nsxt-edge" {
 
 const testAccNsxtEdgeGatewayUpdate = testAccNsxtEdgeGatewayDataSources + `
 resource "vcd_nsxt_edgegateway" "nsxt-edge" {
-  org                     = "{{.Org}}"
-  vdc                     = "{{.NsxtVdc}}"
-  name                    = "{{.NsxtEdgeGatewayVcd}}"
-  description             = "Updated-Description"
-  edge_cluster_id         = "{{.EdgeClusterId}}"
+  org             = "{{.Org}}"
+  vdc             = "{{.NsxtVdc}}"
+  name            = "{{.NsxtEdgeGatewayVcd}}"
+  description     = "Updated-Description"
+  edge_cluster_id = "{{.EdgeClusterId}}"
 
-  external_network_id = data.vcd_external_network_v2.existing-extnet.id
+  external_network_id       = data.vcd_external_network_v2.existing-extnet.id
   dedicate_external_network = false
 
   subnet {
-     gateway               = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
-     prefix_length         = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
-     primary_ip            = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+     gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
+     prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
+     primary_ip    = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
      allocated_ips {
        start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
        end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -114,7 +114,7 @@ func TestAccVcdNsxtEdgeGateway(t *testing.T) {
 
 const testAccNsxtEdgeGatewayDataSources = `
 data "vcd_external_network_v2" "existing-extnet" {
-	name = "{{.ExternalNetwork}}"
+  name = "{{.ExternalNetwork}}"
 }
 `
 

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -128,14 +128,14 @@ resource "vcd_nsxt_edgegateway" "nsxt-edge" {
   external_network_id = data.vcd_external_network_v2.existing-extnet.id
 
   subnet {
-     gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
-     prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
+    gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
+    prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
 
-     primary_ip = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-     allocated_ips {
-       start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-       end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-     }
+    primary_ip = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+    allocated_ips {
+      start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+      end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+    }
   }
 }
 `
@@ -152,13 +152,13 @@ resource "vcd_nsxt_edgegateway" "nsxt-edge" {
   dedicate_external_network = false
 
   subnet {
-     gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
-     prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
-     primary_ip    = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-     allocated_ips {
-       start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-       end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
-     }
+    gateway       = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].gateway
+    prefix_length = tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].prefix_length
+    primary_ip    = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+    allocated_ips {
+      start_address = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+      end_address   = tolist(tolist(data.vcd_external_network_v2.existing-extnet.ip_scope)[0].static_ip_pool)[0].end_address
+    }
   }
 }
 `

--- a/vcd/resource_vcd_nsxt_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_firewall_test.go
@@ -232,13 +232,13 @@ data "vcd_nsxt_app_port_profile" "ssh" {
 }
 
 resource "vcd_nsxt_app_port_profile" "custom-app" {
-  org   = "{{.Org}}"
-  vdc   = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name        = "custom app profile"
   description = "Application port profile for custom application"
 
-  scope       = "TENANT"
+  scope = "TENANT"
 
   app_port {
     protocol = "ICMPv6"

--- a/vcd/resource_vcd_nsxt_ip_set_test.go
+++ b/vcd/resource_vcd_nsxt_ip_set_test.go
@@ -240,8 +240,8 @@ resource "vcd_nsxt_ip_set" "set1" {
 
 const testAccNsxtIpSetEmpty2 = testAccNsxtIpSetPrereqs + `
 resource "vcd_nsxt_ip_set" "set1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing_gw.id
 

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
@@ -230,15 +230,16 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   name        = "test-tunnel-1"
   description = "test-tunnel-description"
-  
-  pre_shared_key    = "test-psk"
+
+  pre_shared_key = "test-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
   # That is a fake remote IP address
   remote_ip_address = "1.2.3.4"
   remote_networks   = ["192.168.1.0/24", "192.168.10.0/24", "192.168.20.0/28"]
 }
+
 `
 const testAccNsxtIpSecVpnTunnel1DS = testAccNsxtIpSecVpnTunnel1 + testAccNsxtIpSecVpnTunnelDS
 
@@ -250,8 +251,8 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing_gw.id
 
   name = "test-tunnel-1-updated"
-  
-  pre_shared_key    = "updated-psk"
+
+  pre_shared_key = "updated-psk"
   # Primary IP address of Edge Gateway
   local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
   local_networks   = ["50.40.40.1/32"]
@@ -271,8 +272,8 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   name    = "test-tunnel-1"
   enabled = false
-  
-  pre_shared_key    = "updated-psk"
+
+  pre_shared_key = "updated-psk"
   # Primary IP address of Edge Gateway
   local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
   local_networks   = ["50.40.40.1/32"]
@@ -538,11 +539,11 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   name        = "test-tunnel-1"
   description = "test-tunnel-description"
-  
-  pre_shared_key    = "test-psk"
+
+  pre_shared_key = "test-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
   # That is a fake remote IP address as there is nothing else to peer to
   remote_ip_address = "1.2.3.4"
   remote_networks   = ["192.168.1.0/24", "192.168.10.0/24", "192.168.20.0/28"]
@@ -554,14 +555,14 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
     ike_digest_algorithms = ["SHA2_256"]
     ike_dh_groups         = ["GROUP14"]
     ike_sa_lifetime       = 86400
-    
-	tunnel_pfs_enabled = true
-	tunnel_df_policy = "COPY"
+
+    tunnel_pfs_enabled           = true
+    tunnel_df_policy             = "COPY"
     tunnel_encryption_algorithms = ["AES_256"]
     tunnel_digest_algorithms     = ["SHA2_256"]
     tunnel_dh_groups             = ["GROUP14"]
     tunnel_sa_lifetime           = 3600
-    
+
     dpd_probe_internal = "30"
   }
 }
@@ -578,11 +579,11 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   name        = "test-tunnel-1"
   description = "test-tunnel-description"
-  
-  pre_shared_key    = "test-psk"
+
+  pre_shared_key = "test-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
   # That is a fake remote IP address as there is nothing else to peer to
   remote_ip_address = "1.2.3.4"
   remote_networks   = ["192.168.1.0/24", "192.168.10.0/24", "192.168.20.0/28"]
@@ -593,14 +594,14 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
     ike_digest_algorithms     = ["SHA2_256"]
     ike_dh_groups             = ["GROUP19"]
     ike_sa_lifetime           = 21600 # 4 hours
-    
-	tunnel_pfs_enabled           = true
-	tunnel_df_policy             = "COPY"
+
+    tunnel_pfs_enabled           = true
+    tunnel_df_policy             = "COPY"
     tunnel_encryption_algorithms = ["AES_128"]
     tunnel_digest_algorithms     = ["SHA2_512"]
     tunnel_dh_groups             = ["GROUP19"]
     tunnel_sa_lifetime           = 6000 # 10 minutes
-    
+
     dpd_probe_internal = "30"
   }
 }
@@ -617,11 +618,11 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   name        = "test-tunnel-1"
   description = "test-tunnel-description"
-  
-  pre_shared_key    = "test-psk"
+
+  pre_shared_key = "test-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["10.10.10.0/24", "30.30.30.0/28", "40.40.40.1/32"]
   # That is a fake remote IP address as there is nothing else to peer to
   remote_ip_address = "1.2.3.4"
   remote_networks   = ["192.168.1.0/24", "192.168.10.0/24", "192.168.20.0/28"]

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
@@ -249,12 +249,12 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing_gw.id
 
-  name        = "test-tunnel-1-updated"
+  name = "test-tunnel-1-updated"
   
   pre_shared_key    = "updated-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["50.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["50.40.40.1/32"]
   # That is a fake remote IP address
   remote_ip_address = "1.2.3.4"
 }
@@ -274,8 +274,8 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
   
   pre_shared_key    = "updated-psk"
   # Primary IP address of Edge Gateway
-  local_ip_address  = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
-  local_networks    = ["50.40.40.1/32"]
+  local_ip_address = tolist(data.vcd_nsxt_edgegateway.existing_gw.subnet)[0].primary_ip
+  local_networks   = ["50.40.40.1/32"]
   # That is a fake remote IP address
   remote_ip_address = "2.3.4.5"
   remote_networks   = ["1.1.1.1/32", "2.2.2.0/24", "3.3.0.0/16"]
@@ -551,9 +551,9 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
     ike_version               = "IKE_V2"
     ike_encryption_algorithms = ["AES_128"]
     # ike_encryption_algorithms = ["AES_128", "AES_256"]
-    ike_digest_algorithms     = ["SHA2_256"]
-    ike_dh_groups             = ["GROUP14"]
-    ike_sa_lifetime           = 86400
+    ike_digest_algorithms = ["SHA2_256"]
+    ike_dh_groups         = ["GROUP14"]
+    ike_sa_lifetime       = 86400
     
 	tunnel_pfs_enabled = true
 	tunnel_df_policy = "COPY"
@@ -594,8 +594,8 @@ resource "vcd_nsxt_ipsec_vpn_tunnel" "tunnel1" {
     ike_dh_groups             = ["GROUP19"]
     ike_sa_lifetime           = 21600 # 4 hours
     
-	tunnel_pfs_enabled = true
-	tunnel_df_policy = "COPY"
+	tunnel_pfs_enabled           = true
+	tunnel_df_policy             = "COPY"
     tunnel_encryption_algorithms = ["AES_128"]
     tunnel_digest_algorithms     = ["SHA2_512"]
     tunnel_dh_groups             = ["GROUP19"]

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -220,15 +220,15 @@ resource "vcd_nsxt_nat_rule" "dnat" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name        = "test-dnat-rule-updated"
-  rule_type  = "DNAT"
+  rule_type   = "DNAT"
   description = "updated-description"
-  
+
   # Using primary_ip from edge gateway
-  external_address  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_address  = "11.11.11.0/32"
+  external_address    = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address    = "11.11.11.0/32"
   dnat_external_port  = 8888
   app_port_profile_id = vcd_nsxt_app_port_profile.custom-app.id
-  
+
   logging = false
   enabled = false
 }

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -182,15 +182,15 @@ resource "vcd_nsxt_nat_rule" "dnat" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name        = "test-dnat-rule-updated"
-  rule_type  = "DNAT"
+  rule_type   = "DNAT"
   description = "updated-description"
-  
+
   # Using primary_ip from edge gateway
-  external_address  = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_address  = "11.11.11.0/32"
+  external_address    = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address    = "11.11.11.0/32"
   dnat_external_port  = 8888
   app_port_profile_id = data.vcd_nsxt_app_port_profile.custom.id
-  
+
   enabled = false
 }
 `
@@ -294,7 +294,6 @@ resource "vcd_nsxt_nat_rule" "no-dnat" {
   name      = "test-no-dnat-rule"
   rule_type = "NO_DNAT"
 
-  
   # Using primary_ip from edge gateway
   external_address   = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
   dnat_external_port = 7777
@@ -405,13 +404,13 @@ const testAccNsxtNatSnat = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "snat" {
   org = "{{.Org}}"
   vdc = "{{.NsxtVdc}}"
-	
+
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name        = "test-snat-rule"
   rule_type   = "SNAT"
   description = "description"
-  
+
   # Using primary_ip from edge gateway
   external_address         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
   internal_address         = "11.11.11.2"
@@ -424,13 +423,13 @@ const testAccNsxtNatSnat2 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "snat" {
   org = "{{.Org}}"
   vdc = "{{.NsxtVdc}}"
-	
+
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
   name        = "test-snat-rule-updated"
   rule_type   = "SNAT"
   description = ""
-  
+
   # Using primary_ip from edge gateway
   external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
   internal_address = "10.10.10.0/24"
@@ -497,7 +496,7 @@ resource "vcd_nsxt_nat_rule" "no-snat" {
   name        = "test-no-snat-rule"
   rule_type   = "NO_SNAT"
   description = "description"
-  
+
   # Using primary_ip from edge gateway
   internal_address = "11.11.11.0/24"
 }

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -142,8 +142,8 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 const natRuleDataSourceDefinition = `
 # skip-binary-test: Data Source test
 data "vcd_nsxt_nat_rule" "nat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
   name            = "{{.RuleName}}"
@@ -176,8 +176,8 @@ data "vcd_nsxt_app_port_profile" "custom" {
 }
 
 resource "vcd_nsxt_nat_rule" "dnat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -199,8 +199,8 @@ const testAccNsxtNatDnatStep2DS = testAccNsxtNatDnatStep2 + natRuleDataSourceDef
 
 const testAccNsxtNatDnatStep5 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_app_port_profile" "custom-app" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   name        = "custom app profile"
   description = "Application port profile for custom application"
@@ -214,8 +214,8 @@ resource "vcd_nsxt_app_port_profile" "custom-app" {
 
 
 resource "vcd_nsxt_nat_rule" "dnat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -286,8 +286,8 @@ func TestAccVcdNsxtNatRuleNoDnat(t *testing.T) {
 
 const testAccNsxtNatNoDnat = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "no-dnat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -296,7 +296,7 @@ resource "vcd_nsxt_nat_rule" "no-dnat" {
 
   
   # Using primary_ip from edge gateway
-  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  external_address   = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
   dnat_external_port = 7777
 }
 `
@@ -403,8 +403,8 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 
 const testAccNsxtNatSnat = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "snat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 	
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -422,8 +422,8 @@ const testAccNsxtNatSnatDS = testAccNsxtNatSnat + natRuleDataSourceDefinition
 
 const testAccNsxtNatSnat2 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "snat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 	
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -432,9 +432,9 @@ resource "vcd_nsxt_nat_rule" "snat" {
   description = ""
   
   # Using primary_ip from edge gateway
-  external_address         = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
-  internal_address         = "10.10.10.0/24"
-  logging = false
+  external_address = tolist(data.vcd_nsxt_edgegateway.existing.subnet)[0].primary_ip
+  internal_address = "10.10.10.0/24"
+  logging          = false
 }
 `
 
@@ -489,8 +489,8 @@ func TestAccVcdNsxtNatRuleNoSnat(t *testing.T) {
 
 const testAccNsxtNatNoSnat = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_nat_rule" "no-snat" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -499,7 +499,7 @@ resource "vcd_nsxt_nat_rule" "no-snat" {
   description = "description"
   
   # Using primary_ip from edge gateway
-  internal_address         = "11.11.11.0/24"
+  internal_address = "11.11.11.0/24"
 }
 `
 

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -83,9 +83,9 @@ data "vcd_nsxt_edgegateway" "existing" {
 }
 
 resource "vcd_network_routed_v2" "net1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
-  name = "nsxt-routed-dhcp"
+  org         = "{{.Org}}"
+  vdc         = "{{.NsxtVdc}}"
+  name        = "nsxt-routed-dhcp"
   description = "NSX-T routed network for DHCP testing"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
@@ -102,11 +102,11 @@ resource "vcd_network_routed_v2" "net1" {
 
 const testAccRoutedNetDhcpStep1 = testAccRoutedNetDhcpConfig + `
 resource "vcd_nsxt_network_dhcp" "pools" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   org_network_id = vcd_network_routed_v2.net1.id
-  
+
   pool {
     start_address = "7.1.1.100"
     end_address   = "7.1.1.110"
@@ -116,11 +116,11 @@ resource "vcd_nsxt_network_dhcp" "pools" {
 
 const testAccRoutedNetDhcpStep2 = testAccRoutedNetDhcpConfig + `
 resource "vcd_nsxt_network_dhcp" "pools" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   org_network_id = vcd_network_routed_v2.net1.id
-  
+
   pool {
     start_address = "7.1.1.100"
     end_address   = "7.1.1.110"

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -81,17 +81,17 @@ func TestAccVcdNsxtSecurityGroupEmpty(t *testing.T) {
 
 const testAccNsxtSecurityGroupPrereqsEmpty = `
 data "vcd_nsxt_edgegateway" "existing" {
-	org  = "{{.Org}}"
-	vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
-	name = "{{.EdgeGw}}"
+  name = "{{.EdgeGw}}"
 }
 `
 
 const testAccNsxtSecurityGroupEmpty = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_security_group" "group1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
@@ -102,8 +102,8 @@ resource "vcd_nsxt_security_group" "group1" {
 
 const testAccNsxtSecurityGroupEmpty2 = testAccNsxtSecurityGroupPrereqsEmpty + `
 resource "vcd_nsxt_security_group" "group1" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -95,7 +95,7 @@ resource "vcd_nsxt_security_group" "group1" {
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  name = "test-security-group"
+  name        = "test-security-group"
   description = "test-security-group-description"
 }
 `

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -252,12 +252,12 @@ resource "vcd_network_routed_v2" "{{.NetworkName}}" {
 }
 
 resource "vcd_network_isolated_v2" "net-test" {
-  name            = "{{.NetworkName}}-isolated"
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
+  name = "{{.NetworkName}}-isolated"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
   
-  gateway         = "110.10.102.1"
-  prefix_length   = 26
+  gateway       = "110.10.102.1"
+  prefix_length = 26
 
   static_ip_pool {
     start_address = "110.10.102.2"
@@ -266,10 +266,10 @@ resource "vcd_network_isolated_v2" "net-test" {
 }
 
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
   
-  org_network_id  = vcd_network_routed_v2.{{.NetworkName}}.id
+  org_network_id = vcd_network_routed_v2.{{.NetworkName}}.id
 
   pool {
     start_address = "10.10.102.210"
@@ -283,11 +283,11 @@ resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
 }
 
 resource "vcd_nsxt_network_imported" "imported-test" {
-  name            = "{{.NetworkName}}-imported"
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
-  gateway         = "12.12.2.1"
-  prefix_length   = 24
+  name          = "{{.NetworkName}}-imported"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  gateway       = "12.12.2.1"
+  prefix_length = 24
 
   nsxt_logical_switch_name = "{{.ImportSegment}}"
 
@@ -427,8 +427,8 @@ resource "vcd_network_isolated_v2" "net-test" {
 }
 
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
   
   org_network_id  = vcd_network_routed_v2.{{.NetworkName}}.id
 
@@ -444,11 +444,11 @@ resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
 }
 
 resource "vcd_nsxt_network_imported" "imported-test" {
-  name            = "{{.NetworkName}}-imported"
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
-  gateway         = "12.12.2.1"
-  prefix_length   = 24
+  name          = "{{.NetworkName}}-imported"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  gateway       = "12.12.2.1"
+  prefix_length = 24
 
   nsxt_logical_switch_name = "{{.ImportSegment}}"
 
@@ -507,11 +507,11 @@ resource "vcd_vm" "{{.VMName}}" {
   # You cannot remove NICs from an active virtual machine on which no operating system is installed.
   power_on = false
 
-  description   = "test empty standalone VM"
-  name          = "{{.VMName}}"
-  memory        = 512
-  cpus          = 2
-  cpu_cores     = 1 
+  description = "test empty standalone VM"
+  name        = "{{.VMName}}"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1 
   
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -528,7 +528,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed_v2.net2.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	adapter_type       = "PCNet32"
+	  adapter_type       = "PCNet32"
   }
 
   network {

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -255,7 +255,7 @@ resource "vcd_network_isolated_v2" "net-test" {
   name = "{{.NetworkName}}-isolated"
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
-  
+
   gateway       = "110.10.102.1"
   prefix_length = 26
 
@@ -308,7 +308,7 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   bus_sub_type    = "{{.busSubType}}"
   storage_profile = "{{.storageProfileName}}"
 
-  depends_on = [vcd_network_routed_v2.{{.NetworkName}}, vcd_network_isolated_v2.net-test, 
+  depends_on = [vcd_network_routed_v2.{{.NetworkName}}, vcd_network_isolated_v2.net-test,
   vcd_nsxt_network_imported.imported-test]
 }
 
@@ -417,8 +417,8 @@ resource "vcd_network_isolated_v2" "net-test" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
   
-  gateway         = "110.10.102.1"
-  prefix_length   = 26
+  gateway       = "110.10.102.1"
+  prefix_length = 26
 
   static_ip_pool {
     start_address = "110.10.102.2"
@@ -429,7 +429,7 @@ resource "vcd_network_isolated_v2" "net-test" {
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
-  
+
   org_network_id = vcd_network_routed_v2.{{.NetworkName}}.id
 
   pool {

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -268,7 +268,7 @@ resource "vcd_network_isolated_v2" "net-test" {
 resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
-  
+
   org_network_id = vcd_network_routed_v2.{{.NetworkName}}.id
 
   pool {
@@ -309,7 +309,7 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
   storage_profile = "{{.storageProfileName}}"
 
   depends_on = [vcd_network_routed_v2.{{.NetworkName}}, vcd_network_isolated_v2.net-test, 
-                vcd_nsxt_network_imported.imported-test]
+  vcd_nsxt_network_imported.imported-test]
 }
 
 resource "vcd_vm" "{{.VmName}}" {
@@ -384,7 +384,7 @@ output "disk_unit_number" {
 }
 output "vm" {
   value = vcd_vm.{{.VmName}}
-  
+
   sensitive = true
 }
 `
@@ -413,9 +413,9 @@ resource "vcd_network_routed_v2" "{{.NetworkName}}" {
 }
 
 resource "vcd_network_isolated_v2" "net-test" {
-  name            = "{{.NetworkName}}-isolated"
-  org             = "{{.Org}}"
-  vdc             = "{{.Vdc}}"
+  name = "{{.NetworkName}}-isolated"
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
   
   gateway         = "110.10.102.1"
   prefix_length   = 26
@@ -430,7 +430,7 @@ resource "vcd_nsxt_network_dhcp" "{{.NetworkName}}-dhcp" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
   
-  org_network_id  = vcd_network_routed_v2.{{.NetworkName}}.id
+  org_network_id = vcd_network_routed_v2.{{.NetworkName}}.id
 
   pool {
     start_address = "10.10.102.210"
@@ -511,8 +511,8 @@ resource "vcd_vm" "{{.VMName}}" {
   name        = "{{.VMName}}"
   memory      = 512
   cpus        = 2
-  cpu_cores   = 1 
-  
+  cpu_cores   = 1
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -528,7 +528,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed_v2.net2.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	  adapter_type       = "PCNet32"
+    adapter_type       = "PCNet32"
   }
 
   network {

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -416,7 +416,7 @@ resource "vcd_network_isolated_v2" "net-test" {
   name = "{{.NetworkName}}-isolated"
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
-  
+
   gateway       = "110.10.102.1"
   prefix_length = 26
 

--- a/vcd/resource_vcd_nsxv_dhcp_relay_test.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay_test.go
@@ -162,7 +162,7 @@ resource "vcd_nsxv_dhcp_relay" "relay_config" {
   }
 
   relay_agent {
-    network_name        = vcd_network_routed.test-routed[1].name
+    network_name       = vcd_network_routed.test-routed[1].name
     gateway_ip_address = "210.201.1.1"
   }
 }

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -223,7 +223,7 @@ resource "vcd_nsxv_dnat" "test" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
-  
+
   network_type = "ext"
   network_name = "{{.NetworkName}}"
 

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -282,8 +282,8 @@ resource "vcd_network_routed" "net" {
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
 
-  name         = "test-org-for-dnat"
-  gateway      = "10.10.0.1"
+  name    = "test-org-for-dnat"
+  gateway = "10.10.0.1"
 
   static_ip_pool {
     start_address = "10.10.0.152"

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -615,24 +615,24 @@ func testAccCheckVcdFirewallRuleDestroy(resource string) resource.TestCheckFunc 
 
 const testAccVcdEdgeFirewallRule0 = `
 resource "vcd_nsxv_firewall_rule" "rule0" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "test-rule"
-	rule_tag = "30000"
-	action = "deny"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "test-rule"
+  rule_tag     = "30000"
+  action       = "deny"  
 
-	source {
-		ip_addresses = ["any"]
-	}
-  
-	destination {
-		ip_addresses = ["192.168.1.110"]
-	}
-  
-	service {
-		protocol = "any"
-	}
+  source {
+  	ip_addresses = ["any"]
+  }
+
+  destination {
+  	ip_addresses = ["192.168.1.110"]
+  }
+
+  service {
+  	protocol = "any"
+  }
 }
 
 resource "vcd_nsxv_firewall_rule" "rule0-2" {

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -620,123 +620,123 @@ resource "vcd_nsxv_firewall_rule" "rule0" {
   edge_gateway = "{{.EdgeGateway}}"
   name         = "test-rule"
   rule_tag     = "30000"
-  action       = "deny"  
+  action       = "deny"
 
   source {
-  	ip_addresses = ["any"]
+    ip_addresses = ["any"]
   }
 
   destination {
-  	ip_addresses = ["192.168.1.110"]
+    ip_addresses = ["192.168.1.110"]
   }
 
   service {
-  	protocol = "any"
+    protocol = "any"
   }
 }
 
 resource "vcd_nsxv_firewall_rule" "rule0-2" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule 123123"
-	action = "deny"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "rule 123123"
+  action       = "deny"
 
-	source {
-		ip_addresses = ["4.4.4.4"]
-	}
-  
-	destination {
-		ip_addresses = ["5.5.5.5"]
-	}
-  
-	service {
-		protocol = "any"
-	}
-	# Dependency helps to ensure provisioning order (which becomes rule processing order)
-	depends_on = ["vcd_nsxv_firewall_rule.rule0"]
+  source {
+    ip_addresses = ["4.4.4.4"]
+  }
+
+  destination {
+    ip_addresses = ["5.5.5.5"]
+  }
+
+  service {
+    protocol = "any"
+  }
+  # Dependency helps to ensure provisioning order (which becomes rule processing order)
+  depends_on = ["vcd_nsxv_firewall_rule.rule0"]
 }
 
 data "vcd_nsxv_firewall_rule" "rule0" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
 
-	rule_id      = vcd_nsxv_firewall_rule.rule0.id
+  rule_id = vcd_nsxv_firewall_rule.rule0.id
 }
 `
 
 const testAccVcdEdgeFirewallRule1 = `
 resource "vcd_nsxv_firewall_rule" "rule1" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "test-rule-1"
-	action = "deny"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "test-rule-1"
+  action       = "deny"
 
-	source {
-		gateway_interfaces = ["internal"]
-	}
-  
-	destination {
-		gateway_interfaces = ["external"]
-	}
-	service {
-		protocol = "tcp"
-		port     = "443"
-	}
+  source {
+    gateway_interfaces = ["internal"]
   }
+
+  destination {
+    gateway_interfaces = ["external"]
+  }
+  service {
+    protocol = "tcp"
+    port     = "443"
+  }
+}
 `
 
 const testAccVcdEdgeFirewallRule2 = `
 resource "vcd_nsxv_firewall_rule" "rule2" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "test-rule-2"
-	action = "deny"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "test-rule-2"
+  action       = "deny"
 
-	source {
-		gateway_interfaces = ["vse"]
-	}
-  
-	destination {
-		gateway_interfaces = ["{{.NetworkName}}"]
-	}
+  source {
+    gateway_interfaces = ["vse"]
+  }
 
-	service {
-		protocol    = "TCP"
-		port        = "443-543"
-		source_port = "2000-4000"
-	}
+  destination {
+    gateway_interfaces = ["{{.NetworkName}}"]
+  }
+
+  service {
+    protocol    = "TCP"
+    port        = "443-543"
+    source_port = "2000-4000"
+  }
 }
 
 output "destination_gateway_interface" {
-	value = tolist(vcd_nsxv_firewall_rule.rule2.destination[0].gateway_interfaces)[0]
+  value = tolist(vcd_nsxv_firewall_rule.rule2.destination[0].gateway_interfaces)[0]
 }
 `
 
 const testAccVcdEdgeFirewallRule3 = `
 resource "vcd_nsxv_firewall_rule" "rule3" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	action          = "deny"
-	enabled         = "false"
-	logging_enabled = "true"
+  org             = "{{.Org}}"
+  vdc             = "{{.Vdc}}"
+  edge_gateway    = "{{.EdgeGateway}}"
+  action          = "deny"
+  enabled         = "false"
+  logging_enabled = "true"
 
-	source {
-		org_networks = [vcd_network_routed.test-routed[0].name]
-	}
-  
-	destination {
-		exclude      = "true"
-		org_networks = [vcd_network_routed.test-routed[1].name]
-	}
-	service {
-		protocol = "tcp"
-		port     = "443"
-	}
+  source {
+    org_networks = [vcd_network_routed.test-routed[0].name]
+  }
+
+  destination {
+    exclude      = "true"
+    org_networks = [vcd_network_routed.test-routed[1].name]
+  }
+  service {
+    protocol = "tcp"
+    port     = "443"
+  }
 }
 resource "vcd_network_routed" "test-routed" {
   count        = 2
@@ -756,125 +756,125 @@ resource "vcd_network_routed" "test-routed" {
 
 const testAccVcdEdgeFirewallRule4 = `
 resource "vcd_nsxv_firewall_rule" "rule4" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "test-rule-4"
-	action = "deny"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "test-rule-4"
+  action       = "deny"
 
-	source {
-		gateway_interfaces = ["internal"]
-	}
-  
-	destination {
-		gateway_interfaces = ["external"]
-	}
-
-	service {
-		protocol = "tcp"
-		port     = "443"
-	}
-	
-	service {
-		protocol = "tcp"
-		port     = "8443"
-		source_port = "20000-40000"
-	}
-
-	service {
-		protocol = "UDP"
-		port     = "10000"
-	}
-
-	service {
-		protocol    = "udp"
-		port        = "10000"
-		source_port = "20000"
-	}
-
-	service {
-		protocol = "ICMP"
-	}
+  source {
+    gateway_interfaces = ["internal"]
   }
 
-data "vcd_nsxv_firewall_rule" "rule4" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
+  destination {
+    gateway_interfaces = ["external"]
+  }
 
-	rule_id      = vcd_nsxv_firewall_rule.rule4.id
+  service {
+    protocol = "tcp"
+    port     = "443"
+  }
+
+  service {
+    protocol    = "tcp"
+    port        = "8443"
+    source_port = "20000-40000"
+  }
+
+  service {
+    protocol = "UDP"
+    port     = "10000"
+  }
+
+  service {
+    protocol    = "udp"
+    port        = "10000"
+    source_port = "20000"
+  }
+
+  service {
+    protocol = "ICMP"
+  }
+}
+
+data "vcd_nsxv_firewall_rule" "rule4" {
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+
+  rule_id = vcd_nsxv_firewall_rule.rule4.id
 }
 `
 
 const testAccVcdEdgeFirewallRule5 = `
 resource "vcd_nsxv_firewall_rule" "rule5" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "test-rule-5"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "test-rule-5"
 
-	source {
-		gateway_interfaces = ["internal"]
-	}
-  
-	destination {
-		gateway_interfaces = ["external"]
-	}
-
-	service {
-		protocol = "tcp"
-	}
-
-	service {
-		protocol = "udp"
-	}
-
+  source {
+    gateway_interfaces = ["internal"]
   }
+
+  destination {
+    gateway_interfaces = ["external"]
+  }
+
+  service {
+    protocol = "tcp"
+  }
+
+  service {
+    protocol = "udp"
+  }
+
+}
 `
 
 const testAccVcdEdgeFirewallRule8 = `
 resource "vcd_nsxv_firewall_rule" "rule6" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "below-rule"
-	action = "accept"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "below-rule"
+  action       = "accept"
 
-	source {
-		ip_addresses = ["10.10.10.0/24", "11.10.10.0/24"]
-	}
-  
-	destination {
-		ip_addresses = ["20.10.10.0/24", "21.10.10.0/24"]
-	}
+  source {
+    ip_addresses = ["10.10.10.0/24", "11.10.10.0/24"]
+  }
 
-	service {
-		protocol = "any"
-	}
+  destination {
+    ip_addresses = ["20.10.10.0/24", "21.10.10.0/24"]
+  }
+
+  service {
+    protocol = "any"
+  }
 }
 
 resource "vcd_nsxv_firewall_rule" "rule6-6" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "above-rule"
-	action = "accept"
-	above_rule_id = vcd_nsxv_firewall_rule.rule6.id
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  edge_gateway  = "{{.EdgeGateway}}"
+  name          = "above-rule"
+  action        = "accept"
+  above_rule_id = vcd_nsxv_firewall_rule.rule6.id
 
 
-	source {
-		ip_addresses = ["30.10.10.0/24", "31.10.10.0/24"]
-	}
-  
-	destination {
-		ip_addresses = ["40.10.10.0/24", "41.10.10.0/24"]
-	}
+  source {
+    ip_addresses = ["30.10.10.0/24", "31.10.10.0/24"]
+  }
 
-	service {
-		protocol = "ANY"
-	}
+  destination {
+    ip_addresses = ["40.10.10.0/24", "41.10.10.0/24"]
+  }
 
-	depends_on = ["vcd_nsxv_firewall_rule.rule6"]
+  service {
+    protocol = "ANY"
+  }
+
+  depends_on = ["vcd_nsxv_firewall_rule.rule6"]
 }
 `
 
@@ -991,65 +991,65 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 
 const testAccVcdEdgeFirewallRuleIpSets = `
 resource "vcd_nsxv_firewall_rule" "ip_sets" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ip_sets"
-	action = "accept"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "rule-with-ip_sets"
+  action       = "accept"
 
-	source {
-		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
-	}
-  
-	destination {
-		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
-	}
+  source {
+    ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
+  }
 
-	service {
-		protocol = "any"
-	}
+  destination {
+    ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
+  }
+
+  service {
+    protocol = "any"
+  }
 }
 
 resource "vcd_nsxv_ip_set" "aceeptance-ipset-1" {
-	name = "acceptance test IPset 1"
-	ip_addresses = ["222.222.222.1/24"]
+  name         = "acceptance test IPset 1"
+  ip_addresses = ["222.222.222.1/24"]
 }
 
 resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
-	name = "acceptance test IPset 2"
-	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
+  name         = "acceptance test IPset 2"
+  ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
 }
 `
 
 const testAccVcdEdgeFirewallRuleIpSetsUpdate = `
 resource "vcd_nsxv_firewall_rule" "ip_sets" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "updated-rule-with-ip_sets"
-	action = "accept"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "updated-rule-with-ip_sets"
+  action       = "accept"
 
-	source {
-		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
-	}
-  
-	destination {
-		ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
-	}
+  source {
+    ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-2.name]
+  }
 
-	service {
-		protocol = "icmp"
-	}
+  destination {
+    ip_sets = [vcd_nsxv_ip_set.aceeptance-ipset-1.name]
+  }
+
+  service {
+    protocol = "icmp"
+  }
 }
 
 resource "vcd_nsxv_ip_set" "aceeptance-ipset-1" {
-	name = "acceptance test IPset 1"
-	ip_addresses = ["222.222.222.1/24"]
+  name         = "acceptance test IPset 1"
+  ip_addresses = ["222.222.222.1/24"]
 }
 
 resource "vcd_nsxv_ip_set" "aceeptance-ipset-2" {
-	name = "acceptance test IPset 2"
-	ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
+  name         = "acceptance test IPset 2"
+  ip_addresses = ["11.11.11.1-11.11.11.100", "12.12.12.1"]
 }
 `
 
@@ -1161,29 +1161,28 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 }
 
 const testAccVcdEdgeFirewallRuleVmsPrereqs = `
-
 resource "vcd_network_routed" "net" {
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
-  
-	name         = "fw-routed-net"
-	edge_gateway = "{{.EdgeGateway}}"
-	gateway      = "47.10.0.1"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	static_ip_pool {
-	  start_address = "47.10.0.152"
-	  end_address   = "47.10.0.254"
-	}
+  name         = "fw-routed-net"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "47.10.0.1"
+
+  static_ip_pool {
+    start_address = "47.10.0.152"
+    end_address   = "47.10.0.254"
+  }
 }
 resource "vcd_vapp" "fw-test" {
   name = "fw-test"
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.fw-test.name
-  org_network_name   = vcd_network_routed.net.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.fw-test.name
+  org_network_name = vcd_network_routed.net.name
 }
 
 resource "vcd_vapp_vm" "fw-vm" {
@@ -1208,44 +1207,44 @@ resource "vcd_vapp_vm" "fw-vm" {
 
 const testAccVcdEdgeFirewallRuleVms = testAccVcdEdgeFirewallRuleVmsPrereqs + `
 resource "vcd_nsxv_firewall_rule" "vms" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ip_sets"
-	action = "accept"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "rule-with-ip_sets"
+  action       = "accept"
 
-	source {
-		vm_ids = [vcd_vapp_vm.fw-vm.id]
-	}
-  
-	destination {
-		ip_addresses = ["any"]
-	}
+  source {
+    vm_ids = [vcd_vapp_vm.fw-vm.id]
+  }
 
-	service {
-		protocol = "any"
-	}
+  destination {
+    ip_addresses = ["any"]
+  }
+
+  service {
+    protocol = "any"
+  }
 }
 `
 
 const testAccVcdEdgeFirewallRuleVmsUpdate = testAccVcdEdgeFirewallRuleVmsPrereqs + `
 resource "vcd_nsxv_firewall_rule" "vms" {
-	org          = "{{.Org}}"
-	vdc          = "{{.Vdc}}"
-	edge_gateway = "{{.EdgeGateway}}"
-	name = "rule-with-ip_sets"
-	action = "accept"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  name         = "rule-with-ip_sets"
+  action       = "accept"
 
-	source {
-		ip_addresses = ["any"]
-	}
-  
-	destination {
-		vm_ids = [vcd_vapp_vm.fw-vm.id]
-	}
+  source {
+    ip_addresses = ["any"]
+  }
 
-	service {
-		protocol = "any"
-	}
+  destination {
+    vm_ids = [vcd_vapp_vm.fw-vm.id]
+  }
+
+  service {
+    protocol = "any"
+  }
 }
 `

--- a/vcd/resource_vcd_nsxv_snat_test.go
+++ b/vcd/resource_vcd_nsxv_snat_test.go
@@ -99,8 +99,8 @@ resource "vcd_network_routed" "net" {
   vdc          = "{{.Vdc}}"
   edge_gateway = "{{.EdgeGateway}}"
 
-  name         = "test-org-for-snat"
-  gateway      = "4.4.4.1"
+  name    = "test-org-for-snat"
+  gateway = "4.4.4.1"
 
   static_ip_pool {
     start_address = "4.4.4.152"

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -328,11 +328,11 @@ func init() {
 
 const testAccCheckVcdOrgBasic = `
 resource "vcd_org" "{{.OrgName}}" {
-  name              = "{{.OrgName}}"
-  full_name         = "{{.FullName}}"
-  description       = "{{.Description}}"
-  delete_force      = "true"
-  delete_recursive  = "true"
+  name             = "{{.OrgName}}"
+  full_name        = "{{.FullName}}"
+  description      = "{{.Description}}"
+  delete_force     = "true"
+  delete_recursive = "true"
 }
 `
 
@@ -354,8 +354,8 @@ resource "vcd_org" "{{.OrgName}}" {
     delete_on_storage_lease_expiration    = {{.VappDeleteOnLeaseExp}}
   }
   vapp_template_lease {
-    maximum_storage_lease_in_sec          = {{.TemplStorageLease}}
-    delete_on_storage_lease_expiration    = {{.TemplDeleteOnLeaseExp}}
+    maximum_storage_lease_in_sec       = {{.TemplStorageLease}}
+    delete_on_storage_lease_expiration = {{.TemplDeleteOnLeaseExp}}
   }
 }
 `

--- a/vcd/resource_vcd_org_user_test.go
+++ b/vcd/resource_vcd_org_user_test.go
@@ -264,6 +264,10 @@ func TestAccVcdOrgUserFull(t *testing.T) {
 // properties values from organization data source
 func TestAccVcdOrgUserWithDS(t *testing.T) {
 	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	userData := prepareUserData(t)
 
@@ -286,39 +290,36 @@ func TestAccVcdOrgUserWithDS(t *testing.T) {
 	}
 
 	configText := templateFill(template, params)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	} else {
-		fmt.Printf("%s (%s)\n", ud.name, ud.roleName)
-		debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
-		resource.Test(t, resource.TestCase{
-			PreCheck:          func() { testAccPreCheck(t) },
-			ProviderFactories: testAccProviders,
-			CheckDestroy:      nil,
-			Steps: []resource.TestStep{
-				resource.TestStep{
-					Config: configText,
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(
-							"vcd_org_user."+ud.name, "name", ud.name),
-						resource.TestCheckResourceAttr(
-							"vcd_org_user."+ud.name, "role", ud.roleName),
-						resource.TestCheckResourceAttrPair(
-							"vcd_org_user."+ud.name, "deployed_vm_quota",
-							"data.vcd_org."+testConfig.VCD.Org, "deployed_vm_quota"),
-						resource.TestCheckResourceAttrPair(
-							"vcd_org_user."+ud.name, "stored_vm_quota",
-							"data.vcd_org."+testConfig.VCD.Org, "stored_vm_quota"),
-						resource.TestCheckResourceAttr(
-							"data.vcd_org_user.DSExistingUser", "name", dsOrgUser),
-						resource.TestCheckResourceAttr(
-							"data.vcd_org_user.DSExistingUser", "role", govcd.OrgUserRoleOrganizationAdministrator),
-					),
-				},
+
+	fmt.Printf("%s (%s)\n", ud.name, ud.roleName)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      nil,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"vcd_org_user."+ud.name, "name", ud.name),
+					resource.TestCheckResourceAttr(
+						"vcd_org_user."+ud.name, "role", ud.roleName),
+					resource.TestCheckResourceAttrPair(
+						"vcd_org_user."+ud.name, "deployed_vm_quota",
+						"data.vcd_org."+testConfig.VCD.Org, "deployed_vm_quota"),
+					resource.TestCheckResourceAttrPair(
+						"vcd_org_user."+ud.name, "stored_vm_quota",
+						"data.vcd_org."+testConfig.VCD.Org, "stored_vm_quota"),
+					resource.TestCheckResourceAttr(
+						"data.vcd_org_user.DSExistingUser", "name", dsOrgUser),
+					resource.TestCheckResourceAttr(
+						"data.vcd_org_user.DSExistingUser", "role", govcd.OrgUserRoleOrganizationAdministrator),
+				),
 			},
-		})
-	}
+		},
+	})
+
 	cleanUserData(t)
 	postTestChecks(t)
 }

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -273,10 +273,10 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
   storage_profile {
-    name     = "{{.ProviderVdcStorageProfile}}"
-    enabled  = true
-    limit    = 10240
-    default  = true
+    name    = "{{.ProviderVdcStorageProfile}}"
+    enabled = true
+    limit   = 10240
+    default = true
   }
 
   metadata = {
@@ -292,7 +292,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValue}}
 
   default_vm_sizing_policy_id = vcd_vm_sizing_policy.minSize3.id
-  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.minSize2.id,vcd_vm_sizing_policy.minSize3.id]
+  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.minSize2.id, vcd_vm_sizing_policy.minSize3.id]
 }
 `
 

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -360,10 +360,10 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
   storage_profile {
-    name     = "{{.ProviderVdcStorageProfile}}"
-    enabled  = true
-    limit    = 10240
-    default  = true
+    name    = "{{.ProviderVdcStorageProfile}}"
+    enabled = true
+    limit   = 10240
+    default = true
   }
 
   metadata = {

--- a/vcd/resource_vcd_rights_bundle_test.go
+++ b/vcd/resource_vcd_rights_bundle_test.go
@@ -135,7 +135,7 @@ resource "vcd_rights_bundle" "{{.RightsBundleName}}" {
     "vApp Template / Media: View",
   ]
   publish_to_all_tenants = false
-  tenants                = [ "{{.Tenant}}" ]
+  tenants                = ["{{.Tenant}}"]
 }
 `
 

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -301,12 +301,12 @@ resource "vcd_vm" "{{.VMName}}" {
   # You cannot remove NICs from an active virtual machine on which no operating system is installed.
   power_on = false
 
-  description   = "test empty standalone VM"
-  name          = "{{.VMName}}"
-  memory        = 512
-  cpus          = 2
-  cpu_cores     = 1 
-  
+  description = "test empty standalone VM"
+  name        = "{{.VMName}}"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -322,7 +322,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed_v2.net2.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	adapter_type       = "PCNet32"
+    adapter_type       = "PCNet32"
   }
 
   network {

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -245,8 +245,7 @@ output "disk_unit_number" {
   value = tolist(vcd_vm.{{.VmName}}.disk)[0].unit_number
 }
 output "vm" {
-  value = vcd_vm.{{.VmName}}
-  
+  value     = vcd_vm.{{.VmName}}
   sensitive = true
 }
 `

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -318,10 +318,10 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
   storage_profile {
-    name     = "{{.ProviderVdcStorageProfile}}"
-    enabled  = true
-    limit    = 90240
-    default  = true
+    name    = "{{.ProviderVdcStorageProfile}}"
+    enabled = true
+    limit   = 90240
+    default = true
   }
 
   metadata = {
@@ -337,7 +337,7 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValue}}
 
   default_vm_sizing_policy_id = vcd_vm_sizing_policy.size_full.id
-  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.size_cpu.id,vcd_vm_sizing_policy.size_full.id]
+  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.size_cpu.id, vcd_vm_sizing_policy.size_full.id]
 }
 `
 const testAccCheckVcdEmptyVmWithSizing = testAccCheckVcdEmptyWithSizing + `
@@ -360,7 +360,7 @@ resource "vcd_vm" "{{.VMName1}}" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   memory           = 1024
- }
+}
 
 resource "vcd_vm" "{{.VMName2}}" {
   org = "{{.Org}}"
@@ -380,7 +380,7 @@ resource "vcd_vm" "{{.VMName2}}" {
   memory_hot_add_enabled = true
 
   sizing_policy_id = vcd_vm_sizing_policy.size_full.id
- }
+}
 
 resource "vcd_vm" "{{.VMName3}}" {
   org = "{{.Org}}"
@@ -405,7 +405,7 @@ resource "vcd_vm" "{{.VMName4}}" {
   power_on      = "false"
 
   sizing_policy_id = vcd_vm_sizing_policy.size_full.id
- }
+}
 `
 
 const testAccCheckVcdEmptyVmWithSizingUpdate = "# skip-binary-test: only for updates " +
@@ -435,8 +435,8 @@ resource "vcd_vm" "{{.VMName2}}" {
 
   power_on = true
 
-  description   = "test empty VM2"
-  name          = "{{.VMName2}}"
+  description = "test empty VM2"
+  name        = "{{.VMName2}}"
   
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -347,8 +347,8 @@ resource "vcd_vm" "{{.VMName1}}" {
 
   power_on = true
 
-  description   = "test empty VM"
-  name          = "{{.VMName1}}"
+  description = "test empty VM"
+  name        = "{{.VMName1}}"
   
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -368,8 +368,8 @@ resource "vcd_vm" "{{.VMName2}}" {
 
   power_on = true
 
-  description   = "test empty VM2"
-  name          = "{{.VMName2}}"
+  description = "test empty VM2"
+  name        = "{{.VMName2}}"
   
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -415,8 +415,8 @@ resource "vcd_vm" "{{.VMName1}}" {
   org = "{{.Org}}"
   vdc = vcd_org_vdc.{{.VdcName}}.name
 
-  name          = "{{.VMName1}}"
-  description   = "test empty VM updated"
+  name        = "{{.VMName1}}"
+  description = "test empty VM updated"
 
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -448,7 +448,7 @@ resource "vcd_vm" "{{.VMName2}}" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   # allows to change only not defined in sizing policy
-  memory           = 2048
+  memory = 2048
 }
 
 resource "vcd_vm" "{{.VMName3}}" {
@@ -462,7 +462,7 @@ resource "vcd_vm" "{{.VMName3}}" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   # allows to change only not defined in sizing policy
-  memory           = 3072
+  memory = 3072
 }
 
 resource "vcd_vm" "{{.VMName5}}" {

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -349,7 +349,7 @@ resource "vcd_vm" "{{.VMName1}}" {
 
   description = "test empty VM"
   name        = "{{.VMName1}}"
-  
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -370,7 +370,7 @@ resource "vcd_vm" "{{.VMName2}}" {
 
   description = "test empty VM2"
   name        = "{{.VMName2}}"
-  
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -437,7 +437,7 @@ resource "vcd_vm" "{{.VMName2}}" {
 
   description = "test empty VM2"
   name        = "{{.VMName2}}"
-  
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -275,22 +275,20 @@ resource "vcd_vapp" "{{.VappName3}}" {
 }
 
 resource "vcd_vapp_access_control" "{{.AccessControlIdentifier0}}" {
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+  vapp_id = vcd_vapp.{{.VappName0}}.id
 
-  org      = "{{.Org}}"
-  vdc      = "{{.Vdc}}"
-  vapp_id  = vcd_vapp.{{.VappName0}}.id
-
-  shared_with_everyone    = {{.SharedToEveryone}}
+  shared_with_everyone = {{.SharedToEveryone}}
   {{.EveryoneAccessLevel}}
 }
 
 resource "vcd_vapp_access_control" "{{.AccessControlIdentifier1}}" {
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+  vapp_id = vcd_vapp.{{.VappName1}}.id
 
-  org      = "{{.Org}}"
-  vdc      = "{{.Vdc}}"
-  vapp_id  = vcd_vapp.{{.VappName1}}.id
-
-  shared_with_everyone    = false
+  shared_with_everyone = false
 
   shared_with {
     user_id      = vcd_org_user.{{.UserName1}}.id
@@ -299,12 +297,11 @@ resource "vcd_vapp_access_control" "{{.AccessControlIdentifier1}}" {
 }
 
 resource "vcd_vapp_access_control" "{{.AccessControlIdentifier2}}" {
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+  vapp_id = vcd_vapp.{{.VappName2}}.id
 
-  org      = "{{.Org}}"
-  vdc      = "{{.Vdc}}"
-  vapp_id  = vcd_vapp.{{.VappName2}}.id
-
-  shared_with_everyone    = false
+  shared_with_everyone = false
 
   shared_with {
     user_id      = vcd_org_user.{{.UserName1}}.id
@@ -317,10 +314,9 @@ resource "vcd_vapp_access_control" "{{.AccessControlIdentifier2}}" {
 }
 
 resource "vcd_vapp_access_control" "{{.AccessControlIdentifier3}}" {
-
-  org      = "{{.Org}}"
-  vdc      = "{{.Vdc}}"
-  vapp_id  = vcd_vapp.{{.VappName3}}.id
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+  vapp_id = vcd_vapp.{{.VappName3}}.id
 
   shared_with_everyone = false
 

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -280,6 +280,7 @@ resource "vcd_vapp_access_control" "{{.AccessControlIdentifier0}}" {
   vapp_id = vcd_vapp.{{.VappName0}}.id
 
   shared_with_everyone = {{.SharedToEveryone}}
+
 {{.EveryoneAccessLevel}}
 }
 

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -27,7 +27,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 		"Org":                      testConfig.VCD.Org,
 		"Vdc":                      testConfig.VCD.Vdc,
 		"SharedToEveryone":         "true",
-		"EveryoneAccessLevel":      fmt.Sprintf(`everyone_access_level = "%s"`, types.ControlAccessReadWrite),
+		"EveryoneAccessLevel":      fmt.Sprintf(`  everyone_access_level = "%s"`, types.ControlAccessReadWrite),
 		"AccessControlIdentifier0": "AC-Vapp0",
 		"AccessControlIdentifier1": "AC-Vapp1",
 		"AccessControlIdentifier2": "AC-Vapp2",
@@ -280,7 +280,7 @@ resource "vcd_vapp_access_control" "{{.AccessControlIdentifier0}}" {
   vapp_id = vcd_vapp.{{.VappName0}}.id
 
   shared_with_everyone = {{.SharedToEveryone}}
-  {{.EveryoneAccessLevel}}
+{{.EveryoneAccessLevel}}
 }
 
 resource "vcd_vapp_access_control" "{{.AccessControlIdentifier1}}" {

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -324,13 +324,13 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   # You cannot remove NICs from an active virtual machine on which no operating system is installed.
   power_on = false
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  description   = "test empty VM"
-  name          = "{{.VMName}}"
-  memory        = 512
-  cpus          = 2
-  cpu_cores     = 1 
-  
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  description = "test empty VM"
+  name        = "{{.VMName}}"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -413,7 +413,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
- }
+}
 `
 
 const testAccCheckVcdVAppEmptyVmStep1 = testAccCheckVcdVAppEmptyVmNetworkShared + `

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -346,7 +346,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	adapter_type       = "PCNet32"
+    adapter_type       = "PCNet32"
   }
 
   network {
@@ -371,7 +371,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     ip_allocation_mode = "POOL"
     is_primary         = false
     adapter_type       = "e1000e"
-	mac                = "00:00:00:11:11:11"
+    mac                = "00:00:00:11:11:11"
   }
 
   network {
@@ -410,7 +410,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
  }
@@ -489,8 +489,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
-  } 
+  }
 }
 `

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -419,23 +419,23 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 const testAccCheckVcdVAppEmptyVmStep1 = testAccCheckVcdVAppEmptyVmNetworkShared + `
 # skip-binary-test: only for updates
 resource "vcd_vapp" "{{.VAppName}}" {
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
-	name       = "{{.VAppName}}"
-	depends_on = ["vcd_network_routed.net", "vcd_network_routed.net2"]
+  name       = "{{.VAppName}}"
+  depends_on = ["vcd_network_routed.net", "vcd_network_routed.net2"]
 }
 
 resource "vcd_vapp_vm" "{{.VMName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  name          = "{{.VMName}}"
-  memory        = 512
-  cpus          = 2
-  cpu_cores     = 1
-  description   = "test empty VM updated"
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  name        = "{{.VMName}}"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+  description = "test empty VM updated"
 
   os_type                        = "rhel4Guest"
   hardware_version               = "vmx-14"
@@ -471,7 +471,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	mac                = "00:00:00:11:11:11"
+    mac                = "00:00:00:11:11:11"
   }
 
   network {

--- a/vcd/resource_vcd_vapp_firewall_rules_test.go
+++ b/vcd/resource_vcd_vapp_firewall_rules_test.go
@@ -328,8 +328,8 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
   name        = "{{.VmName1}}"
   memory      = 512
   cpus        = 2
-  cpu_cores   = 1 
-  
+  cpu_cores   = 1
+
   os_type                        = "sles10_64Guest"
   hardware_version               = "vmx-11"
   expose_hardware_virtualization = true
@@ -344,16 +344,16 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName2}}" {
-  org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
-  vapp_name     = vcd_vapp.{{.VappName}}.name
+  org       = "{{.Org}}"
+  vdc       = "{{.Vdc}}"
+  vapp_name = vcd_vapp.{{.VappName}}.name
 
   description = "test empty VM"
   name        = "{{.VmName2}}"
   memory      = 512
   cpus        = 2
-  cpu_cores   = 1 
-  
+  cpu_cores   = 1
+
   os_type          = "sles10_64Guest"
   hardware_version = "vmx-11"
   computer_name    = "compName"

--- a/vcd/resource_vcd_vapp_firewall_rules_test.go
+++ b/vcd/resource_vcd_vapp_firewall_rules_test.go
@@ -361,7 +361,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
     type               = "vapp"
     name               = vcd_vapp_network.vappRoutedNet.name
     ip_allocation_mode = "MANUAL"
-    ip            = "192.168.2.12"
+    ip                 = "192.168.2.12"
   }
 
   network {
@@ -385,7 +385,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   enabled = true
 
   rule {
-    name      = "{{.Name1}}"
+    name             = "{{.Name1}}"
     policy           = "drop"
     protocol         = "udp"
     destination_port = "21"
@@ -395,7 +395,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name      = "{{.Name2}}"
+    name             = "{{.Name2}}"
     policy           = "allow"
     protocol         = "any"
     destination_port = "any"
@@ -405,7 +405,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name            = "{{.Name3}}"
+    name                   = "{{.Name3}}"
     policy                 = "allow"
     protocol               = "any"
     destination_vm_id      = vcd_vapp_vm.{{.VmName2}}.id
@@ -419,7 +419,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name      = "{{.Name4}}"
+    name             = "{{.Name4}}"
     enabled          = false
     policy           = "drop"
     protocol         = "any"
@@ -441,7 +441,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}2" {
   log_default_action = true
 
   rule {
-    name      = "{{.Name1}}"
+    name             = "{{.Name1}}"
     policy           = "drop"
     protocol         = "udp"
     destination_port = "221"
@@ -465,7 +465,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   enabled = false
 
   rule {
-    name      = "{{.Name1}}"
+    name             = "{{.Name1}}"
     policy           = "drop"
     protocol         = "udp"
     destination_port = "21"
@@ -475,7 +475,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name      = "{{.Name2}}"
+    name             = "{{.Name2}}"
     policy           = "allow"
     protocol         = "any"
     destination_port = "any"
@@ -485,7 +485,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name      = "{{.Name4}}"
+    name             = "{{.Name4}}"
     enabled          = false
     policy           = "drop"
     protocol         = "any"
@@ -497,7 +497,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}" {
   }
 
   rule {
-    name            = "{{.Name3}}"
+    name                   = "{{.Name3}}"
     policy                 = "allow"
     protocol               = "any"
     destination_vm_id      = vcd_vapp_vm.{{.VmName2}}.id
@@ -523,7 +523,7 @@ resource "vcd_vapp_firewall_rules" "{{.ResourceName}}2" {
   enabled = false
 
   rule {
-    name      = "{{.Name1}}"
+    name             = "{{.Name1}}"
     policy           = "drop"
     protocol         = "udp"
     destination_port = "221"

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -28,9 +28,9 @@ func TestAccVcdVAppMultiVmInTemplate(t *testing.T) {
 	vappName := t.Name()
 	vmName := t.Name() + "VM"
 	vmName2 := t.Name() + "VM2"
-	catalogItemMultiVm := "template_name       = vcd_catalog_item.defaultOva.name"
+	catalogItemMultiVm := "template_name = vcd_catalog_item.defaultOva.name"
 	if testConfig.VCD.Catalog.CatalogItemWithMultiVms != "" {
-		catalogItemMultiVm = "template_name  = \"" + testConfig.VCD.Catalog.CatalogItemWithMultiVms + "\""
+		catalogItemMultiVm = "template_name = \"" + testConfig.VCD.Catalog.CatalogItemWithMultiVms + "\""
 		t.Log("Test using `catalogItemWithMultiVms` variable from configuration")
 	} else {
 		t.Log("Test using `ovaVappMultiVmsPath` variable from configuration")
@@ -106,8 +106,8 @@ resource "vcd_catalog_item" "defaultOva" {
   org     = "{{.Org}}"
   catalog = "{{.Catalog}}"
 
-  name                 = "TestAccVcdVAppMultiVmInTemplate"
-  ova_path             = "{{.OvaPath}}"
+  name     = "TestAccVcdVAppMultiVmInTemplate"
+  ova_path = "{{.OvaPath}}"
 }
 `
 

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -139,13 +139,15 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {
-  org         	      = "{{.Org}}"
-  vdc         	      = "{{.Vdc}}"
-  vapp_name 	      = vcd_vapp.{{.VappName}}.name
-  name    	          = "{{.VmName}}"
-  computer_name       = "{{.ComputerName}}"
-  catalog_name	      = "{{.Catalog}}"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.{{.VappName}}.name
+  name          = "{{.VmName}}"
+  computer_name = "{{.ComputerName}}"
+  catalog_name	= "{{.Catalog}}"
+
   {{.CatalogItemMultiVm}}
+
   vm_name_in_template = "{{.VmNameInTemplate}}"
   memory              = 1024
   cpus                = 2
@@ -164,13 +166,15 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName2}}" {
-  org         	      = "{{.Org}}"
-  vdc         	      = "{{.Vdc}}"
-  vapp_name           = vcd_vapp.{{.VappName}}.name
-  name	              = "{{.VmName2}}"
-  computer_name       = "{{.ComputerName}}"
-  catalog_name	      = "{{.Catalog}}"
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.{{.VappName}}.name
+  name          = "{{.VmName2}}"
+  computer_name = "{{.ComputerName}}"
+  catalog_name  = "{{.Catalog}}"
+
   {{.CatalogItemMultiVm}}
+
   vm_name_in_template = "{{.VmNameInTemplate2}}"
   memory              = 1024
   cpus                = 2

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -144,7 +144,7 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   vapp_name     = vcd_vapp.{{.VappName}}.name
   name          = "{{.VmName}}"
   computer_name = "{{.ComputerName}}"
-  catalog_name	= "{{.Catalog}}"
+  catalog_name  = "{{.Catalog}}"
 
   {{.CatalogItemMultiVm}}
 

--- a/vcd/resource_vcd_vapp_nat_rules_test.go
+++ b/vcd/resource_vcd_vapp_nat_rules_test.go
@@ -277,7 +277,7 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
   name        = "{{.VmName1}}"
   memory      = 512
   cpus        = 2
-  cpu_cores   = 1 
+  cpu_cores   = 1
 
   power_on = false  
 
@@ -295,15 +295,15 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
 }
 
 resource "vcd_vapp_vm" "{{.VmName2}}" {
-  org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
-  vapp_name     = vcd_vapp.{{.VappName}}.name
+  org       = "{{.Org}}"
+  vdc       = "{{.Vdc}}"
+  vapp_name = vcd_vapp.{{.VappName}}.name
 
   description = "test empty VM"
   name        = "{{.VmName2}}"
   memory      = 512
   cpus        = 2
-  cpu_cores   = 1 
+  cpu_cores   = 1
 
   power_on = false
   
@@ -314,7 +314,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
     type               = "vapp"
     name               = vcd_vapp_network.vappRoutedNet.name
     ip_allocation_mode = "MANUAL"
-    ip            = "192.168.22.12"
+    ip                 = "192.168.22.12"
   }
 
   network {
@@ -328,10 +328,10 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
 const testAccVcdVappNatRules_rules = testAccVcdVappNatRules_vappAndVm + `
 # For NAT rules to work, firewall has to be enabled.
 resource "vcd_vapp_firewall_rules" "vapp_fw" {
-  vapp_id    = vcd_vapp.TestAccVcdVappNatRules_vapp.id
-  network_id = vcd_vapp_network.vappRoutedNet.id
+  vapp_id        = vcd_vapp.TestAccVcdVappNatRules_vapp.id
+  network_id     = vcd_vapp_network.vappRoutedNet.id
   default_action = "drop"
-  enabled = true
+  enabled        = true
 }
 
 resource "vcd_vapp_nat_rules" "{{.ResourceName}}" {
@@ -343,7 +343,7 @@ resource "vcd_vapp_nat_rules" "{{.ResourceName}}" {
   enabled    = true
 
   rule {
-    mapping_mode = "automatic" 
+    mapping_mode = "automatic"
     vm_nic_id    = 0
     vm_id        = vcd_vapp_vm.{{.VmName1}}.id
   }
@@ -361,17 +361,17 @@ resource "vcd_vapp_nat_rules" "{{.ResourceName}}2" {
   vdc        = "{{.Vdc}}"
   vapp_id    = vcd_vapp.TestAccVcdVappNatRules_vapp.id
   network_id = vcd_vapp_org_network.vappAttachedNet.id
-  
+
   nat_type             = "portForwarding"
   enable_ip_masquerade = true
   enabled              = true
 
   rule {
-    external_port        = 22
-    vm_nic_id            = 0
-    forward_to_port      = 80
-    protocol             = "TCP_UDP"
-    vm_id                = vcd_vapp_vm.{{.VmName1}}.id
+    external_port   = 22
+    vm_nic_id       = 0
+    forward_to_port = 80
+    protocol        = "TCP_UDP"
+    vm_id           = vcd_vapp_vm.{{.VmName1}}.id
   }
 
   rule {
@@ -387,10 +387,10 @@ resource "vcd_vapp_nat_rules" "{{.ResourceName}}2" {
 const testAccVcdVappNatRules_rules_forUpdate = testAccVcdVappNatRules_vappAndVm + `
 # For NAT rules to work, firewall has to be enabled.
 resource "vcd_vapp_firewall_rules" "vapp_fw" {
-  vapp_id    = vcd_vapp.TestAccVcdVappNatRules_vapp.id
-  network_id = vcd_vapp_network.vappRoutedNet.id
+  vapp_id        = vcd_vapp.TestAccVcdVappNatRules_vapp.id
+  network_id     = vcd_vapp_network.vappRoutedNet.id
   default_action = "drop"
-  enabled = true
+  enabled        = true
 }
 
 resource "vcd_vapp_nat_rules" "{{.ResourceName}}" {
@@ -421,7 +421,7 @@ resource "vcd_vapp_nat_rules" "{{.ResourceName}}2" {
   vdc        = "{{.Vdc}}"
   vapp_id    = vcd_vapp.TestAccVcdVappNatRules_vapp.id
   network_id = vcd_vapp_org_network.vappAttachedNet.id
- 
+
   nat_type             = "portForwarding"
   enable_ip_masquerade = false
   enabled              = false
@@ -435,11 +435,11 @@ resource "vcd_vapp_nat_rules" "{{.ResourceName}}2" {
   }
 
   rule {
-    external_port        = 222
-    vm_nic_id            = 0
-    forward_to_port      = 800
-    protocol             = "UDP"
-    vm_id                = vcd_vapp_vm.{{.VmName1}}.id
+    external_port   = 222
+    vm_nic_id       = 0
+    forward_to_port = 800
+    protocol        = "UDP"
+    vm_id           = vcd_vapp_vm.{{.VmName1}}.id
   }
 }
 `

--- a/vcd/resource_vcd_vapp_nat_rules_test.go
+++ b/vcd/resource_vcd_vapp_nat_rules_test.go
@@ -279,7 +279,7 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
   cpus        = 2
   cpu_cores   = 1
 
-  power_on = false  
+  power_on = false
 
   os_type                        = "sles10_64Guest"
   hardware_version               = "vmx-11"
@@ -306,7 +306,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
   cpu_cores   = 1
 
   power_on = false
-  
+
   os_type          = "sles10_64Guest"
   hardware_version = "vmx-11"
   computer_name    = "compName"

--- a/vcd/resource_vcd_vapp_org_network_test.go
+++ b/vcd/resource_vcd_vapp_org_network_test.go
@@ -134,11 +134,11 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
 }
 
 resource "vcd_vapp_org_network" "{{.resourceName}}" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.vappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name
-  
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.vappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
+
   is_fenced = "{{.isFenced}}"
 
   retain_ip_mac_enabled = "{{.retainIpMacEnabled}}"
@@ -167,11 +167,11 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
 }
 
 resource "vcd_vapp_org_network" "{{.resourceName}}" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.vappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name
-  
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.vappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
+
   is_fenced = "{{.isFencedForUpdate}}"
 
   retain_ip_mac_enabled = "{{.retainIpMacEnabledForUpdate}}"

--- a/vcd/resource_vcd_vapp_properties_test.go
+++ b/vcd/resource_vcd_vapp_properties_test.go
@@ -86,8 +86,8 @@ resource "vcd_vapp" "{{.VappName}}" {
   vdc  = "{{.Vdc}}"
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 }
 `
@@ -99,8 +99,8 @@ resource "vcd_vapp" "{{.VappName}}" {
   vdc  = "{{.Vdc}}"
 
   guest_properties = {
-	"guest.another.subkey" = "new-value"
-	"guest.third.subkey"   = "third-value"
+    "guest.another.subkey" = "new-value"
+    "guest.third.subkey"   = "third-value"
   }
 }
 `

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -121,6 +121,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
   name = "{{.VappName}}"
+
   depends_on   = ["vcd_network_routed.{{.NetworkName}}"]
 }
 
@@ -128,7 +129,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VappName}}.name
-  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -122,7 +122,7 @@ resource "vcd_vapp" "{{.VappName}}" {
   vdc  = "{{.Vdc}}"
   name = "{{.VappName}}"
 
-  depends_on   = ["vcd_network_routed.{{.NetworkName}}"]
+  depends_on = ["vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -125,10 +125,10 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_static_routing_test.go
+++ b/vcd/resource_vcd_vapp_static_routing_test.go
@@ -188,7 +188,7 @@ resource "vcd_vapp_static_routing" "{{.ResourceName}}" {
   vdc        = "{{.Vdc}}"
   vapp_id    = vcd_vapp.{{.VappName}}.id
   network_id = vcd_vapp_network.vappRoutedNet.id
-  enabled     = true
+  enabled    = true
 
   rule {
     name         = "rule1"
@@ -210,7 +210,7 @@ resource "vcd_vapp_static_routing" "{{.ResourceName}}" {
   vdc        = "{{.Vdc}}"
   vapp_id    = vcd_vapp.{{.VappName}}.id
   network_id = vcd_vapp_network.vappRoutedNet.id
-  enabled     = false
+  enabled    = false
 
   rule {
     name         = "rule1"

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -163,8 +163,8 @@ resource "vcd_vapp" "{{.VappName}}" {
   }
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 }
 

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -153,10 +153,10 @@ func init() {
 const testAccCheckVcdVApp_basic = `
 
 resource "vcd_vapp" "{{.VappName}}" {
-  org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
-  name          = "{{.VappName}}"
-  description   = "{{.VappDescription}}"
+  org         = "{{.Org}}"
+  vdc         = "{{.Vdc}}"
+  name        = "{{.VappName}}"
+  description = "{{.VappDescription}}"
 
   metadata = {
     vapp_metadata = "vApp Metadata."
@@ -170,25 +170,25 @@ resource "vcd_vapp" "{{.VappName}}" {
 
 # needed to check power on on update in next step
 resource "vcd_vapp_vm" "test_vm1" {
-  vapp_name     = vcd_vapp.{{.VappName}}.name
-  name          = "test_vm1"
-  memory        = 512
-  cpus          = 1
-  cpu_cores     = 1 
+  vapp_name = vcd_vapp.{{.VappName}}.name
+  name      = "test_vm1"
+  memory    = 512
+  cpus      = 1
+  cpu_cores = 1 
 
-  os_type                        = "rhel4Guest"
-  hardware_version               = "vmx-14"
-  computer_name                  = "compNameUp"
+  os_type          = "rhel4Guest"
+  hardware_version = "vmx-14"
+  computer_name    = "compNameUp"
 }
 `
 
 const testAccCheckVcdVApp_update = `
 # skip-binary-test: only for updates
 resource "vcd_vapp" "{{.VappName}}" {
-  org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
-  name          = "{{.VappName}}"
-  description   = "{{.VappDescription}}"
+  org         = "{{.Org}}"
+  vdc         = "{{.Vdc}}"
+  name        = "{{.VappName}}"
+  description = "{{.VappDescription}}"
 
   metadata = {
     vapp_metadata = "vApp Metadata updated"
@@ -204,14 +204,14 @@ resource "vcd_vapp" "{{.VappName}}" {
 
 # vApp power on won't work if vApp doesn't have VM
 resource "vcd_vapp_vm" "test_vm1" {
-  vapp_name     = vcd_vapp.{{.VappName}}.name
-  name          = "test_vm1"
-  memory        = 512
-  cpus          = 1
-  cpu_cores     = 1 
+  vapp_name = vcd_vapp.{{.VappName}}.name
+  name      = "test_vm1"
+  memory    = 512
+  cpus      = 1
+  cpu_cores = 1 
 
-  os_type                        = "rhel4Guest"
-  hardware_version               = "vmx-14"
-  computer_name                  = "compNameUp"
+  os_type          = "rhel4Guest"
+  hardware_version = "vmx-14"
+  computer_name    = "compNameUp"
 }
 `

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -174,7 +174,7 @@ resource "vcd_vapp_vm" "test_vm1" {
   name      = "test_vm1"
   memory    = 512
   cpus      = 1
-  cpu_cores = 1 
+  cpu_cores = 1
 
   os_type          = "rhel4Guest"
   hardware_version = "vmx-14"
@@ -195,8 +195,8 @@ resource "vcd_vapp" "{{.VappName}}" {
   }
 
   guest_properties = {
-	"guest.another.subkey" = "new-value"
-	"guest.third.subkey"   = "third-value"
+    "guest.another.subkey" = "new-value"
+    "guest.third.subkey"   = "third-value"
   }
 
   power_on = true

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -208,7 +208,7 @@ resource "vcd_vapp_vm" "test_vm1" {
   name      = "test_vm1"
   memory    = 512
   cpus      = 1
-  cpu_cores = 1 
+  cpu_cores = 1
 
   os_type          = "rhel4Guest"
   hardware_version = "vmx-14"

--- a/vcd/resource_vcd_vapp_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vapp_vm_capabilities_test.go
@@ -83,7 +83,6 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
-  
 }
 `
 

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -480,11 +480,11 @@ resource "vcd_vapp_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-    enabled         = false
-    admin_password  = "some password"
+    enabled                = false
+    admin_password         = "some password"
     auto_generate_password = false
-    join_domain     = true
-    join_org_domain = true
+    join_domain            = true
+    join_org_domain        = true
   }
 }
 `

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -226,7 +226,7 @@ resource "vcd_vapp" "test-vapp" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  name       = "{{.VAppName}}"
+  name = "{{.VAppName}}"
 }
 
 resource "vcd_vapp_network" "vappNet" {

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -455,12 +455,12 @@ resource "vcd_vapp_vm" "test-vm" {
   cpu_cores     = 1
 
   customization {
-	enabled                             = true
-	change_sid                          = true
-	allow_local_admin_password          = false
-	must_change_password_on_first_login = true
-	auto_generate_password              = true
-	number_of_auto_logons               = 4
+    enabled                             = true
+    change_sid                          = true
+    allow_local_admin_password          = false
+    must_change_password_on_first_login = true
+    auto_generate_password              = true
+    number_of_auto_logons               = 4
   }
 }
 `
@@ -480,11 +480,11 @@ resource "vcd_vapp_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-	enabled         = false
-	admin_password  = "some password"
-	auto_generate_password = false
-	join_domain     = true
-	join_org_domain = true
+    enabled         = false
+    admin_password  = "some password"
+    auto_generate_password = false
+    join_domain     = true
+    join_org_domain = true
   }
 }
 `
@@ -504,12 +504,12 @@ resource "vcd_vapp_vm" "test-vm-step3" {
   cpu_cores     = 1
 
   customization {
-	enabled                = true
-	join_domain            = true
-	join_domain_name       = "UnrealDomain"
-	join_domain_user       = "NoUser"
-	join_domain_password   = "NoPass"
-	join_domain_account_ou = "ou=IT,dc=some,dc=com"
+    enabled                = true
+    join_domain            = true
+    join_domain_name       = "UnrealDomain"
+    join_domain_user       = "NoUser"
+    join_domain_password   = "NoPass"
+    join_domain_account_ou = "ou=IT,dc=some,dc=com"
   }
 }
 `

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -118,7 +118,7 @@ resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  name       = "{{.VAppName}}" 
+  name = "{{.VAppName}}" 
 }
 
 resource "vcd_network_routed" "net" {
@@ -144,7 +144,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VAppName}}.name
-  org_network_name = vcd_network_routed.net.name 
+  org_network_name = vcd_network_routed.net.name
 }
 `
 
@@ -169,7 +169,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     ip_allocation_mode = "DHCP"
     is_primary         = true
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -141,12 +141,11 @@ resource "vcd_network_routed" "net" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VAppName}}.name
-  org_network_name   = vcd_network_routed.net.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VAppName}}.name
+  org_network_name = vcd_network_routed.net.name 
 }
-
 `
 
 const testAccCheckVcdVAppVmDhcpWait = testAccCheckVcdVAppVmDhcpWaitShared + `

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -118,7 +118,7 @@ resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  name = "{{.VAppName}}" 
+  name = "{{.VAppName}}"
 }
 
 resource "vcd_network_routed" "net" {

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -565,7 +565,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     ip_allocation_mode = "DHCP"
     is_primary         = true
   }
- 
+
   storage_profile = "{{.StorageProfile2}}"
 }
 `

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -5,12 +5,13 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 func TestAccVcdVAppHotUpdateVm(t *testing.T) {
@@ -331,8 +332,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
 
-  memory        = 2048
-  cpus          = 1
+  memory = 2048
+  cpus   = 1
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -351,7 +352,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   }
 
   metadata = {
-    mediaItem_metadata = "data 1"
+    mediaItem_metadata  = "data 1"
     mediaItem_metadata2 = "data 2"
     mediaItem_metadata3 = "data 3"
   }
@@ -378,8 +379,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
  
-  memory        = 3072
-  cpus          = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -398,12 +399,12 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   }
 
   metadata = {
-    mediaItem_metadata = "data 1"
+    mediaItem_metadata  = "data 1"
     mediaItem_metadata2 = "data 3"
   }
 
   guest_properties = {
-	"guest.hostname"       = "test-host2"
+	"guest.hostname" = "test-host2"
   }
 
   storage_profile = "{{.StorageProfile2}}"
@@ -423,8 +424,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
  
-  memory        = 3072
-  cpus          = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = false
   memory_hot_add_enabled = true
@@ -460,8 +461,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
  
-  memory        = 3072
-  cpus          = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -504,8 +505,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
  
-  memory        = 3072
-  cpus          = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -543,8 +544,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
  
-  memory        = 3072
-  cpus          = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -288,7 +288,7 @@ resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  name       = "{{.VAppName}}"
+  name = "{{.VAppName}}"
 }
 
 resource "vcd_network_routed" "net" {
@@ -314,7 +314,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VAppName}}.name
-  org_network_name = vcd_network_routed.net.name 
+  org_network_name = vcd_network_routed.net.name
 }
 `
 
@@ -363,7 +363,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   }
 
   storage_profile = "{{.StorageProfile}}"
- }
+}
 `
 
 const testAccCheckVcdVAppHotUpdateVmStep1 = `# skip-binary-test: only for updates

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -311,10 +311,10 @@ resource "vcd_network_routed" "net" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VAppName}}.name
-  org_network_name   = vcd_network_routed.net.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VAppName}}.name
+  org_network_name = vcd_network_routed.net.name 
 }
 `
 
@@ -343,7 +343,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     ip_allocation_mode = "NONE"
     connected          = false
   }
- 
+
   network {
     type               = "org"
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
@@ -358,8 +358,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   }
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 
   storage_profile = "{{.StorageProfile}}"
@@ -378,7 +378,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
+
   memory = 3072
   cpus   = 3
 
@@ -390,7 +390,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -404,7 +404,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   }
 
   guest_properties = {
-	"guest.hostname" = "test-host2"
+    "guest.hostname" = "test-host2"
   }
 
   storage_profile = "{{.StorageProfile2}}"
@@ -423,7 +423,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
+
   memory = 3072
   cpus   = 3
 
@@ -437,7 +437,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -460,7 +460,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
+
   memory = 3072
   cpus   = 3
 
@@ -474,7 +474,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -504,7 +504,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
+
   memory = 3072
   cpus   = 3
 
@@ -543,7 +543,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
+
   memory = 3072
   cpus   = 3
 

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -159,10 +159,10 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
 }
 
 resource "vcd_vapp_vm" "{{.VmName1}}" {
@@ -180,16 +180,16 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
     type               = "org"
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "MANUAL"
-    ip            = "10.10.102.161"
+    ip                 = "10.10.102.161"
   }
 
   disk {
-    name = vcd_independent_disk.{{.diskResourceName}}.name
-    bus_number = 1
+    name        = vcd_independent_disk.{{.diskResourceName}}.name
+    bus_number  = 1
     unit_number = 0
   }
 
-  depends_on    = ["vcd_vapp.{{.VappName}}","vcd_independent_disk.{{.diskResourceName}}", "vcd_network_routed.{{.NetworkName}}"]
+  depends_on = ["vcd_vapp.{{.VappName}}","vcd_independent_disk.{{.diskResourceName}}", "vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_vm" "{{.VmName2}}" {
@@ -201,7 +201,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
   template_name = "{{.CatalogItem}}"
   memory        = 1024
   cpus          = 2
-  cpu_cores     = 1 
+  cpu_cores     = 1
 
   network {
     type               = "org"
@@ -222,14 +222,12 @@ resource "vcd_vapp_vm" "{{.VmName3}}" {
   memory        = 1024
   cpus          = 2
   cpu_cores     = 1
-  
+
   network {
     type               = "org"
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "MANUAL"
     ip                 = "10.10.102.163"
   }
-
 }
-
 `

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -189,7 +189,7 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
     unit_number = 0
   }
 
-  depends_on = ["vcd_vapp.{{.VappName}}","vcd_independent_disk.{{.diskResourceName}}", "vcd_network_routed.{{.NetworkName}}"]
+  depends_on = ["vcd_vapp.{{.VappName}}", "vcd_independent_disk.{{.diskResourceName}}", "vcd_network_routed.{{.NetworkName}}"]
 }
 
 resource "vcd_vapp_vm" "{{.VmName2}}" {

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -207,7 +207,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
     type               = "org"
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "MANUAL"
-    ip            = "10.10.102.162"
+    ip                 = "10.10.102.162"
   }
 
 }
@@ -227,7 +227,7 @@ resource "vcd_vapp_vm" "{{.VmName3}}" {
     type               = "org"
     name               = vcd_vapp_org_network.vappNetwork1.org_network_name
     ip_allocation_mode = "MANUAL"
-    ip            = "10.10.102.163"
+    ip                 = "10.10.102.163"
   }
 
 }

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -162,7 +162,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VappName}}.name
-  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
 }
 
 resource "vcd_vapp_vm" "{{.VmName1}}" {

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -365,7 +365,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	adapter_type       = "PCNet32" 
+    adapter_type       = "PCNet32" 
   }
 
   network {
@@ -405,7 +405,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
-    connected          = false  
+    connected          = false
   }
 
   network {
@@ -433,7 +433,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
- }
+}
 `
 
 const testAccCheckVcdVAppVmNetworkVmStep1 = testAccCheckVcdVAppVmNetworkShared + `

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -496,7 +496,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
 }

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -391,7 +391,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     ip_allocation_mode = "POOL"
     is_primary         = false
     adapter_type       = "e1000e"
-	mac                = "00:00:00:11:11:11"
+    mac                = "00:00:00:11:11:11"
   }
 
   network {
@@ -430,7 +430,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
  }
@@ -478,7 +478,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net2.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-	mac                = "00:00:00:11:11:11"
+    mac                = "00:00:00:11:11:11"
   }
 
   network {

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -365,7 +365,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net.name
     ip_allocation_mode = "POOL"
     is_primary         = false
-    adapter_type       = "PCNet32" 
+    adapter_type       = "PCNet32"
   }
 
   network {

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -96,8 +96,8 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   cpu_cores     = 1
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 }
 `
@@ -121,8 +121,8 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   cpu_cores     = 1
 
   guest_properties = {
-	"guest.another.subkey" = "new-value"
-	"guest.third.subkey"   = "third-value"
+    "guest.another.subkey" = "new-value"
+    "guest.third.subkey"   = "third-value"
   }
 }
 `

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -264,10 +264,10 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -195,10 +195,10 @@ resource "vcd_vapp" "{{.VappName}}" {
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
-  org                = "{{.Org}}"
-  vdc                = "{{.Vdc}}"
-  vapp_name          = vcd_vapp.{{.VappName}}.name
-  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+  org              = "{{.Org}}"
+  vdc              = "{{.Vdc}}"
+  vapp_name        = vcd_vapp.{{.VappName}}.name
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -260,14 +260,14 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
 resource "vcd_vapp" "{{.VappName}}" {
   name = "{{.VappName}}"
   org  = "{{.Org}}"
-  vdc  = "{{.Vdc}}" 
+  vdc  = "{{.Vdc}}"
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VappName}}.name
-  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -198,7 +198,7 @@ resource "vcd_vapp_org_network" "vappNetwork1" {
   org              = "{{.Org}}"
   vdc              = "{{.Vdc}}"
   vapp_name        = vcd_vapp.{{.VappName}}.name
-  org_network_name = vcd_network_routed.{{.NetworkName}}.name 
+  org_network_name = vcd_network_routed.{{.NetworkName}}.name
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -365,7 +365,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   vapp_name   = vcd_vapp.{{.VAppName}}.name
   description = "test empty VM"
   name        = "{{.VMName}}"
-  
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -384,10 +384,10 @@ resource "vcd_vapp_vm" "{{.VMName}}2" {
 
   power_on = true
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  description   = "test empty VM2"
-  name          = "{{.VMName}}2"
-  
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  description = "test empty VM2"
+  name        = "{{.VMName}}2"
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"
@@ -434,9 +434,9 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   org = "{{.Org}}"
   vdc = vcd_org_vdc.{{.VdcName}}.name
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  name          = "{{.VMName}}"
-  description   = "test empty VM updated"
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  name        = "{{.VMName}}"
+  description = "test empty VM updated"
 
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -455,10 +455,10 @@ resource "vcd_vapp_vm" "{{.VMName}}2" {
 
   power_on = true
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  description   = "test empty VM2"
-  name          = "{{.VMName}}2"
-  
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  description = "test empty VM2"
+  name        = "{{.VMName}}2"
+
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
   catalog_name                   = "{{.Catalog}}"

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -326,10 +326,10 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
   storage_profile {
-    name     = "{{.ProviderVdcStorageProfile}}"
-    enabled  = true
-    limit    = 90240
-    default  = true
+    name    = "{{.ProviderVdcStorageProfile}}"
+    enabled = true
+    limit   = 90240
+    default = true
   }
 
   metadata = {
@@ -345,14 +345,14 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   {{.FlexMemoryOverheadKey}} {{.equalsChar}} {{.FlexMemoryOverheadValue}}
 
   default_vm_sizing_policy_id = vcd_vm_sizing_policy.size_full.id
-  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.size_cpu.id,vcd_vm_sizing_policy.size_full.id]
+  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id, vcd_vm_sizing_policy.size_cpu.id, vcd_vm_sizing_policy.size_full.id]
 }
 
 resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"
   vdc = vcd_org_vdc.{{.VdcName}}.name
 
-  name       = "{{.VAppName}}"
+  name = "{{.VAppName}}"
 }
 `
 const testAccCheckVcdVAppEmptyVmWithSizing = testAccCheckVcdVAppEmptyWithSizing + `
@@ -362,9 +362,9 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   power_on = true
 
-  vapp_name     = vcd_vapp.{{.VAppName}}.name
-  description   = "test empty VM"
-  name          = "{{.VMName}}"
+  vapp_name   = vcd_vapp.{{.VAppName}}.name
+  description = "test empty VM"
+  name        = "{{.VMName}}"
   
   os_type                        = "sles11_64Guest"
   hardware_version               = "vmx-13"
@@ -376,7 +376,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   memory           = 1024
- }
+}
 
 resource "vcd_vapp_vm" "{{.VMName}}2" {
   org = "{{.Org}}"
@@ -397,7 +397,7 @@ resource "vcd_vapp_vm" "{{.VMName}}2" {
   memory_hot_add_enabled = true
 
   sizing_policy_id = vcd_vm_sizing_policy.size_full.id
- }
+}
 
 resource "vcd_vapp_vm" "{{.VMName}}3" {
   org = "{{.Org}}"
@@ -424,7 +424,7 @@ resource "vcd_vapp_vm" "{{.VMName}}4" {
   power_on      = "false"
 
   sizing_policy_id = vcd_vm_sizing_policy.size_full.id
- }
+}
 `
 
 const testAccCheckVcdVAppEmptyVmWithSizingUpdate = "# skip-binary-test: only for updates " +

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -469,7 +469,7 @@ resource "vcd_vapp_vm" "{{.VMName}}2" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   # allows to change only not defined in sizing policy
-  memory           = 2048
+  memory = 2048
 }
 
 resource "vcd_vapp_vm" "{{.VMName}}3" {
@@ -484,7 +484,7 @@ resource "vcd_vapp_vm" "{{.VMName}}3" {
 
   sizing_policy_id = vcd_vm_sizing_policy.size_cpu.id
   # allows to change only not defined in sizing policy
-  memory           = 3072
+  memory = 3072
 }
 
 resource "vcd_vapp_vm" "{{.VMName}}5" {

--- a/vcd/resource_vcd_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vm_capabilities_test.go
@@ -77,7 +77,6 @@ resource "vcd_vm" "{{.VmName}}" {
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
-  
 }
 `
 

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -352,12 +352,12 @@ resource "vcd_vm" "test-vm" {
   cpu_cores     = 1
 
   customization {
-	enabled                             = true
-	change_sid                          = true
-	allow_local_admin_password          = false
-	must_change_password_on_first_login = true
-	auto_generate_password              = true
-	number_of_auto_logons               = 4
+    enabled                             = true
+    change_sid                          = true
+    allow_local_admin_password          = false
+    must_change_password_on_first_login = true
+    auto_generate_password              = true
+    number_of_auto_logons               = 4
   }
 }
 `
@@ -376,11 +376,11 @@ resource "vcd_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-	enabled         = false
-	admin_password  = "some password"
-	auto_generate_password = false
-	join_domain     = true
-	join_org_domain = true
+    enabled         = false
+    admin_password  = "some password"
+    auto_generate_password = false
+    join_domain     = true
+    join_org_domain = true
   }
 }
 `
@@ -399,12 +399,12 @@ resource "vcd_vm" "test-vm-step3" {
   cpu_cores     = 1
 
   customization {
-	enabled                = true
-	join_domain            = true
-	join_domain_name       = "UnrealDomain"
-	join_domain_user       = "NoUser"
-	join_domain_password   = "NoPass"
-	join_domain_account_ou = "ou=IT,dc=some,dc=com"
+    enabled                = true
+    join_domain            = true
+    join_domain_name       = "UnrealDomain"
+    join_domain_user       = "NoUser"
+    join_domain_password   = "NoPass"
+    join_domain_account_ou = "ou=IT,dc=some,dc=com"
   }
 }
 `

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -376,11 +376,11 @@ resource "vcd_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-    enabled         = false
-    admin_password  = "some password"
+    enabled                = false
+    admin_password         = "some password"
     auto_generate_password = false
-    join_domain     = true
-    join_org_domain = true
+    join_domain            = true
+    join_org_domain        = true
   }
 }
 `

--- a/vcd/resource_vcd_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vm_dhcp_wait_test.go
@@ -150,7 +150,7 @@ resource "vcd_vm" "{{.VMName}}" {
     ip_allocation_mode = "DHCP"
     is_primary         = true
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -311,7 +311,7 @@ resource "vcd_vm" "{{.VMName}}" {
   }
 
   guest_properties = {
-	"guest.hostname" = "test-host2"
+    "guest.hostname" = "test-host2"
   }
 
   storage_profile = "{{.StorageProfile2}}"

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -251,7 +251,7 @@ resource "vcd_vm" "{{.VMName}}" {
     ip_allocation_mode = "NONE"
     connected          = false
   }
- 
+
   network {
     type               = "org"
     name               = vcd_network_routed.net.name
@@ -266,12 +266,12 @@ resource "vcd_vm" "{{.VMName}}" {
   }
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 
   storage_profile = "{{.StorageProfile}}"
- }
+}
 `
 
 const testAccCheckVcdHotUpdateVmStep1 = `# skip-binary-test: only for updates
@@ -409,8 +409,8 @@ resource "vcd_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
 
-  memory= 3072
-  cpus  = 3
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -240,8 +240,8 @@ resource "vcd_vm" "{{.VMName}}" {
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
 
-  memory        = 2048
-  cpus          = 1
+  memory = 2048
+  cpus   = 1
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -260,7 +260,7 @@ resource "vcd_vm" "{{.VMName}}" {
   }
 
   metadata = {
-    mediaItem_metadata = "data 1"
+    mediaItem_metadata  = "data 1"
     mediaItem_metadata2 = "data 2"
     mediaItem_metadata3 = "data 3"
   }
@@ -285,9 +285,9 @@ resource "vcd_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
-  memory        = 3072
-  cpus          = 3
+
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -297,7 +297,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net.name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -306,12 +306,12 @@ resource "vcd_vm" "{{.VMName}}" {
   }
 
   metadata = {
-    mediaItem_metadata = "data 1"
+    mediaItem_metadata  = "data 1"
     mediaItem_metadata2 = "data 3"
   }
 
   guest_properties = {
-	"guest.hostname"       = "test-host2"
+	"guest.hostname" = "test-host2"
   }
 
   storage_profile = "{{.StorageProfile2}}"
@@ -329,9 +329,9 @@ resource "vcd_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
-  memory        = 3072
-  cpus          = 3
+
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = false
   memory_hot_add_enabled = true
@@ -343,7 +343,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net.name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -365,9 +365,9 @@ resource "vcd_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
-  memory        = 3072
-  cpus          = 3
+
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -379,7 +379,7 @@ resource "vcd_vm" "{{.VMName}}" {
     name               = vcd_network_routed.net.name
     ip_allocation_mode = "DHCP"
   }
- 
+
   network {
     type               = "none"
     ip_allocation_mode = "NONE"
@@ -408,9 +408,9 @@ resource "vcd_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
-  memory        = 3072
-  cpus          = 3
+
+  memory= 3072
+  cpus  = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -446,9 +446,9 @@ resource "vcd_vm" "{{.VMName}}" {
 
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
- 
-  memory        = 3072
-  cpus          = 3
+
+  memory = 3072
+  cpus   = 3
 
   cpu_hot_add_enabled    = true
   memory_hot_add_enabled = true
@@ -468,7 +468,7 @@ resource "vcd_vm" "{{.VMName}}" {
     ip_allocation_mode = "DHCP"
     is_primary         = true
   }
- 
+
   storage_profile = "{{.StorageProfile2}}"
 }
 `

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -194,9 +194,9 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   org  = "{{.OrgName}}"
   name = "{{.VdcName}}" 
 
-  allocation_model = "{{.AllocationModel}}"
-  network_pool_name     = "{{.NetworkPool}}"
-  provider_vdc_name     = "{{.ProviderVdc}}"
+  allocation_model  = "{{.AllocationModel}}"
+  network_pool_name = "{{.NetworkPool}}"
+  provider_vdc_name = "{{.ProviderVdc}}"
 
   compute_capacity {
     cpu {
@@ -211,10 +211,10 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   }
 
   storage_profile {
-    name     = "{{.ProviderVdcStorageProfile}}"
-    enabled  = true
-    limit    = 102400
-    default  = true
+    name    = "{{.ProviderVdcStorageProfile}}"
+    enabled = true
+    limit   = 102400
+    default = true
   }
 
   enabled                  = true
@@ -225,14 +225,14 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 }
 
 resource "vcd_vapp" "{{.VappName}}" {
-  org              = "{{.Org}}"
-  vdc              =  vcd_org_vdc.{{.VdcName}}.name
+  org  = "{{.Org}}"
+  vdc  =  vcd_org_vdc.{{.VdcName}}.name
   name = "{{.VappName}}"
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {
-  org              = "{{.Org}}"
-  vdc              =  vcd_org_vdc.{{.VdcName}}.name
+  org           = "{{.Org}}"
+  vdc           =  vcd_org_vdc.{{.VdcName}}.name
   vapp_name     = vcd_vapp.{{.VappName}}.name
   name          = "{{.VmName}}"
   computer_name = "{{.ComputerName}}"
@@ -243,12 +243,12 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   cpu_cores     = 1
 
   override_template_disk {
-    bus_type         = "paravirtual"
-    size_in_mb       = "{{.InternalDiskSize}}"
-    bus_number       = 0
-    unit_number      = 0
-    iops             = 0
-    storage_profile  = "{{.StorageProfileName}}"
+    bus_type        = "paravirtual"
+    size_in_mb      = "{{.InternalDiskSize}}"
+    bus_number      = 0
+    unit_number     = 0
+    iops            = 0
+    storage_profile = "{{.StorageProfileName}}"
   }
 
   disk {
@@ -297,7 +297,7 @@ const sourceTestVmInternalDiskIde = sourceTestVmInternalDiskOrgVdcAndVM + `
 # skip-binary-test: expected to fail for allow_vm_reboot=false and bus_type = "ide"
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
   org             = "{{.Org}}"
-  vdc             =  vcd_org_vdc.{{.VdcName}}.name
+  vdc             = vcd_org_vdc.{{.VdcName}}.name
   vapp_name       = vcd_vapp.{{.VappName}}.name
   vm_name         = vcd_vapp_vm.{{.VmName}}.name
   bus_type        = "ide"
@@ -312,7 +312,7 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
 const sourceTestVmInternalDisk = sourceTestVmInternalDiskOrgVdcAndVM + `
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
   org             = "{{.Org}}"
-  vdc             =  vcd_org_vdc.{{.VdcName}}.name
+  vdc             = vcd_org_vdc.{{.VdcName}}.name
   vapp_name       = vcd_vapp.{{.VappName}}.name
   vm_name         = vcd_vapp_vm.{{.VmName}}.name
   bus_type        = "ide"
@@ -325,7 +325,7 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
 
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}" {
   org             = "{{.Org}}"
-  vdc             =  vcd_org_vdc.{{.VdcName}}.name
+  vdc             = vcd_org_vdc.{{.VdcName}}.name
   vapp_name       = vcd_vapp.{{.VappName}}.name
   vm_name         = vcd_vapp_vm.{{.VmName}}.name
   bus_type        = "{{.BusType}}"
@@ -340,7 +340,7 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}" {
 const sourceTestVmInternalDisk_Update1 = sourceTestVmInternalDiskOrgVdcAndVM + `
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}" {
   org             = "{{.Org}}"
-  vdc             =  vcd_org_vdc.{{.VdcName}}.name
+  vdc             = vcd_org_vdc.{{.VdcName}}.name
   vapp_name       = vcd_vapp.{{.VappName}}.name
   vm_name         = vcd_vapp_vm.{{.VmName}}.name
   bus_type        = "{{.BusType}}"
@@ -353,7 +353,7 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}" {
 
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
   org             = "{{.Org}}"
-  vdc             =  vcd_org_vdc.{{.VdcName}}.name
+  vdc             = vcd_org_vdc.{{.VdcName}}.name
   vapp_name       = vcd_vapp.{{.VappName}}.name
   vm_name         = vcd_vapp_vm.{{.VmName}}.name
   bus_type        = "ide"

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -192,7 +192,7 @@ func testCheckInternalDiskNonStringOutputs(internalDiskSize int) resource.TestCh
 const sourceTestVmInternalDiskOrgVdcAndVM = `
 resource "vcd_org_vdc" "{{.VdcName}}" {
   org  = "{{.OrgName}}"
-  name = "{{.VdcName}}" 
+  name = "{{.VdcName}}"
 
   allocation_model  = "{{.AllocationModel}}"
   network_pool_name = "{{.NetworkPool}}"
@@ -226,13 +226,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 
 resource "vcd_vapp" "{{.VappName}}" {
   org  = "{{.Org}}"
-  vdc  =  vcd_org_vdc.{{.VdcName}}.name
+  vdc  = vcd_org_vdc.{{.VdcName}}.name
   name = "{{.VappName}}"
 }
 
 resource "vcd_vapp_vm" "{{.VmName}}" {
   org           = "{{.Org}}"
-  vdc           =  vcd_org_vdc.{{.VdcName}}.name
+  vdc           = vcd_org_vdc.{{.VdcName}}.name
   vapp_name     = vcd_vapp.{{.VappName}}.name
   name          = "{{.VmName}}"
   computer_name = "{{.ComputerName}}"
@@ -320,7 +320,7 @@ resource "vcd_vm_internal_disk" "{{.DiskResourceName}}_ide" {
   bus_number      = "0"
   unit_number     = "0"
   storage_profile = "{{.StorageProfileName}}"
-  allow_vm_reboot = "true" 
+  allow_vm_reboot = "true"
 }
 
 resource "vcd_vm_internal_disk" "{{.DiskResourceName}}" {

--- a/vcd/resource_vcd_vm_properties_test.go
+++ b/vcd/resource_vcd_vm_properties_test.go
@@ -89,8 +89,8 @@ resource "vcd_vm" "{{.VmName}}" {
   cpu_cores     = 1
 
   guest_properties = {
-	"guest.hostname"       = "test-host"
-	"guest.another.subkey" = "another-value"
+    "guest.hostname"       = "test-host"
+    "guest.another.subkey" = "another-value"
   }
 }
 `
@@ -107,8 +107,8 @@ resource "vcd_vm" "{{.VmName}}" {
   cpu_cores     = 1
 
   guest_properties = {
-	"guest.another.subkey" = "new-value"
-	"guest.third.subkey"   = "third-value"
+    "guest.another.subkey" = "new-value"
+    "guest.third.subkey"   = "third-value"
   }
 }
 `

--- a/vcd/resource_vcd_vm_shrink_cpu_test.go
+++ b/vcd/resource_vcd_vm_shrink_cpu_test.go
@@ -66,9 +66,9 @@ resource "vcd_vm" "shrink-vm" {
   catalog_name  = "{{.Catalog}}"
   template_name = vcd_catalog_item.fourcpu4cores.name
 
-  memory        = 512
-  cpus          = 2
-  cpu_cores     = 1
+  memory    = 512
+  cpus      = 2
+  cpu_cores = 1
 
   depends_on = [vcd_catalog_item.fourcpu4cores]
 }

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -391,50 +391,50 @@ resource "vcd_vm_sizing_policy" "{{.PolicyName}}_4" {
 `
 const testAccVmSizingPolicyDataSource = `
 data "vcd_vm_sizing_policy" "vcd_vm_sizing_policy_by_name" {
-	name = vcd_vm_sizing_policy.{{.PolicyName}}_4.name
+  name = vcd_vm_sizing_policy.{{.PolicyName}}_4.name
 }
 
 output "description" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.description
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.description
 }
 
 output "shares" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].shares
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].shares
 }
 
 output "count" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].count
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].count
 }
 
 output "limit_in_mhz" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].limit_in_mhz
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].limit_in_mhz
 }
 
 output "speed_in_mhz" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].speed_in_mhz
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].speed_in_mhz
 }
 
 output "cores_per_socket" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].cores_per_socket
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].cores_per_socket
 }
 
 output "reservation_guarantee" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].reservation_guarantee
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.cpu[0].reservation_guarantee
 }
 
 output "memory_shares" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].shares
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].shares
 }
 
 output "size_in_mb" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].size_in_mb
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].size_in_mb
 }
 
 output "limit_in_mb" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].limit_in_mb
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].limit_in_mb
 }
 
 output "memory_reservation_guarantee" {
-	value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].reservation_guarantee
+  value = data.vcd_vm_sizing_policy.vcd_vm_sizing_policy_by_name.memory[0].reservation_guarantee
 }
 `


### PR DESCRIPTION
Accidentally discovered in #738 this PR fixes `make test-binary-validate` and all of its errors in HCL validation.

`make test-binary-validate` does validation on our acceptance test HCL definitions. In fact they are quite messy and were only `fmt`ed  manually. .

In a nutshell this PR ensure that generated binary tests from our acceptance tests are formatted correctly using `terraform fmt`

Acceptance tests were run on 10.3 to ensure it broke none.