### PR TITLE
Fix coverity scan errors

### DIFF
--- a/.changes/v3.5.0/738-features.md
+++ b/.changes/v3.5.0/738-features.md
@@ -1,4 +1,4 @@
 * **New Resource:** `vcd_nsxt_alb_edgegateway_service_engine_group` for managing NSX-T ALB Service Engine Groups
-  assignments to Edge Gateways [GH-738]
+  assignments to Edge Gateways [GH-738, GH-764]
 * **New Data source:** `vcd_nsxt_alb_edgegateway_service_engine_group` for reading NSX-T ALB Service Engine Groups
-  assignments to Edge Gateways [GH-738]
+  assignments to Edge Gateways [GH-738, GH-764]

--- a/.changes/v3.5.0/757-features.md
+++ b/.changes/v3.5.0/757-features.md
@@ -1,4 +1,4 @@
 * **New Resource:** `vcd_nsxt_alb_virtual_service` for managing NSX-T ALB Virtual Service on NSX-T Edge Gateways
-  [GH-757]
+  [GH-757, GH-764]
 * **New Data source:** `vcd_nsxt_alb_virtual_service` for reading NSX-T ALB Virtual Service on NSX-T Edge Gateways
-  [GH-757]
+  [GH-757, GH-764]

--- a/vcd/datasource_vcd_nsxt_alb_edgegateway_service_engine_group.go
+++ b/vcd/datasource_vcd_nsxt_alb_edgegateway_service_engine_group.go
@@ -85,8 +85,9 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroupRead(ctx context.Context, d *s
 	var err error
 	var edgeAlbServiceEngineAssignment *govcd.NsxtAlbServiceEngineGroupAssignment
 
+	switch {
 	// When `service_engine_group_name` lookup field is presented
-	if serviceEngineGroupName != "" {
+	case serviceEngineGroupName != "":
 		// This will filter service engine groups by assigned NSX-T Edge Gateway ID and additionally filter by Name on client
 		// side
 		queryParams := url.Values{}
@@ -95,10 +96,8 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroupRead(ctx context.Context, d *s
 		if err != nil {
 			return diag.Errorf("error retrieving Service Engine Group assignment to NSX-T Edge Gateway: %s", err)
 		}
-	}
-
-	// When `service_engine_group_id` lookup field is presented
-	if serviceEngineGroupId != "" {
+	// When `id` lookup field is presented
+	case serviceEngineGroupId != "":
 		queryParams := url.Values{}
 		queryParams.Add("filter", fmt.Sprintf("gatewayRef.id==%s;serviceEngineGroupRef.id==%s", edgeGatewayId, serviceEngineGroupId))
 
@@ -117,6 +116,8 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroupRead(ctx context.Context, d *s
 
 		// Exactly one Service Engine Group assignment is found
 		edgeAlbServiceEngineAssignment = edgeAlbServiceEngineAssignments[0]
+	default:
+		return diag.Errorf("Name or ID must be specified for Service Engine Group assignment data source")
 	}
 
 	setAlbServiceEngineGroupAssignmentData(d, edgeAlbServiceEngineAssignment.NsxtAlbServiceEngineGroupAssignment)

--- a/vcd/resource_vcd_nsxt_alb_virtual_service.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service.go
@@ -324,7 +324,7 @@ func setNsxtAlbVirtualServicePortData(d *schema.ResourceData, ports []types.Nsxt
 			portMap["start_port"] = *port.PortStart
 		}
 
-		if port.PortEnd != nil && *port.PortStart != *port.PortEnd {
+		if port.PortEnd != nil && port.PortStart != nil && *port.PortStart != *port.PortEnd {
 			portMap["end_port"] = *port.PortEnd
 		}
 		if port.SslEnabled != nil {


### PR DESCRIPTION
Coverity security scanner had a few errors and this PR is to address them.

Tested `alb` tag on 10.2.2.1 and 10.3.1