### PR TITLE
Fix read of vcd_vapp_vm resource when VM it isn't found. Allows terraform to recreate resource and not fail

### DIFF
--- a/.changes/v3.6.0/783-bug-fixes.md
+++ b/.changes/v3.6.0/783-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix Issue #611 when read of `vcd_vapp_vm` resource failed when vm isn't found. Now allows terraform to recreate resource when it isn't found. [GH-783]

--- a/.changes/v3.6.0/783-bug-fixes.md
+++ b/.changes/v3.6.0/783-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix Issue #611 when read of `vcd_vapp_vm` resource failed when vm isn't found. Now allows terraform to recreate resource when it isn't found. [GH-783]
+* Fix Issue #611 when read of `vcd_vapp_vm` resource failed when VM isn't found. Now allows Terraform to recreate resource when it isn't found. [GH-783]

--- a/.changes/v3.6.0/783-bug-fixes.md
+++ b/.changes/v3.6.0/783-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix Issue #611 when read of `vcd_vapp_vm` resource failed when VM isn't found. Now allows Terraform to recreate resource when it isn't found. [GH-783]
+* Fix Issue #611 when read of `vcd_vapp_vm` and `vcd_vm` resource failed when VM isn't found. Now allows Terraform to recreate resource when it isn't found. [GH-783]

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -161,7 +161,7 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 	vapp, err := vdc.GetVAppByNameOrId(d.Id(), false)
 
 	if err != nil {
-		return fmt.Errorf("error finding VApp: %#v", err)
+		return fmt.Errorf("error finding VApp: %s", err)
 	}
 
 	var runtimeLease = vapp.VApp.LeaseSettingsSection.DeploymentLeaseInSeconds

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -1466,6 +1466,11 @@ func genericVcdVmRead(d *schema.ResourceData, meta interface{}, origin string, v
 					"Please use 'vcd_vapp_vm' resource to specify vApp")
 				dSet(d, "vapp_name", "")
 			}
+			if govcd.IsNotFound(err) {
+				log.Printf("[VM read] error finding vApp '%s': %s%s. Removing it from state.", vappName, err, additionalMessage)
+				d.SetId("")
+				return nil
+			}
 			return fmt.Errorf("[VM read] error finding vApp '%s': %s%s", vappName, err, additionalMessage)
 		}
 		vm, err = vapp.GetVMByNameOrId(identifier, false)

--- a/vcd/resource_vcd_vapp_vm_checks_test.go
+++ b/vcd/resource_vcd_vapp_vm_checks_test.go
@@ -28,12 +28,14 @@ func testAccCheckVcdVAppVmExists(vappName, vmName, node string, vapp *govcd.VApp
 			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
 		}
 
-		vapp, err := vdc.GetVAppByName(vappName, false)
+		newVapp, err := vdc.GetVAppByName(vappName, false)
 		if err != nil {
 			return err
 		}
 
-		newVm, err := vapp.GetVMByName(vmName, false)
+		*vapp = *newVapp
+
+		newVm, err := newVapp.GetVMByName(vmName, false)
 
 		if err != nil {
 			return err

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -104,6 +104,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_vapp_vm."+vmName, `guest_properties`),
 				),
 			},
+			// Validates that if vApp is missing, resource can be recreated and no error is thrown. Covers issue #611
 			resource.TestStep{
 				Config:             configText3,
 				PreConfig:          deleteVapp,

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -45,17 +45,9 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 
 	deleteVapp := func() {
 		t.Log("Deleting vApp for next step")
-		if &vm == nil {
-			t.Errorf("VM to be removed missing")
-			t.FailNow()
-		}
 		err := vm.Delete()
 		if err != nil {
 			t.Errorf("error manually deleting VM: %s", err)
-			t.FailNow()
-		}
-		if &vapp == nil {
-			t.Errorf("vApp to be removed missing")
 			t.FailNow()
 		}
 		//ignore error

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -45,9 +45,17 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 
 	deleteVapp := func() {
 		t.Log("Deleting vApp for next step")
+		if &vm == nil {
+			t.Errorf("VM to be removed missing")
+			t.FailNow()
+		}
 		err := vm.Delete()
 		if err != nil {
 			t.Errorf("error manually deleting VM: %s", err)
+			t.FailNow()
+		}
+		if &vapp == nil {
+			t.Errorf("vApp to be removed missing")
 			t.FailNow()
 		}
 		//ignore error


### PR DESCRIPTION
Ref: https://github.com/vmware/terraform-provider-vcd/issues/611
