### PR TITLE
Fixes for release 3.5.0

### DIFF
--- a/.changes/v3.5.0/761-bug-fixes.md
+++ b/.changes/v3.5.0/761-bug-fixes.md
@@ -1,0 +1,2 @@
+* Skip tests for resources not available in 10.1 [GH-761]
+* Fix wrong references in `TestAccVcdVAppVmMultiNIC` [GH-761]

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -46,6 +46,8 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 			t.Skip(`Works only with system admin privileges`)
 		case dataSourceName == "vcd_external_network_v2" && vcdClient.Client.APIVCDMaxVersionIs("< 33"):
 			t.Skip("External network V2 requires at least API version 33 (VCD 10.0+)")
+		case (dataSourceName == "vcd_library_certificate" || dataSourceName == "vcd_vdc_group") && vcdClient.Client.APIVCDMaxVersionIs("< 35"):
+			t.Skipf("%s requires at least API version 34 (VCD 10.2+)", dataSourceName)
 		case (dataSourceName == "vcd_nsxt_edgegateway" || dataSourceName == "vcd_nsxt_edge_cluster" ||
 			dataSourceName == "vcd_nsxt_security_group" || dataSourceName == "vcd_nsxt_nat_rule" ||
 			dataSourceName == "vcd_nsxt_app_port_profile" || dataSourceName == "vcd_nsxt_ip_set") &&

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -29,7 +29,6 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 		{"global_role", "vcd_global_role", "", "vApp Author"},
 		{"rights_bundle", "vcd_rights_bundle", "", "Default Rights Bundle"},
 		{"right", "vcd_right", "", "Catalog: Change Owner"},
-		{"library_certificate", "vcd_library_certificate", "", ""},
 
 		// entities belonging to an Org don't require an explicit parent, as it is given from the Org passed in the provider
 		// For each resource, we test with and without and explicit parent
@@ -76,6 +75,12 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 		{"lb_virtual_server", "vcd_lb_virtual_server", testConfig.Networking.EdgeGateway, ""},
 		{"lb_app_profile", "vcd_lb_app_profile", testConfig.Networking.EdgeGateway, ""},
 		{"lb_app_rule", "vcd_lb_app_rule", testConfig.Networking.EdgeGateway, ""},
+	}
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient != nil && vcdClient.Client.APIVCDMaxVersionIs(">= 35") {
+		lists = append(lists,
+			listDef{"library_certificate", "vcd_library_certificate", "", ""},
+		)
 	}
 	for _, def := range lists {
 		t.Run(def.name+"-"+def.resourceType, func(t *testing.T) { runResourceInfoTest(def, t) })

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -480,11 +480,11 @@ resource "vcd_vapp_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-	enabled         = false
-	admin_password  = "some password"
+	enabled                = false
+	admin_password         = "some password"
 	auto_generate_password = false
-	join_domain     = true
-	join_org_domain = true
+	join_domain            = true
+	join_org_domain        = true
   }
 }
 `

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -263,7 +263,7 @@ resource "vcd_vapp" "{{.VAppName}}" {
   vdc = "{{.Vdc}}"
 
   name       = "{{.VAppName}}"
-  depends_on = ["vcd_network_routed.net", "vcd_network_routed.net2"]
+  depends_on = [vcd_network_routed.net, vcd_network_routed.net2]
 }
 
 resource "vcd_vapp_network" "vappIsolatedNet" {
@@ -362,7 +362,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = false
 	adapter_type       = "PCNet32" 
@@ -370,14 +370,14 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "DHCP"
     is_primary         = true
   }
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip                 = "11.10.0.170"
     ip_allocation_mode = "MANUAL"
     is_primary         = false
@@ -387,7 +387,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net2.name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = false
     adapter_type       = "e1000e"
@@ -430,7 +430,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   }
  }
@@ -452,21 +452,21 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = true
   }
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "DHCP"
     is_primary         = false
   }
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip                 = "11.10.0.170"
     ip_allocation_mode = "MANUAL"
     is_primary         = false
@@ -475,7 +475,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net2.name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
     is_primary         = false
 	mac                = "00:00:00:11:11:11"
@@ -547,7 +547,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name               = vcd_network_routed.net.name
+    name               = vcd_vapp_org_network.vappAttachedNet.org_network_name
     ip_allocation_mode = "POOL"
     adapter_type       = "vmxnet2"
   }


### PR DESCRIPTION
Some resources are not available in 10.1, and we skip the relevant tests
* Skip Datasource test for vcd_vdc_group and vcd_library_certificate
* Skip Resource List test for vcd_vdc_group

Fix wrong references in TestAccVcdVAppVmMultiNIC