### PR TITLE
Add "lease" section to vcd_vapp

### DIFF
--- a/.changes/v3.5.0/762-improvements.md
+++ b/.changes/v3.5.0/762-improvements.md
@@ -1,0 +1,1 @@
+* **Resource** and **Data source** `vcd_vapp` have a new `lease` block to view and change lease settings.

--- a/.changes/v3.5.0/762-improvements.md
+++ b/.changes/v3.5.0/762-improvements.md
@@ -1,1 +1,1 @@
-* **Resource** and **Data source** `vcd_vapp` have a new `lease` block to view and change lease settings.
+* **Resource** and **Data source** `vcd_vapp` add support for `lease` settings management.

--- a/.changes/v3.5.0/762-improvements.md
+++ b/.changes/v3.5.0/762-improvements.md
@@ -1,1 +1,2 @@
-* **Resource** and **Data source** `vcd_vapp` add support for `lease` settings management.
+* `resource/vcd_vapp` add support for `lease` settings management. [GH-762]
+* `datasource/vcd_vapp` add support for `lease` settings visualization. [GH-762]

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.1
+	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.1
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051
 
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9 h1:A7wRTON3g4dcDULpNU9AmgibGz2uao+mugPN8cz/A5M=
+github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.1 h1:Xn4xtfkyd+7wovO6MsmU6BJKfEh8xzxERvtPCW4tpxo=
-github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.1/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9 h1:A7wRTON3g4dcDULpNU9AmgibGz2uao+mugPN8cz/A5M=
-github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20211224121052-e585117c9eb9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051 h1:sFjpGcBeXIs/qJstfPNxibofPFdMQ9CVXpSG8xzPlMs=
+github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,6 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051 h1:sFjpGcBeXIs/qJstfPNxibofPFdMQ9CVXpSG8xzPlMs=
-github.com/dataclouder/go-vcloud-director/v2 v2.14.0-alpha.3.0.20220103102313-fe8b6ac1d051/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -321,6 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3 h1:VJolXzgomaRPrgzSr0EduuUtJIJEf5RdoLbktZFQqIc=
+github.com/vmware/go-vcloud-director/v2 v2.14.0-rc.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_vapp.go
+++ b/vcd/datasource_vcd_vapp.go
@@ -53,6 +53,25 @@ func datasourceVcdVApp() *schema.Resource {
 				Computed:    true,
 				Description: "Shows the status of the vApp",
 			},
+			"lease": &schema.Schema{
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Defines lease parameters for this vApp",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"runtime_lease_in_sec": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended.  0 means never expires",
+						},
+						"storage_lease_in_sec": &schema.Schema{
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires",
+						},
+					},
+				},
+			},
 		},
 	}
 }

--- a/vcd/datasource_vcd_vapp.go
+++ b/vcd/datasource_vcd_vapp.go
@@ -62,7 +62,7 @@ func datasourceVcdVApp() *schema.Resource {
 						"runtime_lease_in_sec": &schema.Schema{
 							Type:        schema.TypeInt,
 							Computed:    true,
-							Description: "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended.  0 means never expires",
+							Description: "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires",
 						},
 						"storage_lease_in_sec": &schema.Schema{
 							Type:        schema.TypeInt,

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -91,7 +91,7 @@ func resourceVcdVApp() *schema.Resource {
 						"runtime_lease_in_sec": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
-							Description:  "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended.  0 means never expires",
+							Description:  "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires",
 							ValidateFunc: validateIntLeaseSeconds(), // Lease can be either 0 or 3600+
 						},
 						"storage_lease_in_sec": &schema.Schema{

--- a/website/docs/d/vapp.html.markdown
+++ b/website/docs/d/vapp.html.markdown
@@ -59,3 +59,6 @@ The following arguments are supported:
 * `guest_properties` -  Key value map of vApp guest properties.
 * `status` -  The vApp status as a numeric code
 * `status_text` -  The vApp status as text.
+* `lease` (*v3.5+*) - The information about the vApp lease. It includes the following fields:
+  * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires.
+  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires.

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `status_text` - (Computed; *v2.5+*) The vApp status as text.
 * `lease` - (Optional *v3.5+*) the information about the vApp lease. It includes the fields below. When this section is 
    included, both fields are mandatory. If lease values are higher than the ones allowed for the whole Org, the values
-   are **silently** demoted to the highest value allowed.
+   are **silently** reduced to the highest value allowed.
   * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires (or maximum allowed by Org). Regular values accepted from 3600+.
   * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires (or maximum allowed by Org). Regular values accepted from 3600+.
 

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -53,6 +53,11 @@ resource "vcd_vapp_vm" "web1" {
     "vapp.property1" = "value1"
     "vapp.property2" = "value2"
   }
+  
+  lease {
+    runtime_lease_in_sec = 60*60*24*30  # extends the runtime lease to 30 days 
+    storage_lease_in_sec = 60*60*24*7  # extends the storage lease to 7 days
+  } 
 }
 
 resource "vcd_vapp_vm" "web2" {
@@ -101,6 +106,9 @@ The following arguments are supported:
 * `href` - (Computed) The vApp Hyper Reference
 * `status` - (Computed; *v2.5+*) The vApp status as a numeric code
 * `status_text` - (Computed; *v2.5+*) The vApp status as text.
+* `lease` - (Optional *v3.5+*) the information about the vApp lease. It includes the fields below. When this section is included, both fields are mandatory.
+  * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires. Regular values accepted from 3600+.
+  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires. Regular values accepted from 3600+.
 
 
 ## Importing

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -53,11 +53,11 @@ resource "vcd_vapp_vm" "web1" {
     "vapp.property1" = "value1"
     "vapp.property2" = "value2"
   }
-  
+
   lease {
-    runtime_lease_in_sec = 60*60*24*30  # extends the runtime lease to 30 days 
-    storage_lease_in_sec = 60*60*24*7  # extends the storage lease to 7 days
-  } 
+    runtime_lease_in_sec = 60 * 60 * 24 * 30 # extends the runtime lease to 30 days
+    storage_lease_in_sec = 60 * 60 * 24 * 7  # extends the storage lease to 7 days
+  }
 }
 
 resource "vcd_vapp_vm" "web2" {

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -106,9 +106,11 @@ The following arguments are supported:
 * `href` - (Computed) The vApp Hyper Reference
 * `status` - (Computed; *v2.5+*) The vApp status as a numeric code
 * `status_text` - (Computed; *v2.5+*) The vApp status as text.
-* `lease` - (Optional *v3.5+*) the information about the vApp lease. It includes the fields below. When this section is included, both fields are mandatory.
-  * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires. Regular values accepted from 3600+.
-  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires. Regular values accepted from 3600+.
+* `lease` - (Optional *v3.5+*) the information about the vApp lease. It includes the fields below. When this section is 
+   included, both fields are mandatory. If lease values are higher than the ones allowed for the whole Org, the values
+   are **silently** demoted to the highest value allowed.
+  * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires (or maximum allowed by Org). Regular values accepted from 3600+.
+  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires (or maximum allowed by Org. Regular values accepted from 3600+.
 
 
 ## Importing

--- a/website/docs/r/vapp.html.markdown
+++ b/website/docs/r/vapp.html.markdown
@@ -110,7 +110,7 @@ The following arguments are supported:
    included, both fields are mandatory. If lease values are higher than the ones allowed for the whole Org, the values
    are **silently** demoted to the highest value allowed.
   * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires (or maximum allowed by Org). Regular values accepted from 3600+.
-  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires (or maximum allowed by Org. Regular values accepted from 3600+.
+  * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires (or maximum allowed by Org). Regular values accepted from 3600+.
 
 
 ## Importing


### PR DESCRIPTION
Add "lease" section to `vcd_vapp` resource and data source.
They work similarly to section "vapp_lease" in `vcd_org`. Using this section we can get information about the lease and eventually modify it.
When the "lease" block is not set, the vApp inherits the lease terms from the parent organization.