### PR TITLE
Fix bug where VDC storage profile disablement didn't work

### DIFF
--- a/.changes/v3.6.0/781-bug-fixes.md
+++ b/.changes/v3.6.0/781-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixes Issue where VDC creation with storage profile `enabled=false` wasn't working. [GH-781]
+  

--- a/.changes/v3.6.0/781-bug-fixes.md
+++ b/.changes/v3.6.0/781-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fixes Issue where VDC creation with storage profile `enabled=false` wasn't working. [GH-781]
+* Fixes Issue #754 where VDC creation with storage profile `enabled=false` wasn't working [GH-781]
   

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.1
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.1
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4

--- a/go.sum
+++ b/go.sum
@@ -314,13 +314,13 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4 h1:v4ka0qLFwdVKRCCIwZ8FDJo2HvOGZOfaFWzX6OTEJIw=
+github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.1 h1:WKK9z1KsFv3AW+a1U26FwVpBmLoUNIBGh5CMZHT3y6U=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.1/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -314,13 +314,13 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4 h1:v4ka0qLFwdVKRCCIwZ8FDJo2HvOGZOfaFWzX6OTEJIw=
-github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220202151023-366c1d11cca4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2 h1:2GGxH2uev64yAdMayeZaR936McqfdT3dYcw0jJJ8UvE=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -37,10 +37,13 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 			"StorageProfileDefault": false,
 		})
 		if err == nil {
+			fmt.Printf("[INFO] second storage profile will be used in test\n")
 			params["SecondStorageProfile"] = buf.String()
 		} else {
 			fmt.Printf("[WARNING] error reported while filling second storage profile details: %s\n", err)
 		}
+	} else {
+		fmt.Printf("[WARNING] second storage profile will not be used in test\n")
 	}
 
 	params["FuncName"] = t.Name() + "-Update"
@@ -161,7 +164,7 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 					testConditionalCheck(secondStorageProfile != "",
 						testAccFindValuesInSet(resourceDef, "storage_profile", map[string]string{
 							"name":    secondStorageProfile,
-							"enabled": "true",
+							"enabled": "false",
 							"default": "false",
 							"limit":   "20480",
 						})),
@@ -404,7 +407,7 @@ const additionalStorageProfile = `
   #START_STORAGE_PROFILE
   storage_profile {
     name    = "{{.StorageProfileName}}"
-    enabled = true
+    enabled = false
     limit   = 20480
     default = {{.StorageProfileDefault}}
   }

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -525,7 +525,7 @@ func spawnTestOrgVdcSharedCatalog(client *VCDClient, name string) (govcd.AdminCa
 			},
 		},
 		VdcStorageProfile: []*types.VdcStorageProfileConfiguration{&types.VdcStorageProfileConfiguration{
-			Enabled: true,
+			Enabled: takeBoolPointer(true),
 			Units:   "MB",
 			Limit:   1024,
 			Default: true,

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -712,7 +712,7 @@ func updateStorageProfiles(set *schema.Set, client *VCDClient, adminVdc *govcd.A
 			return fmt.Errorf("[updateStorageProfiles] error retrieving storage profile '%s' from provider VDC '%s': %s", spCombo.configuration["name"].(string), providerVdcName, err)
 		}
 		err = adminVdc.AddStorageProfileWait(&types.VdcStorageProfileConfiguration{
-			Enabled: spCombo.configuration["enabled"].(bool),
+			Enabled: takeBoolPointer(spCombo.configuration["enabled"].(bool)),
 			Units:   "MB",
 			Limit:   int64(spCombo.configuration["limit"].(int)),
 			Default: spCombo.configuration["default"].(bool),
@@ -1197,7 +1197,7 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 			Units:   "MB", // only this value is supported
 			Limit:   int64(storageConfiguration["limit"].(int)),
 			Default: storageConfiguration["default"].(bool),
-			Enabled: storageConfiguration["enabled"].(bool),
+			Enabled: takeBoolPointer(storageConfiguration["enabled"].(bool)),
 			ProviderVdcStorageProfile: &types.Reference{
 				HREF: sp.HREF,
 			},


### PR DESCRIPTION
Dep: https://github.com/vmware/go-vcloud-director/pull/433
Ref: https://github.com/vmware/terraform-provider-vcd/issues/754

Fix issue were VDC storage profile disablement value was ignored during serialization (fix is in govcd type changes)