### PR TITLE
Fix enable_ip_masquerade handling in vcd_vapp_nat_rules resource

### DIFF
--- a/.changes/v3.6.0/784-bug-fixes.md
+++ b/.changes/v3.6.0/784-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix Issue #759 where enable_ip_masquerade handling in vcd_vapp_nat_rules resource wasn't correct [GH-784]


### PR DESCRIPTION
Fix for: https://github.com/vmware/terraform-provider-vcd/issues/759

The issue was that treating values was vice versa. On reading and for creating/updating.
The test is still correct and didn't need an update. That's the case when read isn't right, then everything looks good :)

Also updated vcd_vapp_nat_rules to not use deprecated schema.Resource fields for create/update/delete/import, now it uses CreateContext, UpdateContext, ReadContext, DeleteContext.

Also functions return the [diag.Diagnostics struct](https://learn.hashicorp.com/tutorials/terraform/provider-debug) instead of plain Go errors, to adjust their signature to the new CreateContext, UpdateContext, ReadContext, DeleteContext fields.