### PR TITLE
Add catalog details represeting properties as computed fields

### DIFF
--- a/.changes/v3.6.0/800-features.md
+++ b/.changes/v3.6.0/800-features.md
@@ -1,1 +1,1 @@
-* Add `catalog_version`, `number_of_vapp_templates`, `number_of_media`, `is_shared`, `is_published` computed fields to catalog resource and datasource  [GH-800]
+* Add `catalog_version`, `number_of_vapp_templates`, `number_of_media`, `is_shared`, `is_published`, `publish_subscription_type` computed fields to catalog resource and datasource  [GH-800]

--- a/.changes/v3.6.0/800-features.md
+++ b/.changes/v3.6.0/800-features.md
@@ -1,1 +1,2 @@
 * Add `catalog_version`, `number_of_vapp_templates`, `number_of_media`, `is_shared`, `is_published`, `publish_subscription_type` computed fields to catalog resource and datasource  [GH-800]
+* Update `vcd_catalog` datasource so now it can take org from provider level or datasource level like modern resources/datasources [GH-800]

--- a/.changes/v3.6.0/800-features.md
+++ b/.changes/v3.6.0/800-features.md
@@ -1,0 +1,1 @@
+* Add `catalog_version`, `number_of_vapp_templates`, `number_of_media`, `is_shared`, `is_published` computed fields to catalog resource and datasource  [GH-800]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a h1:SVBtvCi7Lw5je2yNNW3e9BSJ0PRySXvSE6oV2y6vDxc=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8 h1:0+DsW+KbPU+aKXzKSjSvJA7ZvpjB2V6q2TvhWXXnryA=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a h1:SVBtvCi7Lw5je2yNNW3e9BSJ0PRySXvSE6oV2y6vDxc=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220325091848-7d836411215a/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -321,6 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9 h1:4bmhpu6116aDka6yqHC4Qw2LJXf4SC4hm9jgrARZ4Ws=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -85,12 +85,17 @@ func datasourceVcdCatalog() *schema.Resource {
 			"is_shared": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Indicates if the catalog is shared.",
+				Description: "True if this catalog is shared.",
 			},
 			"is_published": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Indicates if the catalog is published.",
+				Description: "True if this catalog is shared to all organizations.",
+			},
+			"publish_subscription_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "PUBLISHED if published externally, SUBSCRIBED if subscribed to an external catalog, UNPUBLISHED otherwise.",
 			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,
@@ -177,12 +182,13 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("There was an issue when retrieving the catalog records - %s", err)
 	}
 
-	dSet(d, "catalog_version", catalog.AdminCatalog.VersionNumber)
+	dSet(d, "catalog_version", catalogRecords[0].Version)
 	dSet(d, "owner_name", catalogRecords[0].OwnerName)
 	dSet(d, "number_of_vapp_templates", catalogRecords[0].NumberOfVAppTemplates)
 	dSet(d, "number_of_media", catalogRecords[0].NumberOfMedia)
 	dSet(d, "is_published", catalogRecords[0].IsPublished)
 	dSet(d, "is_shared", catalogRecords[0].IsShared)
+	dSet(d, "publish_subscription_type", catalogRecords[0].PublishSubscriptionType)
 
 	return nil
 }

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -82,11 +82,6 @@ func datasourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
 			},
-			"date_created": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Date when the catalog was created",
-			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -172,8 +167,6 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	dSet(d, "number_of_vapp_templates", len(numberOfVAppTemplates))
-
-	dSet(d, "date_created", catalog.Catalog.DateCreated)
 
 	numberOfMedia, err := catalog.QueryMediaList()
 	if err != nil {

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -82,6 +82,11 @@ func datasourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
 			},
+			"date_created": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the catalog was created",
+			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -167,6 +172,8 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	dSet(d, "number_of_vapp_templates", len(numberOfVAppTemplates))
+
+	dSet(d, "date_created", catalog.Catalog.DateCreated)
 
 	numberOfMedia, err := catalog.QueryMediaList()
 	if err != nil {

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -169,7 +169,7 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("There was an issue when setting metadata into the schema - %s", err)
 	}
 
-	err = setCatalogRecordValuesToSchema(d, adminOrg, catalog.AdminCatalog.Name)
+	err = setCatalogData(d, adminOrg, catalog.AdminCatalog.Name)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -82,6 +82,16 @@ func datasourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
 			},
+			"is_shared": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates if the catalog is shared.",
+			},
+			"is_published": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates if the catalog is published.",
+			},
 			"filter": &schema.Schema{
 				Type:        schema.TypeList,
 				MaxItems:    1,
@@ -175,6 +185,18 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 
 	dSet(d, "number_of_media", len(numberOfMedia))
+
+	dSet(d, "is_published", catalog.Catalog.IsPublished)
+
+	controlAccessParams, err := catalog.GetAccessControl(false)
+	if err != nil {
+		return diag.Errorf("error retrieving catalog access control: %s", err)
+	}
+	if controlAccessParams.IsSharedToEveryone || controlAccessParams.AccessSettings != nil {
+		dSet(d, "is_shared", true)
+	} else {
+		dSet(d, "is_shared", false)
+	}
 
 	return nil
 }

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -147,13 +147,6 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("error retrieving catalog %s: %s", identifier, err)
 	}
 
-	// Catalog record is retrieved to get the owner name, number of vApp templates and medias, and if the catalog is shared and published
-	catalogRecords, err := adminOrg.FindCatalogRecords(catalog.AdminCatalog.Name)
-	if err != nil {
-		log.Printf("[DEBUG] Unable to retrieve catalog record: %s", err)
-		return diag.Errorf("There was an issue when retrieving the catalog records - %s", err)
-	}
-
 	metadata, err := catalog.GetMetadata()
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find catalog metadata: %s", err)
@@ -176,13 +169,10 @@ func datasourceVcdCatalogRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("There was an issue when setting metadata into the schema - %s", err)
 	}
 
-	dSet(d, "catalog_version", catalogRecords[0].Version)
-	dSet(d, "owner_name", catalogRecords[0].OwnerName)
-	dSet(d, "number_of_vapp_templates", catalogRecords[0].NumberOfVAppTemplates)
-	dSet(d, "number_of_media", catalogRecords[0].NumberOfMedia)
-	dSet(d, "is_published", catalogRecords[0].IsPublished)
-	dSet(d, "is_shared", catalogRecords[0].IsShared)
-	dSet(d, "publish_subscription_type", catalogRecords[0].PublishSubscriptionType)
+	err = setCatalogRecordValuesToSchema(d, adminOrg, catalog.AdminCatalog.Name)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return nil
 }

--- a/vcd/filter_get.go
+++ b/vcd/filter_get.go
@@ -38,7 +38,7 @@ func getEntityByFilter(search searchByFilterFunc, queryType, label string, filte
 }
 
 // getCatalogByFilter finds a catalog using a filter block
-func getCatalogByFilter(org *govcd.AdminOrg, filter interface{}, isSysAdmin bool) (*govcd.Catalog, error) {
+func getCatalogByFilter(org *govcd.AdminOrg, filter interface{}, isSysAdmin bool) (*govcd.AdminCatalog, error) {
 	queryType := types.QtCatalog
 	if isSysAdmin {
 		queryType = types.QtAdminCatalog
@@ -52,7 +52,7 @@ func getCatalogByFilter(org *govcd.AdminOrg, filter interface{}, isSysAdmin bool
 		return nil, err
 	}
 
-	catalog, err := org.GetCatalogByHref(queryItem.GetHref())
+	catalog, err := org.GetAdminCatalogByHref(queryItem.GetHref())
 	if err != nil {
 		return nil, fmt.Errorf("[getCatalogByFilter] error retrieving catalog %s: %s", queryItem.GetName(), err)
 	}

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -212,8 +212,8 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error retrieving catalog %s : %s", d.Id(), err)
 	}
 
-	// Catalog record is retrieved to get the number of vApp templates, medias and owner name
-	adminCatalogRecord, err := adminOrg.FindAdminCatalogRecords(adminCatalog.AdminCatalog.Name) // Is this returning one even though there are catalogs with similar names?
+	// Catalog record is retrieved to get the owner name, number of vApp templates and medias, and if the catalog is shared and published
+	catalogRecords, err := adminOrg.FindCatalogRecords(adminCatalog.AdminCatalog.Name)
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find catalog record: %s", err)
 		return err
@@ -255,11 +255,11 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	dSet(d, "catalog_version", adminCatalog.AdminCatalog.VersionNumber)
-	dSet(d, "owner_name", adminCatalogRecord[0].OwnerName)
-	dSet(d, "number_of_vapp_templates", adminCatalogRecord[0].NumberOfVAppTemplates)
-	dSet(d, "number_of_media", adminCatalogRecord[0].NumberOfMedia)
-	dSet(d, "is_published", adminCatalogRecord[0].IsPublished)
-	dSet(d, "is_shared", adminCatalogRecord[0].IsShared)
+	dSet(d, "owner_name", catalogRecords[0].OwnerName)
+	dSet(d, "number_of_vapp_templates", catalogRecords[0].NumberOfVAppTemplates)
+	dSet(d, "number_of_media", catalogRecords[0].NumberOfMedia)
+	dSet(d, "is_published", catalogRecords[0].IsPublished)
+	dSet(d, "is_shared", catalogRecords[0].IsShared)
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -212,15 +212,19 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 
 	adminCatalog, err := adminOrg.GetAdminCatalogByNameOrId(d.Id(), false)
 	if err != nil {
-		log.Printf("[DEBUG] Unable to find catalog. Removing from tfstate")
-		d.SetId("")
+		if govcd.ContainsNotFound(err) {
+			log.Printf("[DEBUG] Unable to find catalog. Removing from tfstate")
+			d.SetId("")
+			return nil
+		}
+
 		return fmt.Errorf("error retrieving catalog %s : %s", d.Id(), err)
 	}
 
 	// Catalog record is retrieved to get the owner name, number of vApp templates and medias, and if the catalog is shared and published
 	catalogRecords, err := adminOrg.FindCatalogRecords(adminCatalog.AdminCatalog.Name)
 	if err != nil {
-		log.Printf("[DEBUG] Unable to find catalog record: %s", err)
+		log.Printf("[DEBUG] Unable to retrieve catalog record: %s", err)
 		return err
 	}
 

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -96,11 +96,11 @@ func resourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Catalog version number.",
 			},
-			"owner_name": {
+			/*"owner_name": { // For some reason some catalogs when retrieved from API doesn't come with this field.
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Owner name from the catalog.",
-			},
+			},*/
 			"number_of_vapp_templates": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -110,6 +110,11 @@ func resourceVcdCatalog() *schema.Resource {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
+			},
+			"date_created": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Date when the catalog was created",
 			},
 		},
 	}
@@ -259,6 +264,8 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error retrieving catalog medias: %s", err)
 	}
 	dSet(d, "number_of_media", len(medias))
+
+	dSet(d, "date_created", adminCatalog.AdminCatalog.Catalog.DateCreated)
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -114,12 +114,17 @@ func resourceVcdCatalog() *schema.Resource {
 			"is_shared": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Indicates if the catalog is shared.",
+				Description: "True if this catalog is shared.",
 			},
 			"is_published": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Indicates if the catalog is published.",
+				Description: "True if this catalog is shared to all organizations.",
+			},
+			"publish_subscription_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "PUBLISHED if published externally, SUBSCRIBED if subscribed to an external catalog, UNPUBLISHED otherwise.",
 			},
 		},
 	}
@@ -254,12 +259,13 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	dSet(d, "catalog_version", adminCatalog.AdminCatalog.VersionNumber)
+	dSet(d, "catalog_version", catalogRecords[0].Version)
 	dSet(d, "owner_name", catalogRecords[0].OwnerName)
 	dSet(d, "number_of_vapp_templates", catalogRecords[0].NumberOfVAppTemplates)
 	dSet(d, "number_of_media", catalogRecords[0].NumberOfMedia)
 	dSet(d, "is_published", catalogRecords[0].IsPublished)
 	dSet(d, "is_shared", catalogRecords[0].IsShared)
+	dSet(d, "publish_subscription_type", catalogRecords[0].PublishSubscriptionType)
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -111,11 +111,6 @@ func resourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
 			},
-			"date_created": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Date when the catalog was created",
-			},
 		},
 	}
 }
@@ -264,8 +259,6 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error retrieving catalog medias: %s", err)
 	}
 	dSet(d, "number_of_media", len(medias))
-
-	dSet(d, "date_created", adminCatalog.AdminCatalog.Catalog.DateCreated)
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -258,7 +258,7 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		}
 	}
 
-	err = setCatalogRecordValuesToSchema(d, adminOrg, adminCatalog.AdminCatalog.Name)
+	err = setCatalogData(d, adminOrg, adminCatalog.AdminCatalog.Name)
 	if err != nil {
 		return err
 	}
@@ -447,7 +447,7 @@ func createOrUpdateAdminCatalogMetadata(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func setCatalogRecordValuesToSchema(d *schema.ResourceData, adminOrg *govcd.AdminOrg, catalogName string) error {
+func setCatalogData(d *schema.ResourceData, adminOrg *govcd.AdminOrg, catalogName string) error {
 	// Catalog record is retrieved to get the owner name, number of vApp templates and medias, and if the catalog is shared and published
 	catalogRecords, err := adminOrg.FindCatalogRecords(catalogName)
 	if err != nil {

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -111,6 +111,16 @@ func resourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "Number of Medias this catalog contains.",
 			},
+			"is_shared": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates if the catalog is shared.",
+			},
+			"is_published": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Indicates if the catalog is published.",
+			},
 		},
 	}
 }
@@ -259,6 +269,18 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("error retrieving catalog medias: %s", err)
 	}
 	dSet(d, "number_of_media", len(medias))
+
+	dSet(d, "is_published", adminCatalog.AdminCatalog.IsPublished)
+
+	controlAccessParams, err := adminCatalog.GetAccessControl(false)
+	if err != nil {
+		return fmt.Errorf("error retrieving catalog access control: %s", err)
+	}
+	if controlAccessParams.IsSharedToEveryone || controlAccessParams.AccessSettings != nil {
+		dSet(d, "is_shared", true)
+	} else {
+		dSet(d, "is_shared", false)
+	}
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -30,50 +30,50 @@ func resourceVcdCatalog() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"storage_profile_id": &schema.Schema{
+			"storage_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Optional storage profile ID",
 			},
-			"created": &schema.Schema{
+			"created": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Time stamp of when the catalog was created",
 			},
-			"delete_force": &schema.Schema{
+			"delete_force": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    false,
 				Description: "When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state.",
 			},
-			"delete_recursive": &schema.Schema{
+			"delete_recursive": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				ForceNew:    false,
 				Description: "When destroying use delete_recursive=True to remove the catalog and any objects it contains that are in a state that normally allows removal.",
 			},
-			"publish_enabled": &schema.Schema{
+			"publish_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "True allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation.",
 			},
-			"cache_enabled": &schema.Schema{
+			"cache_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "True enables early catalog export to optimize synchronization",
 			},
-			"preserve_identity_information": &schema.Schema{
+			"preserve_identity_information": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -89,7 +89,27 @@ func resourceVcdCatalog() *schema.Resource {
 			"metadata": {
 				Type:        schema.TypeMap,
 				Optional:    true,
-				Description: "Key and value pairs for catalog metadata",
+				Description: "Key and value pairs for catalog metadata.",
+			},
+			"catalog_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Catalog version number.",
+			},
+			"owner_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Owner name from the catalog.",
+			},
+			"number_of_vapp_templates": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of vApps this catalog contains.",
+			},
+			"number_of_media": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of Medias this catalog contains.",
 			},
 		},
 	}
@@ -216,6 +236,9 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
+
+	dSet(d, "catalog_version", adminCatalog.AdminCatalog.VersionNumber)
+	dSet(d, "owner_name", adminCatalog.AdminCatalog.Owner.User.Name)
 
 	d.SetId(adminCatalog.AdminCatalog.ID)
 	log.Printf("[TRACE] Catalog read completed: %#v", adminCatalog.AdminCatalog)

--- a/vcd/resource_vcd_catalog.go
+++ b/vcd/resource_vcd_catalog.go
@@ -258,9 +258,11 @@ func genericResourceVcdCatalogRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
-	if err != nil {
-		return err
+	if len(metadata.MetadataEntry) > 0 {
+		err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+		if err != nil {
+			return err
+		}
 	}
 
 	dSet(d, "catalog_version", catalogRecords[0].Version)

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -84,6 +84,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "0"),
 					resource.TestCheckResourceAttr(resourceAddress, "is_shared", "false"),
 					resource.TestCheckResourceAttr(resourceAddress, "is_published", "false"),
+					resource.TestMatchResourceAttr(resourceAddress, "publish_subscription_type", regexp.MustCompile(`^(PUBLISHED|SUBSCRIBED|UNPUBLISHED)$`)),
 				),
 			},
 			// Set storage profile for existing catalog

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -78,10 +78,6 @@ func TestAccVcdCatalog(t *testing.T) {
 						resourceAddress, "metadata.catalog_metadata", "catalog Metadata"),
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2"),
-					//resource.TestCheckResourceAttr(),
-					//resource.TestCheckResourceAttr(),
-					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
-					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -100,6 +96,10 @@ func TestAccVcdCatalog(t *testing.T) {
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2 v2"),
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata3", "catalog Metadata3"),
+					//resource.TestCheckResourceAttr(), // catalog owner
+					//resource.TestCheckResourceAttr(), // catalog version number
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0
@@ -391,7 +391,7 @@ resource "vcd_catalog_item" "{{.CatalogItemName}}" {
   catalog = resource.vcd_catalog.test-catalog.name
 
   name                 = "{{.CatalogItemName}}"
-  description          = "{{.Description}}"
+  description          = "TestDescription"
   ova_path             = "{{.OvaPath}}"
   upload_piece_size    = {{.UploadPieceSize}}
   show_upload_progress = "{{.UploadProgress}}"
@@ -402,7 +402,7 @@ resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
   catalog = resource.vcd_catalog.test-catalog.name
 
   name                 = "{{.CatalogMediaName}}"
-  description          = "{{.Description}}"
+  description          = "TestDescription"
   media_path           = "{{.MediaPath}}"
   upload_piece_size    = {{.UploadPieceSize}}
   show_upload_progress = "{{.UploadProgress}}"
@@ -430,6 +430,28 @@ resource "vcd_catalog" "test-catalog" {
     catalog_metadata2 = "catalog Metadata2 v2"
     catalog_metadata3 = "catalog Metadata3"
   }
+}
+
+resource "vcd_catalog_item" "{{.CatalogItemName}}" {
+  org     = "{{.Org}}"
+  catalog = resource.vcd_catalog.test-catalog.name
+
+  name                 = "{{.CatalogItemName}}"
+  description          = "TestDescription"
+  ova_path             = "{{.OvaPath}}"
+  upload_piece_size    = {{.UploadPieceSize}}
+  show_upload_progress = "{{.UploadProgress}}"
+}
+
+resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+  org     = "{{.Org}}"
+  catalog = resource.vcd_catalog.test-catalog.name
+
+  name                 = "{{.CatalogMediaName}}"
+  description          = "TestDescription"
+  media_path           = "{{.MediaPath}}"
+  upload_piece_size    = {{.UploadPieceSize}}
+  show_upload_progress = "{{.UploadProgress}}"
 }
 `
 

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -78,6 +78,10 @@ func TestAccVcdCatalog(t *testing.T) {
 						resourceAddress, "metadata.catalog_metadata", "catalog Metadata"),
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2"),
+					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "0"),
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "0"),
+					resource.TestMatchResourceAttr(resourceAddress, "date_created", regexp.MustCompile(`^\S+`)),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -100,6 +104,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
+					resource.TestMatchResourceAttr(resourceAddress, "date_created", regexp.MustCompile(`^\S+`)),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -81,7 +81,6 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "0"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "0"),
-					resource.TestMatchResourceAttr(resourceAddress, "date_created", regexp.MustCompile(`^\S+`)),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -104,7 +103,6 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
-					resource.TestMatchResourceAttr(resourceAddress, "date_created", regexp.MustCompile(`^\S+`)),
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -97,7 +97,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata3", "catalog Metadata3"),
 					//resource.TestCheckResourceAttr(), // catalog owner
-					//resource.TestCheckResourceAttr(), // catalog version number
+					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
 				),

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -27,11 +27,20 @@ var TestAccVcdCatalogDescription = "TestAccVcdCatalogBasicDescription"
 func TestAccVcdCatalog(t *testing.T) {
 	preTestChecks(t)
 	var params = StringMap{
-		"Org":            testConfig.VCD.Org,
-		"CatalogName":    TestAccVcdCatalogName,
-		"Description":    TestAccVcdCatalogDescription,
-		"StorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
-		"Tags":           "catalog",
+		"Org":                    testConfig.VCD.Org,
+		"CatalogName":            TestAccVcdCatalogName,
+		"Description":            TestAccVcdCatalogDescription,
+		"StorageProfile":         testConfig.VCD.ProviderVdc.StorageProfile,
+		"CatalogItemName":        "TestCatalogItem",
+		"CatalogItemNameFromUrl": "Test",
+		"DescriptionFromUrl":     "Test",
+		"OvaPath":                testConfig.Ova.OvaPath,
+		"UploadProgressFromUrl":  testConfig.Ova.UploadProgress,
+		"CatalogMediaName":       "TestCatalogMedia",
+		"MediaPath":              testConfig.Media.MediaPath,
+		"UploadPieceSize":        testConfig.Media.UploadPieceSize,
+		"UploadProgress":         testConfig.Media.UploadProgress,
+		"Tags":                   "catalog",
 	}
 
 	configText := templateFill(testAccCheckVcdCatalog, params)
@@ -56,7 +65,7 @@ func TestAccVcdCatalog(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckCatalogDestroy,
 		Steps: []resource.TestStep{
-			// Provision catalog without storage profile
+			// Provision catalog without storage profile and a vApp template and media
 			resource.TestStep{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
@@ -69,6 +78,10 @@ func TestAccVcdCatalog(t *testing.T) {
 						resourceAddress, "metadata.catalog_metadata", "catalog Metadata"),
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2"),
+					//resource.TestCheckResourceAttr(),
+					//resource.TestCheckResourceAttr(),
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
+					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
 				),
 			},
 			// Set storage profile for existing catalog
@@ -372,6 +385,29 @@ resource "vcd_catalog" "test-catalog" {
     catalog_metadata2 = "catalog Metadata2"
   }
 }
+
+resource "vcd_catalog_item" "{{.CatalogItemName}}" {
+  org     = "{{.Org}}"
+  catalog = resource.vcd_catalog.test-catalog.name
+
+  name                 = "{{.CatalogItemName}}"
+  description          = "{{.Description}}"
+  ova_path             = "{{.OvaPath}}"
+  upload_piece_size    = {{.UploadPieceSize}}
+  show_upload_progress = "{{.UploadProgress}}"
+}
+
+resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
+  org     = "{{.Org}}"
+  catalog = resource.vcd_catalog.test-catalog.name
+
+  name                 = "{{.CatalogMediaName}}"
+  description          = "{{.Description}}"
+  media_path           = "{{.MediaPath}}"
+  upload_piece_size    = {{.UploadPieceSize}}
+  show_upload_progress = "{{.UploadProgress}}"
+}
+
 `
 
 const testAccCheckVcdCatalogStep1 = `

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -79,6 +79,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2"),
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
+					resource.TestMatchResourceAttr(resourceAddress, "owner_name", regexp.MustCompile(`^\S+$`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "0"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "0"),
 					resource.TestCheckResourceAttr(resourceAddress, "is_shared", "false"),
@@ -101,8 +102,8 @@ func TestAccVcdCatalog(t *testing.T) {
 						resourceAddress, "metadata.catalog_metadata2", "catalog Metadata2 v2"),
 					resource.TestCheckResourceAttr(
 						resourceAddress, "metadata.catalog_metadata3", "catalog Metadata3"),
-					//resource.TestCheckResourceAttr(), // catalog owner
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
+					resource.TestMatchResourceAttr(resourceAddress, "owner_name", regexp.MustCompile(`^\S+$`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "1"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "1"),
 				),

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -147,7 +147,7 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 		"Tags":           "catalog",
 	}
 
-	configText := templateFill(testAccCheckVcdCatalogStep1, params)
+	configText := templateFill(testAccCheckVcdCatalogWithStorageProfile, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	if vcdShortTest {
@@ -459,6 +459,29 @@ resource "vcd_catalog_media"  "{{.CatalogMediaName}}" {
   media_path           = "{{.MediaPath}}"
   upload_piece_size    = {{.UploadPieceSize}}
   show_upload_progress = "{{.UploadProgress}}"
+}
+`
+
+const testAccCheckVcdCatalogWithStorageProfile = `
+data "vcd_storage_profile" "sp" {
+	name = "{{.StorageProfile}}"
+}
+
+resource "vcd_catalog" "test-catalog" {
+  org = "{{.Org}}" 
+  
+  name               = "{{.CatalogName}}"
+  description        = "{{.Description}}"
+  storage_profile_id = data.vcd_storage_profile.sp.id
+
+  delete_force      = "true"
+  delete_recursive  = "true"
+
+  metadata = {
+    catalog_metadata  = "catalog Metadata v2"
+    catalog_metadata2 = "catalog Metadata2 v2"
+    catalog_metadata3 = "catalog Metadata3"
+  }
 }
 `
 

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -81,6 +81,8 @@ func TestAccVcdCatalog(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddress, "catalog_version", regexp.MustCompile(`^\d+`)),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_vapp_templates", "0"),
 					resource.TestCheckResourceAttr(resourceAddress, "number_of_media", "0"),
+					resource.TestCheckResourceAttr(resourceAddress, "is_shared", "false"),
+					resource.TestCheckResourceAttr(resourceAddress, "is_published", "false"),
 				),
 			},
 			// Set storage profile for existing catalog

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -48,10 +48,12 @@ The following arguments are supported:
 * `preserve_identity_information` - (*v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
 * `metadata` - (*v3.6+*) Key value map of metadata.
 * `catalog_version` - (*v3.6+*) Version number from this catalog.
+* `owner_name` - (*v3.6+*) Owner of the catalog.
 * `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.
 * `number_of_media` - (*v3.6+*) Number of media items available in this catalog.
 * `is_shared` - (*v3.6+*) Indicates if the catalog is shared.
-* `is_published` - (*v3.6+*) Indicates if the catalog is published.
+* `is_published` - (*v3.6+*) Indicates if this catalog is shared to all organizations.
+* `publish_subscription_type` - (*v3.6+*) Shows if the catalog is published, if it is a subscription from another one or none of those.
 
 ## Filter arguments
 

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -47,6 +47,11 @@ The following arguments are supported:
 * `cache_enabled` - (*v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (*v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
 * `metadata` - (*v3.6+*) Key value map of metadata.
+* `catalog_version` - (*v3.6+*) Version number from this catalog.
+* `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.
+* `number_of_media` - (*v3.6+*) Number of media items available in this catalog.
+* `is_shared` - (*v3.6+*) Indicates if the catalog is shared.
+* `is_published` - (*v3.6+*) Indicates if the catalog is published.
 
 ## Filter arguments
 

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -64,6 +64,14 @@ source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/stor
 * `password` - (Optional, *v3.6+*) An optional password to access the catalog. Only ASCII characters are allowed in a valid password.
 * `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign.
 
+## Attribute Reference
+
+* `catalog_version` - (*v3.6+*) Version number from this catalog.
+* `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.
+* `number_of_media` - (*v3.6+*) Number of media items available in this catalog.
+* `is_shared` - (*v3.6+*) Indicates if the catalog is shared.
+* `is_published` - (*v3.6+*) Indicates if the catalog is published.
+
 ## Importing
 
 ~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -67,10 +67,12 @@ source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/stor
 ## Attribute Reference
 
 * `catalog_version` - (*v3.6+*) Version number from this catalog.
+* `owner_name` - (*v3.6+*) Owner of the catalog.
 * `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.
 * `number_of_media` - (*v3.6+*) Number of media items available in this catalog.
 * `is_shared` - (*v3.6+*) Indicates if the catalog is shared.
-* `is_published` - (*v3.6+*) Indicates if the catalog is published.
+* `is_published` - (*v3.6+*) Indicates if this catalog is shared to all organizations.
+* `publish_subscription_type` - (*v3.6+*) Shows if the catalog is published, if it is a subscription from another one or none of those.
 
 ## Importing
 


### PR DESCRIPTION
This PR aims to address the enhancements proposed by @vbauzysvmware on github issue #365 . 

## Description
According to the issue above mentioned, 7 new computed fields have been added to `catalog` resource and datasource. 

## Detailed description
The new computed fields for `catalog` resource and datasource are:

* `catalog_version` - Version number from this catalog.
* `owner_name` - Owner of the catalog.
* `number_of_vapp_templates` - Number of vApp templates available in this catalog.
* `number_of_media` - Number of media items available in this catalog.
* `is_shared` - Indicates if the catalog is shared.
* `is_published` - Indicates if this catalog is shared to all organizations.
* `publish_subscription_type` - Shows if the catalog is published, if it is a subscription from another one or none of those.

This PR relays on https://github.com/vmware/go-vcloud-director/pull/450 