### PR TITLE
Add support for "Publish external catalogs" and "Subscribe to external catalogs " in VCD Org 

### DIFF
--- a/.changes/v3.6.0/803-improvements.md
+++ b/.changes/v3.6.0/803-improvements.md
@@ -1,0 +1,1 @@
+* Add support for `can_publish_external_catalogs` and `can_subscribe_external_catalogs` in `datasource_vcd_org` and `resource_vcd_org` [GH-803]

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.5
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.6
 )

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.5 h1:/vHVcJMrx6t3ST59UkkvaQNNcNWLdRJdbhWDoPBIaiw=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.5/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.6 h1:dlhIfKpEmfSteiQw28LUko4Lrx/lnO6oaAzahwC5e1I=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.6/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_org.go
+++ b/vcd/datasource_vcd_org.go
@@ -44,6 +44,16 @@ func datasourceVcdOrg() *schema.Resource {
 				Computed:    true,
 				Description: "True if this organization is allowed to share catalogs.",
 			},
+			"can_publish_external_catalogs": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if this organization is allowed to publish external catalogs.",
+			},
+			"can_subscribe_external_catalogs": &schema.Schema{
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if this organization is allowed to subscribe to external catalogs.",
+			},
 			"vapp_lease": &schema.Schema{
 				Type:     schema.TypeList,
 				Computed: true,

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -61,6 +61,10 @@ func TestAccVcdDatasourceOrg(t *testing.T) {
 					resource.TestCheckResourceAttrPair(
 						datasource1, "can_publish_catalogs", resourceName2, "can_publish_catalogs"),
 					resource.TestCheckResourceAttrPair(
+						datasource1, "can_publish_external_catalogs", resourceName2, "can_publish_external_catalogs"),
+					resource.TestCheckResourceAttrPair(
+						datasource1, "can_subscribe_external_catalogs", resourceName2, "can_subscribe_external_catalogs"),
+					resource.TestCheckResourceAttrPair(
 						datasource1, "delay_after_power_on_seconds", resourceName2, "delay_after_power_on_seconds"),
 					resource.TestCheckResourceAttrPair(
 						datasource1, "vapp_lease.0.maximum_runtime_lease_in_sec",
@@ -93,15 +97,17 @@ data "vcd_org" "{{.OrgName1}}" {
 }
 
 resource "vcd_org" "{{.OrgName2}}" {
-  name                         = "{{.OrgName2}}"
-  full_name                    = data.vcd_org.{{.OrgName1}}.full_name
-  can_publish_catalogs         = data.vcd_org.{{.OrgName1}}.can_publish_catalogs
-  deployed_vm_quota            = data.vcd_org.{{.OrgName1}}.deployed_vm_quota
-  stored_vm_quota              = data.vcd_org.{{.OrgName1}}.stored_vm_quota
-  is_enabled                   = data.vcd_org.{{.OrgName1}}.is_enabled
-  delay_after_power_on_seconds = data.vcd_org.{{.OrgName1}}.delay_after_power_on_seconds
-  delete_force                 = "true"
-  delete_recursive             = "true"
+  name                            = "{{.OrgName2}}"
+  full_name                       = data.vcd_org.{{.OrgName1}}.full_name
+  can_publish_catalogs            = data.vcd_org.{{.OrgName1}}.can_publish_catalogs
+  can_publish_external_catalogs   = data.vcd_org.{{.OrgName1}}.can_publish_external_catalogs
+  can_subscribe_external_catalogs = data.vcd_org.{{.OrgName1}}.can_subscribe_external_catalogs
+  deployed_vm_quota               = data.vcd_org.{{.OrgName1}}.deployed_vm_quota
+  stored_vm_quota                 = data.vcd_org.{{.OrgName1}}.stored_vm_quota
+  is_enabled                      = data.vcd_org.{{.OrgName1}}.is_enabled
+  delay_after_power_on_seconds    = data.vcd_org.{{.OrgName1}}.delay_after_power_on_seconds
+  delete_force                    = "true"
+  delete_recursive                = "true"
  vapp_lease {
     maximum_runtime_lease_in_sec          = data.vcd_org.{{.OrgName1}}.vapp_lease.0.maximum_runtime_lease_in_sec
     power_off_on_runtime_lease_expiration = data.vcd_org.{{.OrgName1}}.vapp_lease.0.power_off_on_runtime_lease_expiration

--- a/vcd/resource_vcd_org.go
+++ b/vcd/resource_vcd_org.go
@@ -282,7 +282,6 @@ func getSettings(d *schema.ResourceData) *types.OrgSettings {
 
 // Deletes org
 func resourceOrgDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
 
 	//DELETING
 	vcdClient := m.(*VCDClient)
@@ -318,13 +317,13 @@ func resourceOrgDelete(ctx context.Context, d *schema.ResourceData, m interface{
 		log.Printf("[DEBUG] Error deleting org %s: %s", orgName, err)
 		return diag.FromErr(err)
 	}
+
 	log.Printf("[TRACE] Org %s deleted", orgName)
-	return diags
+	return nil
 }
 
 // Update the resource
 func resourceOrgUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
 
 	vcdClient := m.(*VCDClient)
 
@@ -371,7 +370,7 @@ func resourceOrgUpdate(ctx context.Context, d *schema.ResourceData, m interface{
 	}
 
 	log.Printf("[TRACE] Org %s updated", orgName)
-	return diags
+	return nil
 }
 
 // setOrgData sets the data into the resource, taking it from the provided adminOrg
@@ -440,7 +439,6 @@ func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
 
 // Retrieves an Org resource from vCD
 func resourceOrgRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	var diags diag.Diagnostics
 
 	vcdClient := m.(*VCDClient)
 
@@ -470,7 +468,7 @@ func resourceOrgRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	if err != nil {
 		log.Printf("[DEBUG] Org %s not found. Setting ID to nothing", identifier)
 		d.SetId("")
-		return diags
+		return nil
 	}
 	log.Printf("[TRACE] Org with id %s found", identifier)
 	d.SetId(adminOrg.AdminOrg.ID)
@@ -479,7 +477,7 @@ func resourceOrgRead(ctx context.Context, d *schema.ResourceData, m interface{})
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	return diags
+	return nil
 }
 
 // resourceVcdOrgImport is responsible for importing the resource.

--- a/vcd/resource_vcd_org.go
+++ b/vcd/resource_vcd_org.go
@@ -73,6 +73,18 @@ func resourceOrg() *schema.Resource {
 				Default:     true,
 				Description: "True if this organization is allowed to share catalogs.",
 			},
+			"can_publish_external_catalogs": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "True if this organization is allowed to publish external catalogs.",
+			},
+			"can_subscribe_external_catalogs": &schema.Schema{
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "True if this organization is allowed to subscribe to external catalogs.",
+			},
 			"vapp_lease": &schema.Schema{
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -243,12 +255,16 @@ func getSettings(d *schema.ResourceData) *types.OrgSettings {
 	storedVmQuota := d.Get("stored_vm_quota").(int)
 	delay := d.Get("delay_after_power_on_seconds").(int)
 	canPublishCatalogs := d.Get("can_publish_catalogs").(bool)
+	canPublishExternalCatalogs := d.Get("can_publish_external_catalogs").(bool)
+	canSubscribeExternalCatalogs := d.Get("can_subscribe_external_catalogs").(bool)
 
 	generalSettings := &types.OrgGeneralSettings{
 		DeployedVMQuota:          deployedVmQuota,
 		StoredVMQuota:            storedVmQuota,
 		DelayAfterPowerOnSeconds: delay,
 		CanPublishCatalogs:       canPublishCatalogs,
+		CanPublishExternally:     canPublishExternalCatalogs,
+		CanSubscribe:             canSubscribeExternalCatalogs,
 	}
 
 	settings.OrgGeneralSettings = generalSettings
@@ -363,6 +379,8 @@ func setOrgData(d *schema.ResourceData, adminOrg *govcd.AdminOrg) error {
 	dSet(d, "deployed_vm_quota", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.DeployedVMQuota)
 	dSet(d, "stored_vm_quota", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.StoredVMQuota)
 	dSet(d, "can_publish_catalogs", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs)
+	dSet(d, "can_publish_external_catalogs", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally)
+	dSet(d, "can_subscribe_external_catalogs", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe)
 	dSet(d, "delay_after_power_on_seconds", adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.DelayAfterPowerOnSeconds)
 	var err error
 

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -71,83 +71,95 @@ func TestAccVcdOrgFull(t *testing.T) {
 		return
 	}
 	type testOrgData struct {
-		name                  string
-		enabled               bool
-		canPublishCatalogs    bool
-		deployedVmQuota       int
-		storedVmQuota         int
-		runtimeLease          int
-		powerOffonLeaseExp    bool
-		vappStorageLease      int
-		vappDeleteOnLeaseExp  bool
-		templStorageLease     int
-		templDeleteOnLeaseExp bool
+		name                         string
+		enabled                      bool
+		canPublishCatalogs           bool
+		canPublishExternalCatalogs   bool
+		canSubscribeExternalCatalogs bool
+		deployedVmQuota              int
+		storedVmQuota                int
+		runtimeLease                 int
+		powerOffonLeaseExp           bool
+		vappStorageLease             int
+		vappDeleteOnLeaseExp         bool
+		templStorageLease            int
+		templDeleteOnLeaseExp        bool
 	}
 	var orgList = []testOrgData{
 		{
-			name:                  "org1",
-			enabled:               true,
-			canPublishCatalogs:    false,
-			deployedVmQuota:       0,
-			storedVmQuota:         0,
-			runtimeLease:          0, // never expires
-			powerOffonLeaseExp:    true,
-			vappStorageLease:      0, // never expires
-			templDeleteOnLeaseExp: true,
-			templStorageLease:     0, // never expires
-			vappDeleteOnLeaseExp:  true,
+			name:                         "org1",
+			enabled:                      true,
+			canPublishCatalogs:           false,
+			canPublishExternalCatalogs:   false,
+			canSubscribeExternalCatalogs: false,
+			deployedVmQuota:              0,
+			storedVmQuota:                0,
+			runtimeLease:                 0, // never expires
+			powerOffonLeaseExp:           true,
+			vappStorageLease:             0, // never expires
+			templDeleteOnLeaseExp:        true,
+			templStorageLease:            0, // never expires
+			vappDeleteOnLeaseExp:         true,
 		},
 		{
-			name:                  "org2",
-			enabled:               false,
-			canPublishCatalogs:    true,
-			deployedVmQuota:       1,
-			storedVmQuota:         1,
-			runtimeLease:          3600, // 1 hour
-			powerOffonLeaseExp:    true,
-			vappStorageLease:      3600, // 1 hour
-			templDeleteOnLeaseExp: true,
-			templStorageLease:     3600, // 1 hour
-			vappDeleteOnLeaseExp:  true,
+			name:                         "org2",
+			enabled:                      false,
+			canPublishCatalogs:           true,
+			canPublishExternalCatalogs:   true,
+			canSubscribeExternalCatalogs: true,
+			deployedVmQuota:              1,
+			storedVmQuota:                1,
+			runtimeLease:                 3600, // 1 hour
+			powerOffonLeaseExp:           true,
+			vappStorageLease:             3600, // 1 hour
+			templDeleteOnLeaseExp:        true,
+			templStorageLease:            3600, // 1 hour
+			vappDeleteOnLeaseExp:         true,
 		},
 		{
-			name:                  "org3",
-			enabled:               true,
-			canPublishCatalogs:    true,
-			deployedVmQuota:       10,
-			storedVmQuota:         10,
-			runtimeLease:          3600 * 24, // 1 day
-			powerOffonLeaseExp:    false,
-			vappStorageLease:      3600 * 24 * 30, // 1 month
-			templDeleteOnLeaseExp: false,
-			templStorageLease:     3600 * 24 * 365, // 1 year
-			vappDeleteOnLeaseExp:  false,
+			name:                         "org3",
+			enabled:                      true,
+			canPublishCatalogs:           true,
+			canPublishExternalCatalogs:   true,
+			canSubscribeExternalCatalogs: false,
+			deployedVmQuota:              10,
+			storedVmQuota:                10,
+			runtimeLease:                 3600 * 24, // 1 day
+			powerOffonLeaseExp:           false,
+			vappStorageLease:             3600 * 24 * 30, // 1 month
+			templDeleteOnLeaseExp:        false,
+			templStorageLease:            3600 * 24 * 365, // 1 year
+			vappDeleteOnLeaseExp:         false,
 		},
 		{
-			name:                  "org4",
-			enabled:               false,
-			canPublishCatalogs:    false,
-			deployedVmQuota:       100,
-			storedVmQuota:         100,
-			runtimeLease:          3600 * 24 * 15, // 15 days
-			powerOffonLeaseExp:    false,
-			vappStorageLease:      3600 * 24 * 15, // 15 days
-			templDeleteOnLeaseExp: false,
-			templStorageLease:     3600 * 24 * 15, // 15 days
-			vappDeleteOnLeaseExp:  false,
+			name:                         "org4",
+			enabled:                      false,
+			canPublishCatalogs:           false,
+			canPublishExternalCatalogs:   true,
+			canSubscribeExternalCatalogs: true,
+			deployedVmQuota:              100,
+			storedVmQuota:                100,
+			runtimeLease:                 3600 * 24 * 15, // 15 days
+			powerOffonLeaseExp:           false,
+			vappStorageLease:             3600 * 24 * 15, // 15 days
+			templDeleteOnLeaseExp:        false,
+			templStorageLease:            3600 * 24 * 15, // 15 days
+			vappDeleteOnLeaseExp:         false,
 		},
 		{
-			name:                  "org5",
-			enabled:               true,
-			canPublishCatalogs:    true,
-			deployedVmQuota:       200,
-			storedVmQuota:         200,
-			runtimeLease:          3600 * 24 * 7, // 7 days (the default)
-			powerOffonLeaseExp:    false,
-			vappStorageLease:      3600 * 24 * 14, // 14 days (the default)
-			templDeleteOnLeaseExp: false,
-			templStorageLease:     3600 * 24 * 30, // 30 days (the default)
-			vappDeleteOnLeaseExp:  false,
+			name:                         "org5",
+			enabled:                      true,
+			canPublishCatalogs:           true,
+			canPublishExternalCatalogs:   false,
+			canSubscribeExternalCatalogs: true,
+			deployedVmQuota:              200,
+			storedVmQuota:                200,
+			runtimeLease:                 3600 * 24 * 7, // 7 days (the default)
+			powerOffonLeaseExp:           false,
+			vappStorageLease:             3600 * 24 * 14, // 14 days (the default)
+			templDeleteOnLeaseExp:        false,
+			templStorageLease:            3600 * 24 * 30, // 30 days (the default)
+			vappDeleteOnLeaseExp:         false,
 		},
 	}
 	willSkip := false
@@ -155,21 +167,23 @@ func TestAccVcdOrgFull(t *testing.T) {
 	for _, od := range orgList {
 
 		var params = StringMap{
-			"FuncName":              "TestAccVcdOrgFull" + "_" + od.name,
-			"OrgName":               od.name,
-			"FullName":              "Full " + od.name,
-			"Description":           "Organization " + od.name,
-			"CanPublishCatalogs":    od.canPublishCatalogs,
-			"DeployedVmQuota":       od.deployedVmQuota,
-			"StoredVmQuota":         od.storedVmQuota,
-			"IsEnabled":             od.enabled,
-			"RuntimeLease":          od.runtimeLease,
-			"PowerOffOnLeaseExp":    od.powerOffonLeaseExp,
-			"VappStorageLease":      od.vappStorageLease,
-			"VappDeleteOnLeaseExp":  od.vappDeleteOnLeaseExp,
-			"TemplStorageLease":     od.templStorageLease,
-			"TemplDeleteOnLeaseExp": od.templDeleteOnLeaseExp,
-			"Tags":                  "org",
+			"FuncName":                     "TestAccVcdOrgFull" + "_" + od.name,
+			"OrgName":                      od.name,
+			"FullName":                     "Full " + od.name,
+			"Description":                  "Organization " + od.name,
+			"CanPublishCatalogs":           od.canPublishCatalogs,
+			"CanPublishExternalCatalogs":   od.canPublishExternalCatalogs,
+			"CanSubscribeExternalCatalogs": od.canSubscribeExternalCatalogs,
+			"DeployedVmQuota":              od.deployedVmQuota,
+			"StoredVmQuota":                od.storedVmQuota,
+			"IsEnabled":                    od.enabled,
+			"RuntimeLease":                 od.runtimeLease,
+			"PowerOffOnLeaseExp":           od.powerOffonLeaseExp,
+			"VappStorageLease":             od.vappStorageLease,
+			"VappDeleteOnLeaseExp":         od.vappDeleteOnLeaseExp,
+			"TemplStorageLease":            od.templStorageLease,
+			"TemplDeleteOnLeaseExp":        od.templDeleteOnLeaseExp,
+			"Tags":                         "org",
 		}
 
 		configText := templateFill(testAccCheckVcdOrgFull, params)
@@ -185,6 +199,8 @@ func TestAccVcdOrgFull(t *testing.T) {
 		updateParams["FullName"] = params["FullName"].(string) + " updated"
 		updateParams["Description"] = params["Description"].(string) + " updated"
 		updateParams["CanPublishCatalogs"] = !params["CanPublishCatalogs"].(bool)
+		updateParams["CanPublishExternalCatalogs"] = !params["CanPublishExternalCatalogs"].(bool)
+		updateParams["CanSubscribeExternalCatalogs"] = !params["CanSubscribeExternalCatalogs"].(bool)
 		updateParams["IsEnabled"] = !params["IsEnabled"].(bool)
 
 		configTextUpdated := templateFill(testAccCheckVcdOrgFull, updateParams)
@@ -192,10 +208,10 @@ func TestAccVcdOrgFull(t *testing.T) {
 			willSkip = true
 			continue
 		}
-		fmt.Printf("org: %-5s - enabled %-5v - catalogs %-5v - quotas [%3d %3d] - vapp {%10d %5v %10d %5v} - tmpl {%10d %5v}\n",
-			od.name, od.enabled, od.canPublishCatalogs, od.deployedVmQuota, od.storedVmQuota,
-			od.runtimeLease, od.powerOffonLeaseExp, od.vappStorageLease, od.vappDeleteOnLeaseExp,
-			od.templStorageLease, od.templDeleteOnLeaseExp)
+		fmt.Printf("org: %-5s - enabled %-5v - catalogs %-5v - externalCatalogs %-5v - subscribeExternalCatalogs %-5v - quotas [%3d %3d] - vapp {%10d %5v %10d %5v} - tmpl {%10d %5v}\n",
+			od.name, od.enabled, od.canPublishCatalogs, od.canPublishExternalCatalogs, od.canSubscribeExternalCatalogs,
+			od.deployedVmQuota, od.storedVmQuota, od.runtimeLease, od.powerOffonLeaseExp, od.vappStorageLease,
+			od.vappDeleteOnLeaseExp, od.templStorageLease, od.templDeleteOnLeaseExp)
 		debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 		debugPrintf("#[DEBUG] CONFIGURATION: %s", configTextUpdated)
 
@@ -219,6 +235,10 @@ func TestAccVcdOrgFull(t *testing.T) {
 							resourceName, "is_enabled", fmt.Sprintf("%v", od.enabled)),
 						resource.TestCheckResourceAttr(
 							resourceName, "can_publish_catalogs", fmt.Sprintf("%v", od.canPublishCatalogs)),
+						resource.TestCheckResourceAttr(
+							resourceName, "can_publish_external_catalogs", fmt.Sprintf("%v", od.canPublishExternalCatalogs)),
+						resource.TestCheckResourceAttr(
+							resourceName, "can_subscribe_external_catalogs", fmt.Sprintf("%v", od.canSubscribeExternalCatalogs)),
 						resource.TestCheckResourceAttr(
 							resourceName, "deployed_vm_quota", fmt.Sprintf("%d", od.deployedVmQuota)),
 						resource.TestCheckResourceAttr(
@@ -250,6 +270,10 @@ func TestAccVcdOrgFull(t *testing.T) {
 							resourceName, "description", updateParams["Description"].(string)),
 						resource.TestCheckResourceAttr(
 							resourceName, "can_publish_catalogs", fmt.Sprintf("%v", !od.canPublishCatalogs)),
+						resource.TestCheckResourceAttr(
+							resourceName, "can_publish_external_catalogs", fmt.Sprintf("%v", !od.canPublishExternalCatalogs)),
+						resource.TestCheckResourceAttr(
+							resourceName, "can_subscribe_external_catalogs", fmt.Sprintf("%v", !od.canSubscribeExternalCatalogs)),
 						resource.TestCheckResourceAttr(
 							resourceName, "deployed_vm_quota", fmt.Sprintf("%d", updateParams["DeployedVmQuota"].(int))),
 						resource.TestCheckResourceAttr(
@@ -338,15 +362,17 @@ resource "vcd_org" "{{.OrgName}}" {
 
 const testAccCheckVcdOrgFull = `
 resource "vcd_org" "{{.OrgName}}" {
-  name                 = "{{.OrgName}}"
-  full_name            = "{{.FullName}}"
-  description          = "{{.Description}}"
-  can_publish_catalogs = "{{.CanPublishCatalogs}}"
-  deployed_vm_quota    = {{.DeployedVmQuota}}
-  stored_vm_quota      = {{.StoredVmQuota}}
-  is_enabled           = "{{.IsEnabled}}"
-  delete_force         = "true"
-  delete_recursive     = "true"
+  name                            = "{{.OrgName}}"
+  full_name                       = "{{.FullName}}"
+  description                     = "{{.Description}}"
+  can_publish_catalogs            = "{{.CanPublishCatalogs}}"
+  can_publish_external_catalogs   = "{{.CanPublishExternalCatalogs}}"
+  can_subscribe_external_catalogs = "{{.CanSubscribeExternalCatalogs}}"
+  deployed_vm_quota               = {{.DeployedVmQuota}}
+  stored_vm_quota                 = {{.StoredVmQuota}}
+  is_enabled                      = "{{.IsEnabled}}"
+  delete_force                    = "true"
+  delete_recursive                = "true"
   vapp_lease {
     maximum_runtime_lease_in_sec          = {{.RuntimeLease}}
     power_off_on_runtime_lease_expiration = {{.PowerOffOnLeaseExp}}

--- a/website/docs/d/org.html.markdown
+++ b/website/docs/d/org.html.markdown
@@ -57,11 +57,11 @@ The following arguments are supported:
 * `deployed_vm_quota` - Maximum number of virtual machines that can be deployed simultaneously by a member of this organization.
 * `stored_vm_quota` - Maximum number of virtual machines in vApps or vApp templates that can be stored in an undeployed state by a member of this organization.
 * `can_publish_catalogs` - True if this organization is allowed to share catalogs.
+* `can_publish_external_catalogs` - (*v3.6+*) - True if this organization is allowed to publish external catalogs.
+* `can_subscribe_external_catalogs` - (*v3.6+*) - True if this organization is allowed to subscribe to external catalogs.
 * `delay_after_power_on_seconds` - Specifies this organization's default for virtual machine boot delay after power on.
 * `vapp_lease` - (*v2.7+*) - Defines lease parameters for vApps created in this organization. See [vApp Lease](#vapp-lease) below for details. 
 * `vapp_template_lease` - (*v2.7+*) - Defines lease parameters for vApp templates created in this organization. See [vApp Template Lease](#vapp-template-lease) below for details.
-* `can_publish_external_catalogs` - (*v3.6+*) - True if this organization is allowed to publish external catalogs.
-* `can_subscribe_external_catalogs` - (*v3.6+*) - True if this organization is allowed to subscribe to external catalogs.
 
 <a id="vapp-lease"></a>
 ## vApp Lease

--- a/website/docs/d/org.html.markdown
+++ b/website/docs/d/org.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 * `delay_after_power_on_seconds` - Specifies this organization's default for virtual machine boot delay after power on.
 * `vapp_lease` - (*v2.7+*) - Defines lease parameters for vApps created in this organization. See [vApp Lease](#vapp-lease) below for details. 
 * `vapp_template_lease` - (*v2.7+*) - Defines lease parameters for vApp templates created in this organization. See [vApp Template Lease](#vapp-template-lease) below for details.
+* `can_publish_external_catalogs` - (*v3.6+*) - True if this organization is allowed to publish external catalogs.
+* `can_subscribe_external_catalogs` - (*v3.6+*) - True if this organization is allowed to subscribe to external catalogs.
 
 <a id="vapp-lease"></a>
 ## vApp Lease

--- a/website/docs/r/org.html.markdown
+++ b/website/docs/r/org.html.markdown
@@ -60,6 +60,8 @@ The following arguments are supported:
 * `delay_after_power_on_seconds` - (Optional) - Specifies this organization's default for virtual machine boot delay after power on. Default is `0`.
 * `vapp_lease` - (Optional; *v2.7+*) - Defines lease parameters for vApps created in this organization. See [vApp Lease](#vapp-lease) below for details. 
 * `vapp_template_lease` - (Optional; *v2.7+*) - Defines lease parameters for vApp templates created in this organization. See [vApp Template Lease](#vapp-template-lease) below for details.
+* `can_publish_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to publish external catalogs. Default is `false`.
+* `can_subscribe_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to subscribe to external catalogs. Default is `false`.
 
 <a id="vapp-lease"></a>
 ## vApp Lease

--- a/website/docs/r/org.html.markdown
+++ b/website/docs/r/org.html.markdown
@@ -57,11 +57,11 @@ The following arguments are supported:
 * `deployed_vm_quota` - (Optional) - Maximum number of virtual machines that can be deployed simultaneously by a member of this organization. Default is unlimited (0)
 * `stored_vm_quota` - (Optional) - Maximum number of virtual machines in vApps or vApp templates that can be stored in an undeployed state by a member of this organization. Default is unlimited (0)
 * `can_publish_catalogs` - (Optional) - True if this organization is allowed to share catalogs. Default is `true`.
+* `can_publish_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to publish external catalogs. Default is `false`.
+* `can_subscribe_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to subscribe to external catalogs. Default is `false`.
 * `delay_after_power_on_seconds` - (Optional) - Specifies this organization's default for virtual machine boot delay after power on. Default is `0`.
 * `vapp_lease` - (Optional; *v2.7+*) - Defines lease parameters for vApps created in this organization. See [vApp Lease](#vapp-lease) below for details. 
 * `vapp_template_lease` - (Optional; *v2.7+*) - Defines lease parameters for vApp templates created in this organization. See [vApp Template Lease](#vapp-template-lease) below for details.
-* `can_publish_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to publish external catalogs. Default is `false`.
-* `can_subscribe_external_catalogs` - (Optional; *v3.6+*) - True if this organization is allowed to subscribe to external catalogs. Default is `false`.
 
 <a id="vapp-lease"></a>
 ## vApp Lease


### PR DESCRIPTION
This PR is related #775 

# Description
This PR aims to give support to both `datasource_vcd_org`  and `resource_vcd_org` to "Publish external catalogs" and "Subscribe to external catalogs" options.

# Detailed description
The goal of this PR is add support to `resource_vcd_org` to change the boolean values from "Publish external catalogs" and "Subscribe to external catalogs" using `resource_vcd_org` via its new two schema entries `can_publish_external_catalogs`and `can_subscribe_external_catalogs`.  
  
Also, these two new schema entries will be available in `datasource_vcd_org` for reading the current value.  
  
Acceptance test `TestAccVcdOrgFull` has been modified to accommodate these new values. 
This new feature have been tested using acceptance tests and also tested manually.