### PR TITLE
Add catalog resource and datasource metadata enhancement

### DIFF
--- a/.changes/v3.6.0/780-improvements.md
+++ b/.changes/v3.6.0/780-improvements.md
@@ -1,0 +1,2 @@
+* `resource/vcd_catalog` add support for `metadata` so this field can be set when creating/updating catalogs. [GH-780]
+* `datasource/vcd_catalog` add support for `metadata` so this field can be retrieved when reading from catalogs. [GH-780]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,9 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
+<<<<<<< HEAD
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2
+=======
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3
+>>>>>>> b0bbb31 (Update go.mod and small fixes)
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-<<<<<<< HEAD
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2
-=======
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3
->>>>>>> b0bbb31 (Update go.mod and small fixes)
 )

--- a/go.sum
+++ b/go.sum
@@ -319,16 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-<<<<<<< HEAD
-<<<<<<< HEAD
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2 h1:2GGxH2uev64yAdMayeZaR936McqfdT3dYcw0jJJ8UvE=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
-=======
->>>>>>> f3ec6ba (Add go sum and mod for testing)
-=======
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3 h1:m7+m6+8qSlkZbwTyGW+FsSdJApBa4rdjooNCGGy/4kI=
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
->>>>>>> b0bbb31 (Update go.mod and small fixes)
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5 h1:R8V71qZK57NDFL3Wj2k+2RYZ/SMyGOkW8L4j7Pd9lrQ=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -322,10 +320,15 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 <<<<<<< HEAD
+<<<<<<< HEAD
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2 h1:2GGxH2uev64yAdMayeZaR936McqfdT3dYcw0jJJ8UvE=
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 =======
 >>>>>>> f3ec6ba (Add go sum and mod for testing)
+=======
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3 h1:m7+m6+8qSlkZbwTyGW+FsSdJApBa4rdjooNCGGy/4kI=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+>>>>>>> b0bbb31 (Update go.mod and small fixes)
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5 h1:R8V71qZK57NDFL3Wj2k+2RYZ/SMyGOkW8L4j7Pd9lrQ=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220131113413-403e99301fb5/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -319,8 +321,11 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+<<<<<<< HEAD
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2 h1:2GGxH2uev64yAdMayeZaR936McqfdT3dYcw0jJJ8UvE=
 github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+=======
+>>>>>>> f3ec6ba (Add go sum and mod for testing)
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -2,8 +2,9 @@ package vcd
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -55,6 +56,13 @@ func datasourceVcdCatalog() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary.",
+			},
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Key and value pairs for catalog metadata",
+				// For now underlying go-vcloud-director repo only supports
+				// a value of type String in this map.
 			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,
@@ -112,6 +120,12 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error retrieving catalog %s: %s", identifier, err)
 	}
 
+	metadata, err := catalog.GetMetadata()
+	if err != nil {
+		log.Printf("[DEBUG] Unable to find catalog metadata: %s", err)
+		return diag.Errorf("There was an issue when retrieving metadata - %s", err)
+	}
+
 	dSet(d, "description", catalog.Catalog.Description)
 	dSet(d, "created", catalog.Catalog.DateCreated)
 	dSet(d, "name", catalog.Catalog.Name)
@@ -121,5 +135,11 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		dSet(d, "cache_enabled", catalog.Catalog.PublishExternalCatalogParams.IsCachedEnabled)
 		dSet(d, "preserve_identity_information", catalog.Catalog.PublishExternalCatalogParams.PreserveIdentityInfoFlag)
 	}
+
+	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+	if err != nil {
+		return diag.Errorf("There was an issue when setting metadata into the schema - %s", err)
+	}
+
 	return nil
 }

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -61,8 +61,6 @@ func datasourceVcdCatalog() *schema.Resource {
 				Type:        schema.TypeMap,
 				Computed:    true,
 				Description: "Key and value pairs for catalog metadata",
-				// For now underlying go-vcloud-director repo only supports
-				// a value of type String in this map.
 			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -3,6 +3,7 @@ package vcd
 import (
 	"context"
 	"fmt"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 	"log"
 	"strings"
 

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -388,14 +388,14 @@ func createOrUpdateAdminCatalogMetadata(d *schema.ResourceData, meta interface{}
 			}
 		}
 		for _, k := range toBeRemovedMetadata {
-			err := catalog.DeleteMetadata(k)
+			err := catalog.DeleteMetadataEntry(k)
 			if err != nil {
 				return fmt.Errorf("error deleting metadata: %s", err)
 			}
 		}
 		// Add new metadata
 		for k, v := range newMetadata {
-			_, err = catalog.AddMetadata(types.MetadataStringValue, k, v.(string))
+			err = catalog.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
 			if err != nil {
 				return fmt.Errorf("error adding metadata: %s", err)
 			}

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -140,7 +140,7 @@ func resourceVcdCatalogCreate(ctx context.Context, d *schema.ResourceData, meta 
 
 	err = createOrUpdateAdminCatalogMetadata(d, meta)
 	if err != nil {
-		return diag.Errorf("error adding media item metadata: %s", err)
+		return diag.Errorf("error adding catalog metadata: %s", err)
 	}
 
 	log.Printf("[TRACE] Catalog created: %#v", catalog)
@@ -211,7 +211,7 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 
 	metadata, err := adminCatalog.GetMetadata()
 	if err != nil {
-		log.Printf("[DEBUG] Unable to find media item metadata: %s", err)
+		log.Printf("[DEBUG] Unable to find catalog metadata: %s", err)
 		return err
 	}
 
@@ -287,7 +287,7 @@ func resourceVcdCatalogUpdate(ctx context.Context, d *schema.ResourceData, meta 
 
 	err = createOrUpdateAdminCatalogMetadata(d, meta)
 	if err != nil {
-		return diag.Errorf("error updating media item metadata: %s", err)
+		return diag.Errorf("error updating catalog metadata: %s", err)
 	}
 
 	return resourceVcdCatalogRead(ctx, d, meta)
@@ -360,7 +360,7 @@ func resourceVcdCatalogImport(ctx context.Context, d *schema.ResourceData, meta 
 
 func createOrUpdateAdminCatalogMetadata(d *schema.ResourceData, meta interface{}) error {
 
-	log.Printf("[TRACE] adding/updating metadata for media item")
+	log.Printf("[TRACE] adding/updating metadata for catalog")
 
 	vcdClient := meta.(*VCDClient)
 

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
@@ -91,8 +89,6 @@ func resourceVcdCatalog() *schema.Resource {
 				Type:        schema.TypeMap,
 				Optional:    true,
 				Description: "Key and value pairs for catalog metadata",
-				// For now underlying go-vcloud-director repo only supports
-				// a value of type String in this map.
 			},
 		},
 	}

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -395,7 +395,7 @@ func createOrUpdateAdminCatalogMetadata(d *schema.ResourceData, meta interface{}
 		}
 		// Add new metadata
 		for k, v := range newMetadata {
-			_, err = catalog.AddMetadata(govcd.MetadataStringValue, k, v.(string))
+			_, err = catalog.AddMetadata(types.MetadataStringValue, k, v.(string))
 			if err != nil {
 				return fmt.Errorf("error adding metadata: %s", err)
 			}

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -3,13 +3,15 @@ package vcd
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func resourceVcdCatalogItem() *schema.Resource {
@@ -289,14 +291,14 @@ func createOrUpdateCatalogItemMetadata(d *schema.ResourceData, meta interface{})
 			}
 		}
 		for _, k := range toBeRemovedMetadata {
-			err := vAppTemplate.DeleteMetadata(k)
+			err := vAppTemplate.DeleteMetadataEntry(k)
 			if err != nil {
 				return fmt.Errorf("error deleting metadata: %s", err)
 			}
 		}
 		// Add new metadata
 		for k, v := range newMetadata {
-			_, err := vAppTemplate.AddMetadata(k, v.(string))
+			err := vAppTemplate.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
 			if err != nil {
 				return fmt.Errorf("error adding metadata: %s", err)
 			}

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -3,13 +3,15 @@ package vcd
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func resourceVcdCatalogMedia() *schema.Resource {
@@ -315,14 +317,14 @@ func createOrUpdateMediaItemMetadata(d *schema.ResourceData, meta interface{}) e
 			}
 		}
 		for _, k := range toBeRemovedMetadata {
-			err := media.DeleteMetadata(k)
+			err := media.DeleteMetadataEntry(k)
 			if err != nil {
 				return fmt.Errorf("error deleting metadata: %s", err)
 			}
 		}
 		// Add new metadata
 		for k, v := range newMetadata {
-			_, err = media.AddMetadata(k, v.(string))
+			err = media.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
 			if err != nil {
 				return fmt.Errorf("error adding metadata: %s", err)
 			}

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -65,6 +65,10 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAddress, "description", TestAccVcdCatalogDescription),
 					resource.TestCheckResourceAttr(resourceAddress, "storage_profile_id", ""),
 					testAccCheckVcdCatalogExists(resourceAddress),
+					resource.TestCheckResourceAttr(
+						resourceAddress, "metadata.mediaItem_metadata", "mediaItem Metadata"),
+					resource.TestCheckResourceAttr(
+						resourceAddress, "metadata.mediaItem_metadata2", "mediaItem Metadata2"),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -77,6 +81,12 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddress, "storage_profile_id",
 						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
 					testAccCheckVcdCatalogExists(resourceAddress),
+					resource.TestCheckResourceAttr(
+						resourceAddress, "metadata.mediaItem_metadata", "mediaItem Metadata v2"),
+					resource.TestCheckResourceAttr(
+						resourceAddress, "metadata.mediaItem_metadata2", "mediaItem Metadata2 v2"),
+					resource.TestCheckResourceAttr(
+						resourceAddress, "metadata.mediaItem_metadata3", "mediaItem Metadata3"),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0
@@ -356,6 +366,11 @@ resource "vcd_catalog" "test-catalog" {
 
   delete_force      = "true"
   delete_recursive  = "true"
+
+  metadata = {
+    mediaItem_metadata = "mediaItem Metadata"
+    mediaItem_metadata2 = "mediaItem Metadata2"
+  }
 }
 `
 
@@ -373,6 +388,12 @@ resource "vcd_catalog" "test-catalog" {
 
   delete_force      = "true"
   delete_recursive  = "true"
+
+  metadata = {
+    mediaItem_metadata = "mediaItem Metadata v2"
+    mediaItem_metadata2 = "mediaItem Metadata2 v2"
+    mediaItem_metadata3 = "mediaItem Metadata3"
+  }
 }
 `
 

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -368,8 +368,8 @@ resource "vcd_catalog" "test-catalog" {
   delete_recursive  = "true"
 
   metadata = {
-    mediaItem_metadata = "mediaItem Metadata"
-    mediaItem_metadata2 = "mediaItem Metadata2"
+    catalog_metadata  = "catalog Metadata"
+    catalog_metadata2 = "catalog Metadata2"
   }
 }
 `
@@ -390,9 +390,9 @@ resource "vcd_catalog" "test-catalog" {
   delete_recursive  = "true"
 
   metadata = {
-    mediaItem_metadata = "mediaItem Metadata v2"
-    mediaItem_metadata2 = "mediaItem Metadata2 v2"
-    mediaItem_metadata3 = "mediaItem Metadata3"
+    catalog  = "catalog Metadata v2"
+    catalog2 = "catalog Metadata2 v2"
+    catalog3 = "catalog Metadata3"
   }
 }
 `

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -66,9 +66,9 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAddress, "storage_profile_id", ""),
 					testAccCheckVcdCatalogExists(resourceAddress),
 					resource.TestCheckResourceAttr(
-						resourceAddress, "metadata.mediaItem_metadata", "mediaItem Metadata"),
+						resourceAddress, "metadata.catalog_metadata", "catalog Metadata"),
 					resource.TestCheckResourceAttr(
-						resourceAddress, "metadata.mediaItem_metadata2", "mediaItem Metadata2"),
+						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2"),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -82,11 +82,11 @@ func TestAccVcdCatalog(t *testing.T) {
 						regexp.MustCompile(`^urn:vcloud:vdcstorageProfile:`)),
 					testAccCheckVcdCatalogExists(resourceAddress),
 					resource.TestCheckResourceAttr(
-						resourceAddress, "metadata.mediaItem_metadata", "mediaItem Metadata v2"),
+						resourceAddress, "metadata.catalog_metadata", "catalog Metadata v2"),
 					resource.TestCheckResourceAttr(
-						resourceAddress, "metadata.mediaItem_metadata2", "mediaItem Metadata2 v2"),
+						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2 v2"),
 					resource.TestCheckResourceAttr(
-						resourceAddress, "metadata.mediaItem_metadata3", "mediaItem Metadata3"),
+						resourceAddress, "metadata.catalog_metadata3", "catalog Metadata3"),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0
@@ -390,9 +390,9 @@ resource "vcd_catalog" "test-catalog" {
   delete_recursive  = "true"
 
   metadata = {
-    catalog  = "catalog Metadata v2"
-    catalog2 = "catalog Metadata2 v2"
-    catalog3 = "catalog Metadata3"
+    catalog_metadata  = "catalog Metadata v2"
+    catalog_metadata2 = "catalog Metadata2 v2"
+    catalog_metadata3 = "catalog Metadata3"
   }
 }
 `

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 const vAppUnknownStatus = "-unknown-status-"
@@ -225,23 +226,15 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		for _, k := range toBeRemovedMetadata {
-			task, err := vapp.DeleteMetadata(k)
+			err := vapp.DeleteMetadataEntry(k)
 			if err != nil {
 				return fmt.Errorf("error deleting metadata: %#v", err)
 			}
-			err = task.WaitTaskCompletion()
-			if err != nil {
-				return fmt.Errorf(errorCompletingTask, err)
-			}
 		}
 		for k, v := range newMetadata {
-			task, err := vapp.AddMetadata(k, v.(string))
+			err := vapp.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
 			if err != nil {
 				return fmt.Errorf("error adding metadata: %#v", err)
-			}
-			err = task.WaitTaskCompletion()
-			if err != nil {
-				return fmt.Errorf(errorCompletingTask, err)
 			}
 		}
 	}

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 * `publish_enabled` - (*v3.6+*) Enable allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation. Default is `false`.
 * `cache_enabled` - (*v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (*v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
+* `metadata` -  (*v3.6+*) Key value map of metadata.
 
 ## Filter arguments
 

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `publish_enabled` - (*v3.6+*) Enable allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation. Default is `false`.
 * `cache_enabled` - (*v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (*v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
-* `metadata` -  (*v3.6+*) Key value map of metadata.
+* `metadata` - (*v3.6+*) Key value map of metadata.
 
 ## Filter arguments
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -62,6 +62,7 @@ source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/stor
 * `cache_enabled` - (Optional, *v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (Optional, *v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
 * `password` - (Optional, *v3.6+*) An optional password to access the catalog. Only ASCII characters are allowed in a valid password.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign
 
 ## Importing
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -62,7 +62,7 @@ source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/stor
 * `cache_enabled` - (Optional, *v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (Optional, *v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
 * `password` - (Optional, *v3.6+*) An optional password to access the catalog. Only ASCII characters are allowed in a valid password.
-* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign.
 
 ## Importing
 


### PR DESCRIPTION
This PR targets #372 regarding metadata on catalog resource and datasource.

With this enhancement, now when creating a Catalog using `vcd_catalog` it is possible to include metadata. An example would be:
```
resource "vcd_catalog" "test-catalog" {
  org = "my_org" 
  
  name               = "my_catalog"
  description        = "This is just a test catalog"

  delete_force      = "true"
  delete_recursive  = "true"

  metadata = {
    catalog  = "catalog Metadata v2"
    catalog2 = "catalog Metadata2 v2"
    catalog3 = "catalog Metadata3"
  }
}
```

Also, when using `vcd_catalog` datasource, also metadata regarding a catalog will be retrieved in the compute field `metadata`.