### PR TITLE
Add datasource for vcd_org_group

### DIFF
--- a/vcd/datasource_vcd_org_group.go
+++ b/vcd/datasource_vcd_org_group.go
@@ -1,0 +1,81 @@
+package vcd
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"log"
+)
+
+func datasourceVcdOrgGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdOrgGroupRead,
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:        schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"name", "id"},
+				Description:  "Name of the Organization group",
+			},
+			"id": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ExactlyOneOf: []string{"name", "id"},
+				Description:  "Organization group ID",
+			},
+			"provider_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceVcdOrgGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrg, err)
+	}
+
+	// get by ID when it's available
+	var orgGroup *govcd.OrgGroup
+	identifier := d.Get("id").(string)
+	if identifier != "" {
+		orgGroup, err = adminOrg.GetGroupById(identifier, false)
+	} else if d.Get("name").(string) != "" {
+		identifier = d.Get("name").(string)
+		orgGroup, err = adminOrg.GetGroupByName(identifier, false)
+	} else {
+		return diag.Errorf("Id or Name value is missing %s", err)
+	}
+
+	if err != nil {
+		return diag.Errorf("org group %s not found: %s", identifier, err)
+	}
+
+	log.Printf("Org group with name %s found", identifier)
+	d.SetId(orgGroup.Group.ID)
+	dSet(d, "name", orgGroup.Group.Name)
+	dSet(d, "provider_type", orgGroup.Group.ProviderType)
+	dSet(d, "description", orgGroup.Group.Description)
+	dSet(d, "role", orgGroup.Group.Role.Name)
+	return nil
+}

--- a/vcd/datasource_vcd_org_group_test.go
+++ b/vcd/datasource_vcd_org_group_test.go
@@ -1,0 +1,4 @@
+//go:build org || ALL || functional
+// +build org ALL functional
+
+package vcd

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -30,6 +30,7 @@ func Resources(nameRegexp string, includeDeprecated bool) (map[string]*schema.Re
 
 var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_org":                                       datasourceVcdOrg(),                              // 2.5
+	"vcd_org_group":                                 datasourceVcdOrgGroup(),                         // 3.6
 	"vcd_org_user":                                  datasourceVcdOrgUser(),                          // 3.0
 	"vcd_org_vdc":                                   datasourceVcdOrgVdc(),                           // 2.5
 	"vcd_catalog":                                   datasourceVcdCatalog(),                          // 2.5

--- a/vcd/resource_vcd_org.go
+++ b/vcd/resource_vcd_org.go
@@ -7,7 +7,9 @@
 package vcd
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,57 +25,57 @@ import (
 // https://code.vmware.com/apis/287/vcloud#/doc/doc/operations/DELETE-Organization.html
 func resourceOrg() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceOrgCreate,
-		Read:   resourceOrgRead,
-		Update: resourceOrgUpdate,
-		Delete: resourceOrgDelete,
+		CreateContext: resourceOrgCreate,
+		ReadContext:   resourceOrgRead,
+		UpdateContext: resourceOrgUpdate,
+		DeleteContext: resourceOrgDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceVcdOrgImport,
+			StateContext: resourceVcdOrgImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-			"full_name": &schema.Schema{
+			"full_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: false,
 			},
-			"is_enabled": &schema.Schema{
+			"is_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     true,
 				Description: "True if this organization is enabled (allows login and all other operations).",
 			},
-			"deployed_vm_quota": &schema.Schema{
+			"deployed_vm_quota": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "Maximum number of virtual machines that can be deployed simultaneously by a member of this organization. (0 = unlimited)",
 			},
-			"stored_vm_quota": &schema.Schema{
+			"stored_vm_quota": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      0,
 				ValidateFunc: validation.IntAtLeast(0),
 				Description:  "Maximum number of virtual machines in vApps or vApp templates that can be stored in an undeployed state by a member of this organization. (0 = unlimited)",
 			},
-			"can_publish_catalogs": &schema.Schema{
+			"can_publish_catalogs": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "True if this organization is allowed to share catalogs.",
 			},
-			"vapp_lease": &schema.Schema{
+			"vapp_lease": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
@@ -81,25 +83,25 @@ func resourceOrg() *schema.Resource {
 				Description: "Defines lease parameters for vApps created in this organization",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"maximum_runtime_lease_in_sec": &schema.Schema{
+						"maximum_runtime_lease_in_sec": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  "How long vApps can run before they are automatically stopped (in seconds). 0 means never expires",
 							ValidateFunc: validateIntLeaseSeconds(), // Lease can be either 0 or 3600+
 						},
-						"power_off_on_runtime_lease_expiration": &schema.Schema{
+						"power_off_on_runtime_lease_expiration": {
 							Type:     schema.TypeBool,
 							Required: true,
 							Description: "When true, vApps are powered off when the runtime lease expires. " +
 								"When false, vApps are suspended when the runtime lease expires",
 						},
-						"maximum_storage_lease_in_sec": &schema.Schema{
+						"maximum_storage_lease_in_sec": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  "How long stopped vApps are available before being automatically cleaned up (in seconds). 0 means never expires",
 							ValidateFunc: validateIntLeaseSeconds(), // Lease can be either 0 or 3600+
 						},
-						"delete_on_storage_lease_expiration": &schema.Schema{
+						"delete_on_storage_lease_expiration": {
 							Type:     schema.TypeBool,
 							Required: true,
 							Description: "If true, storage for a vApp is deleted when the vApp's lease expires. " +
@@ -108,7 +110,7 @@ func resourceOrg() *schema.Resource {
 					},
 				},
 			},
-			"vapp_template_lease": &schema.Schema{
+			"vapp_template_lease": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
@@ -116,13 +118,13 @@ func resourceOrg() *schema.Resource {
 				Description: "Defines lease parameters for vApp templates created in this organization",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"maximum_storage_lease_in_sec": &schema.Schema{
+						"maximum_storage_lease_in_sec": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  "How long vApp templates are available before being automatically cleaned up (in seconds). 0 means never expires",
 							ValidateFunc: validateIntLeaseSeconds(), // Lease can be either 0 or 3600+
 						},
-						"delete_on_storage_lease_expiration": &schema.Schema{
+						"delete_on_storage_lease_expiration": {
 							Type:     schema.TypeBool,
 							Required: true,
 							Description: "If true, storage for a vAppTemplate is deleted when the vAppTemplate lease expires. " +
@@ -131,18 +133,18 @@ func resourceOrg() *schema.Resource {
 					},
 				},
 			},
-			"delay_after_power_on_seconds": &schema.Schema{
+			"delay_after_power_on_seconds": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Specifies this organization's default for virtual machine boot delay after power on.",
 			},
-			"delete_force": &schema.Schema{
+			"delete_force": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    false,
 				Description: "When destroying use delete_force=True with delete_recursive=True to remove an org and any objects it contains, regardless of their state.",
 			},
-			"delete_recursive": &schema.Schema{
+			"delete_recursive": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    false,
@@ -153,12 +155,12 @@ func resourceOrg() *schema.Resource {
 }
 
 // creates an organization based on defined resource
-func resourceOrgCreate(d *schema.ResourceData, m interface{}) error {
-	vcdClient := m.(*VCDClient)
+func resourceOrgCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
 
 	orgName, fullName, err := getOrgNames(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	isEnabled := d.Get("is_enabled").(bool)
 	description := d.Get("description").(string)
@@ -170,23 +172,23 @@ func resourceOrgCreate(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		log.Printf("[DEBUG] Error creating Org: %s", err)
-		return fmt.Errorf("[org creation] error creating Org %s: %s", orgName, err)
+		return diag.Errorf("[org creation] error creating Org %s: %s", orgName, err)
 	}
 
 	err = task.WaitTaskCompletion()
 	if err != nil {
 		log.Printf("[DEBUG] Error running Org creation task: %s", err)
-		return fmt.Errorf("[org creation] error running Org (%s) creation task: %s", orgName, err)
+		return diag.Errorf("[org creation] error running Org (%s) creation task: %s", orgName, err)
 	}
 
 	org, err := vcdClient.GetAdminOrgByName(orgName)
 	if err != nil {
-		return fmt.Errorf("[org creation] error retrieving Org %s after creation: %s", orgName, err)
+		return diag.Errorf("[org creation] error retrieving Org %s after creation: %s", orgName, err)
 	}
 	log.Printf("[TRACE] Org %s created with id: %s", orgName, org.AdminOrg.ID)
 
 	d.SetId(org.AdminOrg.ID)
-	return resourceOrgRead(d, m)
+	return resourceOrgRead(ctx, d, meta)
 }
 
 func getSettings(d *schema.ResourceData) *types.OrgSettings {
@@ -263,16 +265,16 @@ func getSettings(d *schema.ResourceData) *types.OrgSettings {
 }
 
 // Deletes org
-func resourceOrgDelete(d *schema.ResourceData, m interface{}) error {
+func resourceOrgDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	//DELETING
-	vcdClient := m.(*VCDClient)
+	vcdClient := meta.(*VCDClient)
 	deleteForce := d.Get("delete_force").(bool)
 	deleteRecursive := d.Get("delete_recursive").(bool)
 
 	orgName, _, err := getOrgNames(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	identifier := d.Id()
@@ -287,7 +289,7 @@ func resourceOrgDelete(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error fetching Org %s: %s", orgName, err)
+		return diag.Errorf("error fetching Org %s: %s", orgName, err)
 	}
 
 	log.Printf("[TRACE] Org %s found", orgName)
@@ -297,20 +299,20 @@ func resourceOrgDelete(d *schema.ResourceData, m interface{}) error {
 	err = adminOrg.Delete(deleteForce, deleteRecursive)
 	if err != nil {
 		log.Printf("[DEBUG] Error deleting org %s: %s", orgName, err)
-		return err
+		return diag.FromErr(err)
 	}
 	log.Printf("[TRACE] Org %s deleted", orgName)
 	return nil
 }
 
 // Update the resource
-func resourceOrgUpdate(d *schema.ResourceData, m interface{}) error {
+func resourceOrgUpdate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
-	vcdClient := m.(*VCDClient)
+	vcdClient := meta.(*VCDClient)
 
 	orgName, fullName, err := getOrgNames(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	identifier := d.Id()
@@ -325,7 +327,7 @@ func resourceOrgUpdate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error fetching Org %s: %s", orgName, err)
+		return diag.Errorf("error fetching Org %s: %s", orgName, err)
 	}
 
 	settings := getSettings(d)
@@ -342,12 +344,12 @@ func resourceOrgUpdate(d *schema.ResourceData, m interface{}) error {
 
 	if err != nil {
 		log.Printf("[DEBUG] Error updating Org %s : %s", orgName, err)
-		return fmt.Errorf("error updating Org %s", err)
+		return diag.Errorf("error updating Org %s", err)
 	}
 	err = task.WaitTaskCompletion()
 	if err != nil {
 		log.Printf("[DEBUG] Error completing update of Org %s : %s", orgName, err)
-		return fmt.Errorf("error completing update of Org %s", err)
+		return diag.Errorf("error completing update of Org %s", err)
 	}
 
 	log.Printf("[TRACE] Org %s updated", orgName)
@@ -355,7 +357,7 @@ func resourceOrgUpdate(d *schema.ResourceData, m interface{}) error {
 }
 
 // setOrgData sets the data into the resource, taking it from the provided adminOrg
-func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
+func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) diag.Diagnostics {
 	dSet(d, "name", adminOrg.AdminOrg.Name)
 	dSet(d, "full_name", adminOrg.AdminOrg.FullName)
 	dSet(d, "description", adminOrg.AdminOrg.Description)
@@ -388,7 +390,7 @@ func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
 		vappLeaseSlice := []map[string]interface{}{vappLease}
 		err = d.Set("vapp_lease", vappLeaseSlice)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -409,7 +411,7 @@ func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
 		vappTemplateLeaseSlice := []map[string]interface{}{vappTemplateLease}
 		err = d.Set("vapp_template_lease", vappTemplateLeaseSlice)
 		if err != nil {
-			return err
+			return diag.FromErr(err)
 		}
 	}
 
@@ -417,12 +419,12 @@ func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
 }
 
 // Retrieves an Org resource from vCD
-func resourceOrgRead(d *schema.ResourceData, m interface{}) error {
-	vcdClient := m.(*VCDClient)
+func resourceOrgRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
 
 	orgName, _, err := getOrgNames(d)
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	identifier := d.Id()
@@ -460,7 +462,7 @@ func resourceOrgRead(d *schema.ResourceData, m interface{}) error {
 // For this resource, the import path is just the org name.
 //
 // Example import path (id): orgName
-func resourceVcdOrgImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVcdOrgImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	orgName := d.Id()
 
 	vcdClient := meta.(*VCDClient)
@@ -469,9 +471,9 @@ func resourceVcdOrgImport(d *schema.ResourceData, meta interface{}) ([]*schema.R
 		return nil, fmt.Errorf(errorRetrievingOrg, err)
 	}
 
-	err = setOrgData(d, adminOrg)
+	diagnosis := setOrgData(d, adminOrg)
 
-	if err != nil {
+	if diagnosis.HasError() {
 		return []*schema.ResourceData{}, err
 	}
 

--- a/vcd/resource_vcd_org_group.go
+++ b/vcd/resource_vcd_org_group.go
@@ -1,7 +1,9 @@
 package vcd
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
 
@@ -13,12 +15,12 @@ import (
 
 func resourceVcdOrgGroup() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceVcdOrgGroupCreate,
-		Read:   resourceVcdOrgGroupRead,
-		Update: resourceVcdOrgGroupUpdate,
-		Delete: resourceVcdOrgGroupDelete,
+		CreateContext: resourceVcdOrgGroupCreate,
+		ReadContext:   resourceVcdOrgGroupRead,
+		UpdateContext: resourceVcdOrgGroupUpdate,
+		DeleteContext: resourceVcdOrgGroupDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceVcdOrgGroupImport,
+			StateContext: resourceVcdOrgGroupImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -29,25 +31,25 @@ func resourceVcdOrgGroup() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true, // vCD does not allow to change group name
 				Description: "Group name",
 			},
-			"provider_type": &schema.Schema{
+			"provider_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true, // vCD does not allow to change provider type
 				Description:  "Identity provider type - 'SAML' or 'INTEGRATED' for LDAP",
 				ValidateFunc: validation.StringInSlice([]string{"SAML", "INTEGRATED"}, false),
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Description",
 			},
-			"role": &schema.Schema{
+			"role": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Existing role name to assign",
@@ -56,17 +58,17 @@ func resourceVcdOrgGroup() *schema.Resource {
 	}
 }
 
-func resourceVcdOrgGroupCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceVcdOrgGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return fmt.Errorf(errorRetrievingOrg, err)
+		return diag.Errorf(errorRetrievingOrg, err)
 	}
 
 	roleName := d.Get("role").(string)
 	role, err := adminOrg.GetRoleReference(roleName)
 	if err != nil {
-		return fmt.Errorf("unable to find role %s: %s", roleName, err)
+		return diag.Errorf("unable to find role %s: %s", roleName, err)
 	}
 
 	newGroup := govcd.NewGroup(&vcdClient.Client, adminOrg)
@@ -80,19 +82,19 @@ func resourceVcdOrgGroupCreate(d *schema.ResourceData, meta interface{}) error {
 
 	createdGroup, err := adminOrg.CreateGroup(newGroup.Group)
 	if err != nil {
-		return fmt.Errorf("error creating group %s: %s", groupDefinition.Name, err)
+		return diag.Errorf("error creating group %s: %s", groupDefinition.Name, err)
 	}
 
 	d.SetId(createdGroup.Group.ID)
 
-	return resourceVcdOrgGroupRead(d, meta)
+	return resourceVcdOrgGroupRead(ctx, d, meta)
 }
 
-func resourceVcdOrgGroupRead(d *schema.ResourceData, meta interface{}) error {
+func resourceVcdOrgGroupRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return fmt.Errorf(errorRetrievingOrg, err)
+		return diag.Errorf(errorRetrievingOrg, err)
 	}
 
 	group, err := adminOrg.GetGroupById(d.Id(), false)
@@ -103,7 +105,7 @@ func resourceVcdOrgGroupRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("error finding group %s: %s", d.Id(), err)
+		return diag.Errorf("error finding group %s: %s", d.Id(), err)
 	}
 
 	dSet(d, "name", group.Group.Name)
@@ -114,16 +116,16 @@ func resourceVcdOrgGroupRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceVcdOrgGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceVcdOrgGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return fmt.Errorf(errorRetrievingOrg, err)
+		return diag.Errorf(errorRetrievingOrg, err)
 	}
 
 	group, err := adminOrg.GetGroupById(d.Id(), false)
 	if err != nil {
-		return fmt.Errorf("error finding group for update %s: %s", d.Id(), err)
+		return diag.Errorf("error finding group for update %s: %s", d.Id(), err)
 	}
 
 	// Role change
@@ -131,7 +133,7 @@ func resourceVcdOrgGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		roleName := d.Get("role").(string)
 		role, err := adminOrg.GetRoleReference(roleName)
 		if err != nil {
-			return fmt.Errorf("unable to find role %s: %s", roleName, err)
+			return diag.Errorf("unable to find role %s: %s", roleName, err)
 		}
 		group.Group.Role = role
 	}
@@ -143,27 +145,27 @@ func resourceVcdOrgGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	err = group.Update()
 	if err != nil {
-		return fmt.Errorf("error updating group %s: %s", group.Group.Name, err)
+		return diag.Errorf("error updating group %s: %s", group.Group.Name, err)
 	}
 
-	return resourceVcdOrgGroupRead(d, meta)
+	return resourceVcdOrgGroupRead(ctx, d, meta)
 }
 
-func resourceVcdOrgGroupDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceVcdOrgGroupDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return fmt.Errorf(errorRetrievingOrg, err)
+		return diag.Errorf(errorRetrievingOrg, err)
 	}
 
 	group, err := adminOrg.GetGroupById(d.Id(), false)
 	if err != nil {
-		return fmt.Errorf("error finding group for deletion %s: %s", d.Id(), err)
+		return diag.Errorf("error finding group for deletion %s: %s", d.Id(), err)
 	}
 
 	err = group.Delete()
 	if err != nil {
-		return fmt.Errorf("could not delete group %s: %s", group.Group.Name, err)
+		return diag.Errorf("could not delete group %s: %s", group.Group.Name, err)
 	}
 
 	return nil
@@ -175,7 +177,7 @@ func resourceVcdOrgGroupDelete(d *schema.ResourceData, meta interface{}) error {
 //
 // Example import path (id): my-org.my-group
 // Note: the separator can be changed using Provider.import_separator or variable VCD_IMPORT_SEPARATOR
-func resourceVcdOrgGroupImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVcdOrgGroupImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 2 {
 		return nil, fmt.Errorf("resource name must be specified as org.org_group")

--- a/vcd/resource_vcd_org_group.go
+++ b/vcd/resource_vcd_org_group.go
@@ -34,13 +34,13 @@ func resourceVcdOrgGroup() *schema.Resource {
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true, // vCD does not allow to change group name
+				ForceNew:    true, // VCD does not allow to change group name
 				Description: "Group name",
 			},
 			"provider_type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true, // vCD does not allow to change provider type
+				ForceNew:     true, // VCD does not allow to change provider type
 				Description:  "Identity provider type - 'SAML' or 'INTEGRATED' for LDAP",
 				ValidateFunc: validation.StringInSlice([]string{"SAML", "INTEGRATED"}, false),
 			},


### PR DESCRIPTION
This PR addresses #730 by adding the requested datasource.

Getting inspired by **vdc_group** datasource, the **vcd_org_group** can be also fetched by ID or by Name.

Extra:

- Refactored resource_vcd_org_group to not use deprecated Terraform SDK signatures for create/update/delete/import.
- Refactored resource_vcd_org to not use deprecated Terraform SDK signatures for create/update/delete/import.