### PR TITLE
Add resource/data source`vcd_nsxt_distributed_firewall` and data source `vcd_nsxt_network_context_profile`

### DIFF
--- a/.changes/v3.6.0/789-features.md
+++ b/.changes/v3.6.0/789-features.md
@@ -1,1 +1,1 @@
-* `vcd_independent_disk` allows creating additionally shared disks types by configuring `sharing_type` (VCD 10.3+). Also, add update support. Add new disk type `NVME` and new attributes `encrypted` and `uuid`. Import now allows listing all independent disks in VDC [GH-789]
+* `vcd_independent_disk` allows creating additionally shared disks types by configuring `sharing_type` (VCD 10.3+). Also, add update support. Add new disk type `NVME` and new attributes `encrypted` and `uuid`. Import now allows listing all independent disks in VDC [GH-789, GH-810]

--- a/.changes/v3.6.0/810-features.md
+++ b/.changes/v3.6.0/810-features.md
@@ -1,6 +1,6 @@
-* **New Resource:** `vcd_nsxt_distributed_firewall` allows to manage Distributed Firewall Rules in
-  VDC Groups [GH-810]
-* **New Data Source:** `vcd_nsxt_distributed_firewall` allows to lookup firewall rules in VDC Groups
+* **New Resource:** `vcd_nsxt_distributed_firewall` manages Distributed Firewall Rules in VDC Groups
   [GH-810]
-* **New Data Source:** `vcd_nsxt_network_context_profile` allows to lookup ID for usage in
+* **New Data Source:** `vcd_nsxt_distributed_firewall` provides lookup functionality for Distributed
+  Firewall rules in VDC Groups [GH-810]
+* **New Data Source:** `vcd_nsxt_network_context_profile` allows user to lookup ID for usage in
   `vcd_nsxt_distributed_firewall` [GH-810]

--- a/.changes/v3.6.0/810-features.md
+++ b/.changes/v3.6.0/810-features.md
@@ -2,5 +2,5 @@
   [GH-810]
 * **New Data Source:** `vcd_nsxt_distributed_firewall` provides lookup functionality for Distributed
   Firewall rules in VDC Groups [GH-810]
-* **New Data Source:** `vcd_nsxt_network_context_profile` allows user to lookup ID for usage in
-  `vcd_nsxt_distributed_firewall` [GH-810]
+* **New Data Source:** `vcd_nsxt_network_context_profile` allows user to lookup Network Context
+  Profile ID for usage in `vcd_nsxt_distributed_firewall` [GH-810]

--- a/.changes/v3.6.0/810-features.md
+++ b/.changes/v3.6.0/810-features.md
@@ -1,0 +1,6 @@
+* **New Resource:** `vcd_nsxt_distributed_firewall` allows to manage Distributed Firewall Rules in
+  VDC Groups [GH-810]
+* **New Data Source:** `vcd_nsxt_distributed_firewall` allows to lookup firewall rules in VDC Groups
+  [GH-810]
+* **New Data Source:** `vcd_nsxt_network_context_profile` allows to lookup ID for usage in
+  `vcd_nsxt_distributed_firewall` [GH-810]

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329194430-d8498f58b471

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.3
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.4
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.3
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406092941-47d706c38a45
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,11 @@ go 1.13
 
 require (
 	github.com/aws/aws-sdk-go v1.30.12 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406092941-47d706c38a45 h1:BMbE1zAPaVZhoqrrdmatp0dWXtI+5JHXKagP6CYAYMc=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406092941-47d706c38a45/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639 h1:jB0qPOeUC8QH2mh19WNgIATIW4GvMv7axQyNRYnWhrU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639 h1:jB0qPOeUC8QH2mh19WNgIATIW4GvMv7axQyNRYnWhrU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220406191604-20f5f1aac639/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
@@ -321,6 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.4 h1:q25W+u8aekOrG7sYbrOnJv3xJ9Frtl4NpxhMu1kZlBw=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e h1:5JaTtQ3GP+hJWiAUqBjaw9dAh1RltfFGi/z6I4kIEIM=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8 h1:0+DsW+KbPU+aKXzKSjSvJA7ZvpjB2V6q2TvhWXXnryA=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.8/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4 h1:1g/k6IEzdgr94zNmxgvZGxsk7oV4zzgdo3zoXi0ddAI=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329194430-d8498f58b471 h1:O8OG7+w3Xf/KZjLgUuuEujtz/ernGU3yg8goBrDW8P0=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329194430-d8498f58b471/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e h1:5JaTtQ3GP+hJWiAUqBjaw9dAh1RltfFGi/z6I4kIEIM=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329122244-a98f4d34e22e/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4 h1:1g/k6IEzdgr94zNmxgvZGxsk7oV4zzgdo3zoXi0ddAI=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220329150941-b268b399b8c4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -253,6 +253,26 @@ func (cli *VCDClient) unlockById(id string) {
 	vcdMutexKV.kvUnlock(id)
 }
 
+// lockParentVdcGroup locks on VDC Group ID in 'vdc_group_id' field
+func (cli *VCDClient) lockParentVdcGroup(d *schema.ResourceData) {
+	vdcGroupId := d.Get("vdc_group_id").(string)
+	if vdcGroupId == "" {
+		panic("'vdc_group_id' is empty")
+	}
+
+	vcdMutexKV.kvLock(vdcGroupId)
+}
+
+// unlockParentVdcGroup unlocks on VDC Group ID in 'vdc_group_id' field
+func (cli *VCDClient) unlockParentVdcGroup(d *schema.ResourceData) {
+	vdcGroupId := d.Get("vdc_group_id").(string)
+	if vdcGroupId == "" {
+		panic("'vdc_group_id' is empty")
+	}
+
+	vcdMutexKV.kvUnlock(vdcGroupId)
+}
+
 // lockIfOwnerIsVdcGroup locks VDC Group based on `owner_id` field (if it is a VDC Group)
 func (cli *VCDClient) lockIfOwnerIsVdcGroup(d *schema.ResourceData) {
 	vdcGroupId := d.Get("owner_id")

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -263,7 +263,7 @@ func (cli *VCDClient) lockParentVdcGroup(d *schema.ResourceData) {
 	vcdMutexKV.kvLock(vdcGroupId)
 }
 
-// unlockParentVdcGroup unlocks on VDC Group ID in 'vdc_group_id' field
+// unlockParentVdcGroup unlocks on VDC Group ID using 'vdc_group_id' field
 func (cli *VCDClient) unlockParentVdcGroup(d *schema.ResourceData) {
 	vdcGroupId := d.Get("vdc_group_id").(string)
 	if vdcGroupId == "" {

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -253,7 +253,7 @@ func (cli *VCDClient) unlockById(id string) {
 	vcdMutexKV.kvUnlock(id)
 }
 
-// lockParentVdcGroup locks on VDC Group ID in 'vdc_group_id' field
+// lockParentVdcGroup locks on VDC Group ID using 'vdc_group_id' field
 func (cli *VCDClient) lockParentVdcGroup(d *schema.ResourceData) {
 	vdcGroupId := d.Get("vdc_group_id").(string)
 	if vdcGroupId == "" {

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -61,7 +61,8 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 		case dataSourceName == "vcd_nsxt_alb_controller" || dataSourceName == "vcd_nsxt_alb_cloud" ||
 			dataSourceName == "vcd_nsxt_alb_importable_cloud" || dataSourceName == "vcd_nsxt_alb_service_engine_group" ||
 			dataSourceName == "vcd_nsxt_alb_settings" || dataSourceName == "vcd_nsxt_alb_edgegateway_service_engine_group" ||
-			dataSourceName == "vcd_nsxt_alb_pool" || dataSourceName == "vcd_nsxt_alb_virtual_service":
+			dataSourceName == "vcd_nsxt_alb_pool" || dataSourceName == "vcd_nsxt_alb_virtual_service" ||
+			dataSourceName == "vcd_nsxt_distributed_firewall":
 			skipNoNsxtAlbConfiguration(t)
 			if !usingSysAdmin() {
 				t.Skip(`Works only with system admin privileges`)
@@ -193,6 +194,8 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			}
 			templateFields = templateFields + `context_id = "` + nsxtManagerUrn + `"` + "\n"
 			// Invalid fields which are required for some resources for search (usually they are used instead of `name`)
+		case "vdc_group_id":
+			templateFields = templateFields + `vdc_group_id = "urn:vcloud:vdcGroup:c19ec5b1-3403-4d00-b414-9da50066dc1e"` + "\n"
 		case "rule_id":
 			templateFields = templateFields + `rule_id = "347928347234"` + "\n"
 		case "name":

--- a/vcd/datasource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/datasource_vcd_nsxt_distributed_firewall.go
@@ -15,15 +15,13 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
 			"vdc_group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "The name of VDC to use, optional if defined at provider level",
+				Description: "The ID of VDC Group",
 			},
 			"rule": {
 				Type:        schema.TypeList, // Firewall rule order matters
@@ -125,7 +123,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 	}
 }
 
-func datasourceVcdNsxtDistributedFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceVcdNsxtDistributedFirewallRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	org, err := vcdClient.GetOrgFromResource(d)

--- a/vcd/datasource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/datasource_vcd_nsxt_distributed_firewall.go
@@ -44,7 +44,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"description": {
 							Type:        schema.TypeString,
 							Computed:    true,
-							Description: "Description is not shown in UI",
+							Description: "Description (not shown in UI)",
 						},
 						"comment": {
 							Type:        schema.TypeString,
@@ -69,7 +69,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
-							Description: "Defined if Firewall Rule is active",
+							Description: "Defines if Firewall Rule is active",
 						},
 						"logging": {
 							Type:        schema.TypeBool,
@@ -79,7 +79,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"source_ids": {
 							Type:        schema.TypeSet,
 							Computed:    true,
-							Description: "A set of Source Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Description: "A set of Source Firewall Group IDs (IP Sets or Security Groups). Empty means 'Any'",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -87,7 +87,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"destination_ids": {
 							Type:        schema.TypeSet,
 							Computed:    true,
-							Description: "A set of Destination Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Description: "A set of Destination Firewall Group IDs (IP Sets or Security Groups). Empty means 'Any'",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -95,7 +95,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"app_port_profile_ids": {
 							Type:        schema.TypeSet,
 							Computed:    true,
-							Description: "A set of Application Port Profile IDs. Leaving it empty means 'Any'",
+							Description: "A set of Application Port Profile IDs.'",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -103,7 +103,7 @@ func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
 						"network_context_profile_ids": {
 							Type:        schema.TypeSet,
 							Computed:    true,
-							Description: "A set of Network Context Profile IDs. Leaving it empty means 'Any'",
+							Description: "A set of Network Context Profile IDs.",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},
@@ -130,22 +130,22 @@ func datasourceVcdNsxtDistributedFirewallRead(ctx context.Context, d *schema.Res
 
 	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf("[Distributed Firewall Read] error retriving Org: %s", err)
+		return diag.Errorf("[Distributed Firewall DS Read] error retriving Org: %s", err)
 	}
 
 	vdcGroup, err := org.GetVdcGroupById(d.Get("vdc_group_id").(string))
 	if err != nil {
-		return diag.Errorf("[Distributed Firewall Read] error retrieving VDC Group: %s", err)
+		return diag.Errorf("[Distributed Firewall DS Read] error retrieving VDC Group: %s", err)
 	}
 
 	fwRules, err := vdcGroup.GetDistributedFirewall()
 	if err != nil {
-		return diag.Errorf("[Distributed Firewall Read] error retrieving NSX-T Firewall Rules: %s", err)
+		return diag.Errorf("[Distributed Firewall DS Read] error retrieving NSX-T Firewall Rules: %s", err)
 	}
 
 	err = setDistributedFirewallData(vcdClient, fwRules.DistributedFirewallRuleContainer, d, vdcGroup.VdcGroup.Id)
 	if err != nil {
-		return diag.Errorf("[Distributed Firewall Read] error storing NSX-T Firewall data to schema: %s", err)
+		return diag.Errorf("[Distributed Firewall DS Read] error storing NSX-T Firewall data to schema: %s", err)
 	}
 
 	d.SetId(vdcGroup.VdcGroup.Id)

--- a/vcd/datasource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/datasource_vcd_nsxt_distributed_firewall.go
@@ -1,0 +1,154 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdNsxtDistributedFirewall() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdNsxtDistributedFirewallRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"rule": {
+				Type:        schema.TypeList, // Firewall rule order matters
+				Computed:    true,
+				Description: "Ordered list of firewall rules",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Firewall Rule ID",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Firewall Rule name",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Description is not shown in UI",
+						},
+						"comment": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Comment that is shown next to rule in UI (VCD 10.3.2+)",
+						},
+						"direction": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Direction on which Firewall Rule applies (One of 'IN', 'OUT', 'IN_OUT')",
+						},
+						"ip_protocol": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Firewall Rule Protocol (One of 'IPV4', 'IPV6', 'IPV4_IPV6')",
+						},
+						"action": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Defines if the rule should 'ALLOW', 'DROP', 'REJECT' matching traffic",
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Defined if Firewall Rule is active",
+						},
+						"logging": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Defines if matching traffic should be logged",
+						},
+						"source_ids": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "A set of Source Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"destination_ids": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "A set of Destination Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"app_port_profile_ids": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "A set of Application Port Profile IDs. Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"network_context_profile_ids": {
+							Type:        schema.TypeSet,
+							Computed:    true,
+							Description: "A set of Network Context Profile IDs. Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"source_groups_excluded": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Reverses firewall matching for to match all except Source Groups specified in 'source_ids' (VCD 10.3.2+)",
+						},
+						"destination_groups_excluded": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Reverses firewall matching for to match all except Destinations Groups specified in 'destination_ids' (VCD 10.3.2+)",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceVcdNsxtDistributedFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error retriving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(d.Get("vdc_group_id").(string))
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error retrieving VDC Group: %s", err)
+	}
+
+	fwRules, err := vdcGroup.GetDistributedFirewall()
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error retrieving NSX-T Firewall Rules: %s", err)
+	}
+
+	err = setDistributedFirewallData(vcdClient, fwRules.DistributedFirewallRuleContainer, d, vdcGroup.VdcGroup.Id)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error storing NSX-T Firewall data to schema: %s", err)
+	}
+
+	d.SetId(vdcGroup.VdcGroup.Id)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_network_context_profile.go
+++ b/vcd/datasource_vcd_nsxt_network_context_profile.go
@@ -1,0 +1,55 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+func datasourceVcdNsxtNetworkContextProfile() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdNsxtNetworkContextProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"context_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Context ID can be one of VDC Group ID, ",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway name in which NAT Rule is located",
+			},
+			"scope": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "SYSTEM",
+				Description:  "'SYSTEM', 'PROVIDER', 'TENANT'",
+				ValidateFunc: validation.StringInSlice([]string{"SYSTEM", "PROVIDER", "TENANT"}, false),
+			},
+		},
+	}
+}
+
+func datasourceVcdNsxtNetworkContextProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	name := d.Get("name").(string)
+	scope := d.Get("scope").(string)
+	contextId := d.Get("context_id").(string)
+
+	nsxtNetworkContextProfile, err := govcd.GetNetworkContextProfilesByNameScopeAndContext(&vcdClient.Client, name, scope, contextId)
+	if err != nil {
+		return diag.Errorf("error finding Network Context Profile with name '%s', scope '%s' and context_id '%s': %s",
+			name, scope, contextId, err)
+	}
+
+	d.SetId(nsxtNetworkContextProfile.ID)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_network_context_profile.go
+++ b/vcd/datasource_vcd_nsxt_network_context_profile.go
@@ -17,13 +17,11 @@ func datasourceVcdNsxtNetworkContextProfile() *schema.Resource {
 			"context_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
-				Description: "Context ID can be one of VDC Group ID, ",
+				Description: "Context ID can be one of VDC, VDC Group, or NSX-T Manager ID",
 			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Edge gateway name in which NAT Rule is located",
 			},
 			"scope": {
@@ -45,7 +43,7 @@ func datasourceVcdNsxtNetworkContextProfileRead(ctx context.Context, d *schema.R
 
 	nsxtNetworkContextProfile, err := govcd.GetNetworkContextProfilesByNameScopeAndContext(&vcdClient.Client, name, scope, contextId)
 	if err != nil {
-		return diag.Errorf("error finding Network Context Profile with name '%s', scope '%s' and context_id '%s': %s",
+		return diag.Errorf("[Network Context profile DS Read] error finding Network Context Profile with name '%s', scope '%s' and context_id '%s': %s",
 			name, scope, contextId, err)
 	}
 

--- a/vcd/datasource_vcd_nsxt_network_context_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_network_context_profile_test.go
@@ -1,0 +1,134 @@
+//go:build nsxt || network || vdcGroup || functional || ALL
+// +build nsxt network vdcGroup functional ALL
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdNsxtNetworkContextProfileInVdc(t *testing.T) {
+	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	skipNoNsxtConfiguration(t)
+
+	var params = StringMap{
+		"Org":     testConfig.VCD.Org,
+		"NsxtVdc": testConfig.Nsxt.Vdc,
+		"Tags":    "nsxt network vdcGroup",
+	}
+
+	configText := templateFill(testAccVcdNsxtNetworkContextProfileDS, params)
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { preRunChecks(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vcd_nsxt_network_context_profile.p", "id", regexp.MustCompile("urn:vcloud:networkContextProfile:")),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "name", "CTRXICA"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "scope", "SYSTEM"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdNsxtNetworkContextProfileDS = `
+data "vcd_org_vdc" "nsxt" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdc}}"
+}
+data "vcd_nsxt_network_context_profile" "p" {
+  context_id = data.vcd_org_vdc.nsxt.id
+  name       = "CTRXICA"
+}
+`
+
+func TestAccVcdNsxtNetworkContextProfileInNsxtManager(t *testing.T) {
+	preTestChecks(t)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	skipNoNsxtConfiguration(t)
+
+	var params = StringMap{
+		"Org":             testConfig.VCD.Org,
+		"NsxtManagerName": testConfig.Nsxt.Manager,
+		"Scope":           "SYSTEM",
+		"Tags":            "nsxt network vdcGroup",
+	}
+
+	configText1 := templateFill(testAccVcdNsxtNetworkContextProfileNsxtManagerDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION - step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	params["Scope"] = "PROVIDER"
+	configText2 := templateFill(testAccVcdNsxtNetworkContextProfileNsxtManagerDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION - step 2: %s", configText2)
+
+	params["FuncName"] = t.Name() + "-step3"
+	params["Scope"] = "TENANT"
+	configText3 := templateFill(testAccVcdNsxtNetworkContextProfileNsxtManagerDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION - step 3: %s", configText3)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { preRunChecks(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vcd_nsxt_network_context_profile.p", "id", regexp.MustCompile("urn:vcloud:networkContextProfile:")),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "name", "CTRXICA"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "scope", "SYSTEM"),
+				),
+			},
+			{
+				Config: configText2,
+				// VCD has no capability to create items in PROVIDER context yet
+				ExpectError: regexp.MustCompile("entity not found"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vcd_nsxt_network_context_profile.p", "id", regexp.MustCompile("urn:vcloud:networkContextProfile:")),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "name", "CTRXICA"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "scope", "PROVIDER"),
+				),
+			},
+			{
+				Config: configText3,
+				// VCD has no capability to create items in TENANT context yet
+				ExpectError: regexp.MustCompile("entity not found"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("data.vcd_nsxt_network_context_profile.p", "id", regexp.MustCompile("urn:vcloud:networkContextProfile:")),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "name", "CTRXICA"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_network_context_profile.p", "scope", "TENANT"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdNsxtNetworkContextProfileNsxtManagerDS = `
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManagerName}}"
+}
+
+data "vcd_nsxt_network_context_profile" "p" {
+  context_id = data.vcd_nsxt_manager.main.id
+  name       = "CTRXICA"
+  scope      = "{{.Scope}}"
+}
+`

--- a/vcd/datasource_vcd_nsxt_network_context_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_network_context_profile_test.go
@@ -29,7 +29,7 @@ func TestAccVcdNsxtNetworkContextProfileInVdc(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { preRunChecks(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -85,7 +85,7 @@ func TestAccVcdNsxtNetworkContextProfileInNsxtManager(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION - step 3: %s", configText3)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { preRunChecks(t) },
+		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -157,6 +157,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_alb_pool":                             resourceVcdAlbPool(),                          // 3.5
 	"vcd_nsxt_alb_virtual_service":                  resourceVcdAlbVirtualService(),                // 3.5
 	"vcd_vdc_group":                                 resourceVdcGroup(),                            // 3.5
+	"vcd_nsxt_distributed_firewall":                 resourceVcdNsxtDistributedFirewall(),          // 3.6
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -93,6 +93,9 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_alb_pool":                             datasourceVcdAlbPool(),                          // 3.5
 	"vcd_nsxt_alb_virtual_service":                  datasourceVcdAlbVirtualService(),                // 3.5
 	"vcd_vdc_group":                                 datasourceVdcGroup(),                            // 3.5
+	"vcd_nsxt_distributed_firewall":                 datasourceVcdNsxtDistributedFirewall(),          // 3.6
+	"vcd_nsxt_network_context_profile":              datasourceVcdNsxtNetworkContextProfile(),        // 3.6
+
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -5,9 +5,10 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"regexp"
 	"testing"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -66,11 +67,11 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 		sharingType = "None"
 	}
 
-	vcdVersionIs103 := func() (bool, error) {
-		if vcdClient != nil && vcdClient.Client.APIVCDMaxVersionIs(">= 36") {
-			return true, nil
+	vcdVersionIsLowerThan1022 := func() (bool, error) {
+		if vcdClient != nil && vcdClient.Client.APIVCDMaxVersionIs(">= 35.2") {
+			return false, nil
 		}
-		return false, nil
+		return true, nil
 	}
 
 	params["FuncName"] = t.Name() + "-Compatibility"
@@ -164,7 +165,7 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 			},
 			{
 				Config:   configTextNvme,
-				SkipFunc: vcdVersionIs103,
+				SkipFunc: vcdVersionIsLowerThan1022,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "owner_name", regexp.MustCompile(`^\S+`)),
 					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "datastore_name", regexp.MustCompile(`^\S+`)),
@@ -184,7 +185,7 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 			},
 			{
 				Config:   configTextNvmeUpdate,
-				SkipFunc: vcdVersionIs103,
+				SkipFunc: vcdVersionIsLowerThan1022,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "owner_name", regexp.MustCompile(`^\S+`)),
 					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "datastore_name", regexp.MustCompile(`^\S+`)),

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -251,7 +251,7 @@ func resourceVcdNetworkRoutedV2Delete(ctx context.Context, d *schema.ResourceDat
 func resourceVcdNetworkRoutedV2Import(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 3 {
-		return nil, fmt.Errorf("[routed network import v2] resource name must be specified as org-name.vdc-name.network-name")
+		return nil, fmt.Errorf("[routed network import v2] resource name must be specified as org-name.vdc-name.network-name or org-name.vdc-group-name.network-name")
 	}
 	orgName, vdcName, networkName := resourceURI[0], resourceURI[1], resourceURI[2]
 	vcdClient := meta.(*VCDClient)

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -248,7 +248,7 @@ func resourceVcdNetworkRoutedV2Delete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceVcdNetworkRoutedV2Import(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVcdNetworkRoutedV2Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[routed network import v2] resource name must be specified as org-name.vdc-name.network-name or org-name.vdc-group-name.network-name")

--- a/vcd/resource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/resource_vcd_nsxt_app_port_profile_test.go
@@ -46,11 +46,11 @@ func TestAccVcdNsxtAppPortProfileTenant(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "TENANT"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -167,11 +167,11 @@ func TestAccVcdNsxtAppPortProfileProvider(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "TENANT"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -415,11 +415,11 @@ func TestAccVcdNsxtAppPortProfileProviderContext(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "TENANT"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
+			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof-updated", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{
 			{
@@ -483,10 +483,7 @@ func TestAccVcdNsxtAppPortProfileTenantContextVdc(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{
@@ -572,10 +569,7 @@ func TestAccVcdNsxtAppPortProfileTenantContextVdcGroup(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{
@@ -676,10 +670,7 @@ func TestAccVcdNsxtAppPortProfileConfigurationMigration(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "PROVIDER"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "TENANT"),
-			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 			testAccCheckOpenApiNsxtAppPortDestroy("custom_app_prof", "SYSTEM"),
 		),
 		Steps: []resource.TestStep{

--- a/vcd/resource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall.go
@@ -367,7 +367,7 @@ func getDistributedFirewallTypes(vcdClient *VCDClient, d *schema.ResourceData) (
 				}
 
 				if destinationGroupsExcluded {
-					sliceOfRules[index].SourceGroupsExcluded = &destinationGroupsExcluded
+					sliceOfRules[index].DestinationGroupsExcluded = &destinationGroupsExcluded
 				}
 			} else {
 				if comment != "" {

--- a/vcd/resource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall.go
@@ -35,7 +35,7 @@ func resourceVcdNsxtDistributedFirewall() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
-				Description: "The name of VDC to use, optional if defined at provider level",
+				Description: "ID of VDC Group for Distributed Firewall",
 			},
 			"rule": {
 				Type:        schema.TypeList, // Firewall rule order matters

--- a/vcd/resource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall.go
@@ -1,0 +1,94 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceVcdNsxtDistributedFirewall() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdNsxtDistributedFirewallCreate,
+		ReadContext:   resourceVcdNsxtDistributedFirewallRead,
+		UpdateContext: resourceVcdNsxtDistributedFirewallUpdate,
+		DeleteContext: resourceVcdNsxtDistributedFirewallDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdNsxtDistributedFirewallImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"edge_gateway": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway name in which NAT Rule is located",
+			},
+			"network_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Org or external network name",
+			},
+		},
+	}
+}
+
+func resourceVcdNsxtDistributedFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentEdgeGtw(d)
+	defer vcdClient.unLockParentEdgeGtw(d)
+
+	// orgName := d.Get("org").(string)
+	// vdcName := d.Get("vdc").(string)
+	// edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	// nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
+	// if err != nil {
+	// 	return diag.Errorf("error retrieving Edge Gateway: %s", err)
+	// }
+
+	// firewallRulesType := getNsxtFirewallTypes(d)
+	// firewallContainer := &types.NsxtFirewallRuleContainer{
+	// 	UserDefinedRules: firewallRulesType,
+	// }
+
+	// _, err = nsxtEdge.UpdateNsxtFirewall(firewallContainer)
+	// if err != nil {
+	// 	return diag.Errorf("error creating NSX-T Firewall Rules: %s", err)
+	// }
+
+	// // ID is stored as Edge Gateway ID - because this is a "container" for all firewall rules at once and each child
+	// // TypeSet element will have a computed ID field for each rule
+	// d.SetId(edgeGatewayId)
+
+	return resourceVcdNsxtDistributedFirewallRead(ctx, d, meta)
+}
+
+func resourceVcdNsxtDistributedFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return resourceVcdNsxtDistributedFirewallRead(ctx, d, meta)
+}
+
+func resourceVcdNsxtDistributedFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVcdNsxtDistributedFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVcdNsxtDistributedFirewallImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return []*schema.ResourceData{d}, nil
+}

--- a/vcd/resource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall.go
@@ -2,16 +2,22 @@ package vcd
 
 import (
 	"context"
+	"fmt"
+	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func resourceVcdNsxtDistributedFirewall() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVcdNsxtDistributedFirewallCreate,
+		CreateContext: resourceVcdNsxtDistributedFirewallCreateUpdate,
 		ReadContext:   resourceVcdNsxtDistributedFirewallRead,
-		UpdateContext: resourceVcdNsxtDistributedFirewallUpdate,
+		UpdateContext: resourceVcdNsxtDistributedFirewallCreateUpdate,
 		DeleteContext: resourceVcdNsxtDistributedFirewallDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVcdNsxtDistributedFirewallImport,
@@ -31,64 +37,361 @@ func resourceVcdNsxtDistributedFirewall() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": {
-				Type:        schema.TypeString,
+			"rule": {
+				Type:        schema.TypeList, // Firewall rule order matters
 				Required:    true,
-				ForceNew:    true,
-				Description: "Edge gateway name in which NAT Rule is located",
-			},
-			"network_name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Org or external network name",
+				MinItems:    1,
+				Description: "Ordered list of firewall rules",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Firewall Rule ID",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Firewall Rule name",
+						},
+						"description": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Description is not shown in UI",
+						},
+						"comment": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Comment that is shown next to rule in UI (VCD 10.3.2+)",
+						},
+						"direction": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Direction on which Firewall Rule applies (One of 'IN', 'OUT', 'IN_OUT')",
+							Default:      "IN_OUT",
+							ValidateFunc: validation.StringInSlice([]string{"IN", "OUT", "IN_OUT"}, false),
+						},
+						"ip_protocol": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  "Firewall Rule Protocol (One of 'IPV4', 'IPV6', 'IPV4_IPV6')",
+							Default:      "IPV4_IPV6",
+							ValidateFunc: validation.StringInSlice([]string{"IPV4", "IPV6", "IPV4_IPV6"}, false),
+						},
+						"action": {
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "Defines if the rule should 'ALLOW', 'DROP', 'REJECT' matching traffic",
+							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP", "REJECT"}, false),
+						},
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     true,
+							Description: "Defined if Firewall Rule is active",
+						},
+						"logging": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Defines if matching traffic should be logged",
+						},
+						"source_ids": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "A set of Source Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"destination_ids": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "A set of Destination Firewall Group IDs (IP Sets or Security Groups). Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"app_port_profile_ids": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "A set of Application Port Profile IDs. Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"network_context_profile_ids": {
+							Type:        schema.TypeSet,
+							Optional:    true,
+							Description: "A set of Network Context Profile IDs. Leaving it empty means 'Any'",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+						"source_groups_excluded": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Reverses firewall matching for to match all except Source Groups specified in 'source_ids' (VCD 10.3.2+)",
+						},
+						"destination_groups_excluded": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "Reverses firewall matching for to match all except Destinations Groups specified in 'destination_ids' (VCD 10.3.2+)",
+						},
+					},
+				},
 			},
 		},
 	}
 }
 
-func resourceVcdNsxtDistributedFirewallCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+// resourceVcdNsxtDistributedFirewallCreateUpdate is used in both Create and Update cases because
+// firewall rules don't have separate create or update methods. Firewall endpoint only uses HTTP PUT
+// for update.
+func resourceVcdNsxtDistributedFirewallCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.lockParentEdgeGtw(d)
-	defer vcdClient.unLockParentEdgeGtw(d)
+	vcdClient.lockParentVdcGroup(d)
+	defer vcdClient.unlockParentVdcGroup(d)
 
-	// orgName := d.Get("org").(string)
-	// vdcName := d.Get("vdc").(string)
-	// edgeGatewayId := d.Get("edge_gateway_id").(string)
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Create/Update] error retriving Org: %s", err)
+	}
 
-	// nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, vdcName, edgeGatewayId)
-	// if err != nil {
-	// 	return diag.Errorf("error retrieving Edge Gateway: %s", err)
-	// }
+	vdcGroup, err := org.GetVdcGroupById(d.Get("vdc_group_id").(string))
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Create/Update] error retrieving VDC Group: %s", err)
+	}
 
-	// firewallRulesType := getNsxtFirewallTypes(d)
-	// firewallContainer := &types.NsxtFirewallRuleContainer{
-	// 	UserDefinedRules: firewallRulesType,
-	// }
+	firewallRulesType, err := getDistributedFirewallTypes(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Create/Update] error getting Distributed Firewall type: %s", err)
+	}
+	_, err = vdcGroup.UpdateDistributedFirewall(firewallRulesType)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Create/Update] error setting Distributed Firewall: %s", err)
+	}
 
-	// _, err = nsxtEdge.UpdateNsxtFirewall(firewallContainer)
-	// if err != nil {
-	// 	return diag.Errorf("error creating NSX-T Firewall Rules: %s", err)
-	// }
+	d.SetId(vdcGroup.VdcGroup.Id)
 
-	// // ID is stored as Edge Gateway ID - because this is a "container" for all firewall rules at once and each child
-	// // TypeSet element will have a computed ID field for each rule
-	// d.SetId(edgeGatewayId)
-
-	return resourceVcdNsxtDistributedFirewallRead(ctx, d, meta)
-}
-
-func resourceVcdNsxtDistributedFirewallUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return resourceVcdNsxtDistributedFirewallRead(ctx, d, meta)
 }
 
 func resourceVcdNsxtDistributedFirewallRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error retriving Org: %s", err)
+	}
+
+	vdcGroupId := d.Id()
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("[Distributed Firewall Read] error retrieving VDC Group (%s): %s", vdcGroupId, err)
+	}
+
+	fwRules, err := vdcGroup.GetDistributedFirewall()
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error retrieving NSX-T Firewall Rules: %s", err)
+	}
+
+	err = setDistributedFirewallData(vcdClient, fwRules.DistributedFirewallRuleContainer, d, vdcGroup.VdcGroup.Id)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Read] error storing NSX-T Firewall data to schema: %s", err)
+	}
+
 	return nil
 }
 
 func resourceVcdNsxtDistributedFirewallDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vcdClient.lockParentVdcGroup(d)
+	defer vcdClient.unlockParentVdcGroup(d)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Delete] error retriving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(d.Get("vdc_group_id").(string))
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Delete] error retrieving VDC Group: %s", err)
+	}
+
+	err = vdcGroup.DeleteAllDistributedFirewallRules()
+	if err != nil {
+		return diag.Errorf("[Distributed Firewall Delete]  error deleting Distributed Firewall rules: %s", err)
+	}
+
 	return nil
 }
 
 func resourceVcdNsxtDistributedFirewallImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("[TRACE] NSX-T Distributed Firewall import initiated")
+
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 2 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-group-name")
+	}
+
+	orgName, vdcGroupName := resourceURI[0], resourceURI[1]
+
+	vcdClient := meta.(*VCDClient)
+	adminOrg, err := vcdClient.GetAdminOrg(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("[Distributed Firewall Import] error retrieving org %s: %s", orgName, err)
+	}
+
+	vdcGroup, err := adminOrg.GetVdcGroupByName(vdcGroupName)
+	if err != nil {
+		return nil, fmt.Errorf("[Distributed Firewall Import] error importing VDC group item: %s", err)
+	}
+
+	d.SetId(vdcGroup.VdcGroup.Id)
+	dSet(d, "org", orgName)
+
 	return []*schema.ResourceData{d}, nil
+}
+
+func setDistributedFirewallData(vcdClient *VCDClient, dfwRules *types.DistributedFirewallRules, d *schema.ResourceData, vdcGroupId string) error {
+	dSet(d, "vdc_group_id", vdcGroupId)
+
+	result := make([]interface{}, len(dfwRules.Values))
+	for index, value := range dfwRules.Values {
+		sourceSlice := extractIdsFromOpenApiReferences(value.SourceFirewallGroups)
+		sourceSet := convertStringsTotTypeSet(sourceSlice)
+
+		destinationSlice := extractIdsFromOpenApiReferences(value.DestinationFirewallGroups)
+		destinationSet := convertStringsTotTypeSet(destinationSlice)
+
+		appPortProfileSlice := extractIdsFromOpenApiReferences(value.ApplicationPortProfiles)
+		appPortProfileSet := convertStringsTotTypeSet(appPortProfileSlice)
+
+		netContextProfileSlice := extractIdsFromOpenApiReferences(value.NetworkContextProfiles)
+		netPortProfileSet := convertStringsTotTypeSet(netContextProfileSlice)
+
+		var actionFieldValue string
+		if vcdClient.Client.APIVCDMaxVersionIs(">= 35.2") {
+			actionFieldValue = value.ActionValue
+		} else { // TODO remove this when VCD 10.2 support is dropped
+			actionFieldValue = value.Action
+		}
+
+		result[index] = map[string]interface{}{
+			"id":                          value.ID,
+			"name":                        value.Name,
+			"description":                 value.Description,
+			"comment":                     value.Comments,
+			"action":                      actionFieldValue,
+			"enabled":                     value.Enabled,
+			"ip_protocol":                 value.IpProtocol,
+			"direction":                   value.Direction,
+			"logging":                     value.Logging,
+			"source_ids":                  sourceSet,
+			"destination_ids":             destinationSet,
+			"app_port_profile_ids":        appPortProfileSet,
+			"network_context_profile_ids": netPortProfileSet,
+			"source_groups_excluded":      value.SourceGroupsExcluded,
+			"destination_groups_excluded": value.DestinationGroupsExcluded,
+		}
+	}
+
+	return d.Set("rule", result)
+}
+
+func getDistributedFirewallTypes(vcdClient *VCDClient, d *schema.ResourceData) (*types.DistributedFirewallRules, error) {
+	ruleInterfaceSlice := d.Get("rule").([]interface{})
+	if len(ruleInterfaceSlice) > 0 {
+		sliceOfRules := make([]*types.DistributedFirewallRule, len(ruleInterfaceSlice))
+		for index, oneRule := range ruleInterfaceSlice {
+			oneRuleMapInterface := oneRule.(map[string]interface{})
+
+			sliceOfRules[index] = &types.DistributedFirewallRule{
+				Name:        oneRuleMapInterface["name"].(string),
+				Description: oneRuleMapInterface["description"].(string),
+				ActionValue: oneRuleMapInterface["action"].(string),
+				Enabled:     oneRuleMapInterface["enabled"].(bool),
+				IpProtocol:  oneRuleMapInterface["ip_protocol"].(string),
+				Logging:     oneRuleMapInterface["logging"].(bool),
+				Direction:   oneRuleMapInterface["direction"].(string),
+				Version:     nil,
+			}
+
+			if oneRuleMapInterface["source_ids"] != nil {
+				sourceGroupIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["source_ids"].(*schema.Set))
+				sliceOfRules[index].SourceFirewallGroups = convertSliceOfStringsToOpenApiReferenceIds(sourceGroupIds)
+			}
+
+			if oneRuleMapInterface["destination_ids"] != nil {
+				destinationGroupIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["destination_ids"].(*schema.Set))
+				sliceOfRules[index].DestinationFirewallGroups = convertSliceOfStringsToOpenApiReferenceIds(destinationGroupIds)
+			}
+
+			if oneRuleMapInterface["app_port_profile_ids"] != nil {
+				appPortProfileIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["app_port_profile_ids"].(*schema.Set))
+				sliceOfRules[index].ApplicationPortProfiles = convertSliceOfStringsToOpenApiReferenceIds(appPortProfileIds)
+			}
+
+			if oneRuleMapInterface["network_context_profile_ids"] != nil {
+				networkContextPortProfileIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["network_context_profile_ids"].(*schema.Set))
+				sliceOfRules[index].NetworkContextProfiles = convertSliceOfStringsToOpenApiReferenceIds(networkContextPortProfileIds)
+			}
+
+			// Perform version specific conversion
+			// TODO remove when VCD 10.2 is not supported anymore
+
+			// ActionValue was introduced in API V35.2 (VCD 10.2.2), for 10.2.0 Action field must
+			// still be used
+			if vcdClient.Client.APIVCDMaxVersionIs("< 35.2") {
+				sliceOfRules[index].Action = sliceOfRules[index].ActionValue
+				sliceOfRules[index].ActionValue = ""
+			}
+
+			// Fields requiring 10.3.2+
+			// TODO remove when VCD 10.3 is not supported anymore
+			comment := oneRuleMapInterface["comment"].(string)
+			sourceGroupsExcluded := oneRuleMapInterface["source_groups_excluded"].(bool)
+			destinationGroupsExcluded := oneRuleMapInterface["destination_groups_excluded"].(bool)
+			if vcdClient.Client.APIVCDMaxVersionIs(">= 36.2") {
+				sliceOfRules[index].Comments = comment
+
+				if sourceGroupsExcluded {
+					sliceOfRules[index].SourceGroupsExcluded = &sourceGroupsExcluded
+				}
+
+				if destinationGroupsExcluded {
+					sliceOfRules[index].SourceGroupsExcluded = &destinationGroupsExcluded
+				}
+			} else {
+				if comment != "" {
+					return nil, fmt.Errorf("field 'comment' can only be set in VCD 10.3.2+")
+				}
+
+				// Two below checks will only throw an error if 'true' value has been set. False
+				// will be ignored (when either set, or not set at all), because the only somewhat
+				// reliable way is to use d.GetOkExists which has been deprecated in SDK with no
+				// reliable replacement. There is no real need to use it here so just leaving one
+				// less place to fix in future if d.GetOkExists is removed from SDK.
+				if sourceGroupsExcluded {
+					return nil, fmt.Errorf("field 'source_groups_excluded' can only be enabled in VCD 10.3.2+")
+				}
+
+				if destinationGroupsExcluded {
+					return nil, fmt.Errorf("field 'source_groups_excluded' can only be enabled in VCD 10.3.2+")
+				}
+			}
+
+		}
+
+		return &types.DistributedFirewallRules{Values: sliceOfRules}, nil
+	}
+
+	return nil, nil
 }

--- a/vcd/resource_vcd_nsxt_distributed_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_test.go
@@ -20,7 +20,6 @@ import (
 // * vcd_nsxt_network_context_profile (data source only)
 // * vcd_vdc_group
 // * vcd_nsxt_edgegateway
-//
 func TestAccVcdDistributedFirewall(t *testing.T) {
 	preTestChecks(t)
 	if !usingSysAdmin() {
@@ -365,6 +364,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
 `
 
 const dfwStep3DS = dfwStep2 + `
+# skip-binary-test: Data Source test
 data "vcd_nsxt_distributed_firewall" "t1" {
   org          = "{{.Org}}"
   vdc_group_id = vcd_vdc_group.test1.id
@@ -389,6 +389,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
 `
 
 const dfwStep6DS = dfwStep4 + `
+# skip-binary-test: Data Source test
 data "vcd_nsxt_distributed_firewall" "t1" {
   org          = "{{.Org}}"
   vdc_group_id = vcd_vdc_group.test1.id

--- a/vcd/resource_vcd_nsxt_distributed_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_test.go
@@ -11,15 +11,8 @@ import (
 )
 
 // TestAccVcdDistributedFirewall goal is to try out diverse configuration of rules. This test should
-// support running on all environments. There are a few additional tests which explicitly check new
-// features introduced in newer VCD versions:
-// * vcd_nsxt_distributed_firewall
-// * vcd_nsxt_app_port_profile
-// * vcd_nsxt_ip_set
-// * vcd_nsxt_security_group
-// * vcd_nsxt_network_context_profile (data source only)
-// * vcd_vdc_group
-// * vcd_nsxt_edgegateway
+// support running on all supported versions of VCD. There are a few additional tests which
+// explicitly check new features introduced in newer VCD versions having versions in their names.
 func TestAccVcdDistributedFirewall(t *testing.T) {
 	preTestChecks(t)
 	if !usingSysAdmin() {

--- a/vcd/resource_vcd_nsxt_distributed_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_test.go
@@ -1,0 +1,496 @@
+//go:build gateway || nsxt || ALL || functional || vdcGroup
+// +build gateway nsxt ALL functional vdcGroup
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccVcdDistributedFirewall(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                       testConfig.VCD.Org,
+		"Name":                      t.Name(),
+		"ProviderVdc":               testConfig.VCD.NsxtProviderVdc.Name,
+		"NetworkPool":               testConfig.VCD.NsxtProviderVdc.NetworkPool,
+		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Dfw":                       "true",
+		"DefaultPolicy":             "true",
+		"TestName":                  t.Name(),
+
+		"NsxtEdgeGatewayVcd": t.Name() + "-edge",
+		"ExternalNetwork":    testConfig.Nsxt.ExternalNetwork,
+
+		"Tags": "vdcGroup gateway nsxt",
+	}
+
+	params["FuncName"] = t.Name() + "-newVdc"
+	configTextPre := templateFill(testAccVcdVdcGroupNew, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configTextPre)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2 := templateFill(dfwStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	params["FuncName"] = t.Name() + "-step4"
+	configText4 := templateFill(dfwStep3DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText4)
+
+	params["FuncName"] = t.Name() + "-step5"
+	configText5 := templateFill(dfwStep4, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText5)
+
+	params["FuncName"] = t.Name() + "-step6"
+	configText6 := templateFill(dfwStep6DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 6: %s", configText6)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+
+		Steps: []resource.TestStep{
+			{
+				// Setup prerequisites
+				Config: configTextPre,
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_distributed_firewall.t1", "id"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.#", "5"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.action", "ALLOW"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.ip_protocol", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.name", "rule2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.ip_protocol", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.action", "DROP"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.network_context_profile_ids.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.name", "rule3"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.ip_protocol", "IPV4"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.action", "DROP"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.app_port_profile_ids.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.name", "rule4"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.direction", "OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.ip_protocol", "IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.action", "ALLOW"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.3.network_context_profile_ids.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.name", "rule5"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.direction", "IN"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.ip_protocol", "IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.action", "ALLOW"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.4.network_context_profile_ids.#", "0"),
+					// stateDumper(),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_distributed_firewall.t1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgObject(testConfig, t.Name()),
+			},
+			{
+				Config: configText4,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual("vcd_nsxt_distributed_firewall.t1", "data.vcd_nsxt_distributed_firewall.t1", nil),
+				),
+			},
+			{
+				Config: configText5,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_distributed_firewall.t1", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.action", "DROP"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.ip_protocol", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.#", "3"),
+					resource.TestMatchResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.0", regexp.MustCompile(`^urn:vcloud:networkContextProfile:`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.1", regexp.MustCompile(`^urn:vcloud:networkContextProfile:`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.2", regexp.MustCompile(`^urn:vcloud:networkContextProfile:`)),
+				),
+			},
+			{
+				Config: configText6,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual("vcd_nsxt_distributed_firewall.t1", "data.vcd_nsxt_distributed_firewall.t1", nil),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+func stateDumper() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		spew.Dump(s)
+		return nil
+	}
+}
+
+const dfwStep2 = testAccVcdVdcGroupNew + `
+resource "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+
+  rule {
+	name        = "rule1"
+	action      = "ALLOW"
+	description = "description"
+  }
+
+  rule {
+	name      = "rule2"
+	action    = "DROP"
+	enabled   = false
+	logging   = true
+	direction = "IN_OUT"
+  }
+
+  rule {
+	name        = "rule3"
+	action      = "DROP"
+	ip_protocol = "IPV4"
+  }
+
+  rule {
+	name        = "rule4"
+	action      = "ALLOW"
+	ip_protocol = "IPV6"
+	direction   = "OUT"
+  }
+
+  rule {
+	name        = "rule5"
+	action      = "ALLOW"
+	ip_protocol = "IPV6"
+	direction   = "IN"
+  }
+}
+`
+
+const dfwStep3DS = dfwStep2 + `
+data "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+}
+`
+
+const dfwStep4 = testAccVcdVdcGroupNew + `
+data "vcd_nsxt_network_context_profile" "cp1" {
+  context_id = vcd_vdc_group.test1.id
+  name       = "360ANTIV"
+}
+
+data "vcd_nsxt_network_context_profile" "cp2" {
+  context_id = vcd_vdc_group.test1.id
+  name         = "AMQP"
+  scope        = "SYSTEM"
+}
+
+data "vcd_nsxt_network_context_profile" "cp3" {
+  context_id = vcd_vdc_group.test1.id
+  name         = "AVAST"
+}
+
+resource "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+
+  rule {
+	name   = "rule1"
+	action = "DROP"
+	network_context_profile_ids = [
+		data.vcd_nsxt_network_context_profile.cp1.id,
+		data.vcd_nsxt_network_context_profile.cp2.id,
+		data.vcd_nsxt_network_context_profile.cp3.id
+		]
+  }
+}
+`
+
+const dfwStep6DS = dfwStep4 + `
+data "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+}
+`
+
+// TestAccVcdDistributedFirewallVCD10_2_2 tests out new 10.2.2+ feature:
+// * Firewall rule 'action' REJECT
+func TestAccVcdDistributedFirewallVCD10_2_2(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	vcdClient := createTemporaryVCDConnection(false)
+	if vcdClient.Client.APIVCDMaxVersionIs("< 35.2") {
+		t.Skipf("This test tests VCD 10.2.2+ (API V35.2+) features. Skipping.")
+	}
+
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                       testConfig.VCD.Org,
+		"Name":                      t.Name(),
+		"ProviderVdc":               testConfig.VCD.NsxtProviderVdc.Name,
+		"NetworkPool":               testConfig.VCD.NsxtProviderVdc.NetworkPool,
+		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Dfw":                       "true",
+		"DefaultPolicy":             "true",
+		"TestName":                  t.Name(),
+
+		"NsxtEdgeGatewayVcd": t.Name() + "-edge",
+		"ExternalNetwork":    testConfig.Nsxt.ExternalNetwork,
+
+		"Tags": "vdcGroup gateway nsxt",
+	}
+
+	params["FuncName"] = t.Name() + "-newVdc"
+	configTextPre := templateFill(testAccVcdVdcGroupNew, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configTextPre)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2 := templateFill(dfwStep2VCD10_2_2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+
+		Steps: []resource.TestStep{
+			{
+				// Setup prerequisites
+				Config: configTextPre,
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_distributed_firewall.t1", "id"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.action", "REJECT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.description", "description"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const dfwStep2VCD10_2_2 = testAccVcdVdcGroupNew + `
+resource "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+
+  rule {
+	name        = "rule1"
+	action      = "REJECT"
+	description = "description"
+  }
+}
+`
+
+func TestAccVcdDistributedFirewallVCD10_3_2(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	vcdClient := createTemporaryVCDConnection(false)
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
+	}
+
+	skipNoNsxtConfiguration(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                       testConfig.VCD.Org,
+		"Name":                      t.Name(),
+		"ProviderVdc":               testConfig.VCD.NsxtProviderVdc.Name,
+		"NetworkPool":               testConfig.VCD.NsxtProviderVdc.NetworkPool,
+		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
+		"Dfw":                       "true",
+		"DefaultPolicy":             "true",
+		"TestName":                  t.Name(),
+
+		"NsxtEdgeGatewayVcd": t.Name() + "-edge",
+		"ExternalNetwork":    testConfig.Nsxt.ExternalNetwork,
+
+		"Tags": "vdcGroup gateway nsxt",
+	}
+
+	params["FuncName"] = t.Name() + "-newVdc"
+	configTextPre := templateFill(testAccVcdVdcGroupNew, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configTextPre)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2 := templateFill(dfwStep2VCD10_3_2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+
+		Steps: []resource.TestStep{
+			{
+				// Setup prerequisites
+				Config: configTextPre,
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_distributed_firewall.t1", "id"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.#", "3"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.name", "rule1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.comment", "longer text comment field filled"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.action", "REJECT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.ip_protocol", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.0.network_context_profile_ids.#", "0"),
+					// resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "source_groups_excluded", "true"),
+					// resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "destination_groups_excluded", "true"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.name", "rule2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.ip_protocol", "IPV4_IPV6"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.action", "DROP"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.app_port_profile_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.network_context_profile_ids.#", "1"),
+					resource.TestMatchResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.1.network_context_profile_ids.0", regexp.MustCompile(`^urn:vcloud:networkContextProfile:`)),
+					// resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "source_groups_excluded", "true"),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.name", "rule3"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.direction", "IN_OUT"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.ip_protocol", "IPV4"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.logging", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.action", "DROP"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.source_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.destination_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_distributed_firewall.t1", "rule.2.app_port_profile_ids.#", "0"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const dfwStep2VCD10_3_2 = testAccVcdVdcGroupNew + `
+data "vcd_nsxt_network_context_profile" "cp1" {
+  context_id = vcd_vdc_group.test1.id
+  name       = "360ANTIV"
+}
+
+resource "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "{{.Org}}"
+  vdc_group_id = vcd_vdc_group.test1.id
+
+  rule {
+	name        = "rule1"
+	action      = "REJECT"
+	description = "description"
+	comment     = "longer text comment field filled"
+
+	// source_groups_excluded      = true
+	// destination_groups_excluded = true
+  }
+
+  rule {
+	name      = "rule2"
+	action    = "DROP"
+	enabled   = false
+	logging   = true
+	direction = "IN_OUT"
+	network_context_profile_ids = [data.vcd_nsxt_network_context_profile.cp1.id]
+
+	// source_groups_excluded = true
+  }
+
+  rule {
+	name        = "rule3"
+	action      = "DROP"
+	ip_protocol = "IPV4"
+
+	// destination_groups_excluded = true
+  }
+}
+`

--- a/vcd/resource_vcd_nsxt_firewall.go
+++ b/vcd/resource_vcd_nsxt_firewall.go
@@ -78,8 +78,8 @@ func resourceVcdNsxtFirewall() *schema.Resource {
 						"action": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  "Defines if the rule should 'ALLOW', 'DROP', 'REJECT' matching traffic",
-							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP", "REJECT"}, false),
+							Description:  "Defines if the rule should 'ALLOW' or 'DROP' matching traffic",
+							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP"}, false),
 						},
 						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
@@ -310,8 +310,8 @@ func getNsxtFirewallTypes(d *schema.ResourceData) []*types.NsxtFirewallRule {
 			}
 
 			if oneRuleMapInterface["app_port_profile_ids"] != nil {
-				appPortProfileIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["app_port_profile_ids"].(*schema.Set))
-				result[index].ApplicationPortProfiles = convertSliceOfStringsToOpenApiReferenceIds(appPortProfileIds)
+				sourceGroups := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["app_port_profile_ids"].(*schema.Set))
+				result[index].ApplicationPortProfiles = convertSliceOfStringsToOpenApiReferenceIds(sourceGroups)
 			}
 		}
 		return result

--- a/vcd/resource_vcd_nsxt_firewall.go
+++ b/vcd/resource_vcd_nsxt_firewall.go
@@ -78,8 +78,8 @@ func resourceVcdNsxtFirewall() *schema.Resource {
 						"action": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  "Defines if the rule should 'ALLOW' or 'DROP' matching traffic",
-							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP"}, false),
+							Description:  "Defines if the rule should 'ALLOW', 'DROP', 'REJECT' matching traffic",
+							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP", "REJECT"}, false),
 						},
 						"enabled": &schema.Schema{
 							Type:        schema.TypeBool,
@@ -310,8 +310,8 @@ func getNsxtFirewallTypes(d *schema.ResourceData) []*types.NsxtFirewallRule {
 			}
 
 			if oneRuleMapInterface["app_port_profile_ids"] != nil {
-				sourceGroups := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["app_port_profile_ids"].(*schema.Set))
-				result[index].ApplicationPortProfiles = convertSliceOfStringsToOpenApiReferenceIds(sourceGroups)
+				appPortProfileIds := convertSchemaSetToSliceOfStrings(oneRuleMapInterface["app_port_profile_ids"].(*schema.Set))
+				result[index].ApplicationPortProfiles = convertSliceOfStringsToOpenApiReferenceIds(appPortProfileIds)
 			}
 		}
 		return result

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -62,7 +62,8 @@ resource "vcd_vdc_group" "test1" {
   starting_vdc_id       = vcd_org_vdc.newVdc.0.id
   participating_vdc_ids = vcd_org_vdc.newVdc.*.id
   
-  dfw_enabled = "{{.Dfw}}"
+  dfw_enabled           = "{{.Dfw}}"
+  default_policy_status = {{if .DefaultPolicy }}true{{else}}false{{end}}
 }
 `
 

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -63,7 +63,7 @@ resource "vcd_vdc_group" "test1" {
   participating_vdc_ids = vcd_org_vdc.newVdc.*.id
   
   dfw_enabled           = "{{.Dfw}}"
-  default_policy_status = {{if .DefaultPolicy }}true{{else}}false{{end}}
+  default_policy_status = {{if eq .DefaultPolicy "true" }}true{{else}}false{{end}}
 }
 `
 

--- a/website/docs/d/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/d/nsxt_distributed_firewall.html.markdown
@@ -14,12 +14,12 @@ The Distributed Firewall data source reads all defined rules for a particular VD
 
 ```hcl
 data "vcd_vdc_group" "g1" {
-  org  = "my-org"
+  org  = "my-org" # Optional, can be inherited from Provider configuration
   name = "my-vdc-group"
 }
 
 data "vcd_nsxt_distributed_firewall" "t1" {
-  org          = "my-org"
+  org          = "my-org"  # Optional, can be inherited from Provider configuration
   vdc_group_id = data.vcd_vdc_group.g1.id
 }
 ```
@@ -28,8 +28,8 @@ data "vcd_nsxt_distributed_firewall" "t1" {
 
 The following arguments are supported:
 
-* `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined
-  at provider level.
+* `org` - (Optional) The name of organization in which Distributed Firewall is located. Optional if
+  defined at provider level.
 * `vdc_group_id` - (Required) The ID of a VDC Group
 
 ## Attribute Reference

--- a/website/docs/d/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/d/nsxt_distributed_firewall.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_distributed_firewall"
+sidebar_current: "docs-vcd-data-source-nsxt-distributed-firewall"
+description: |-
+  The distributed firewall data source reads all defined rules for a particular VDC Group.
+---
+
+# vcd\_nsxt\_distributed\_firewall
+
+The distributed firewall data source reads all defined rules for a particular VDC Group.
+
+## Example Usage
+
+```hcl
+data "vcd_vdc_group" "g1" {
+  org  = "my-org"
+  name = "my-vdc-group"
+}
+data "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "my-org"
+  vdc_group_id = data.vcd_vdc_group.g1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined
+  at provider level.
+* `vdc_group_id` - (Required) The ID of a VDC Group
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_distributed_firewall`](/providers/vmware/vcd/latest/docs/resources/nsxt_distributed_firewall)
+resource are available.

--- a/website/docs/d/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/d/nsxt_distributed_firewall.html.markdown
@@ -19,7 +19,7 @@ data "vcd_vdc_group" "g1" {
 }
 
 data "vcd_nsxt_distributed_firewall" "t1" {
-  org          = "my-org"  # Optional, can be inherited from Provider configuration
+  org          = "my-org" # Optional, can be inherited from Provider configuration
   vdc_group_id = data.vcd_vdc_group.g1.id
 }
 ```

--- a/website/docs/d/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/d/nsxt_distributed_firewall.html.markdown
@@ -3,12 +3,12 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_distributed_firewall"
 sidebar_current: "docs-vcd-data-source-nsxt-distributed-firewall"
 description: |-
-  The distributed firewall data source reads all defined rules for a particular VDC Group.
+  The Distributed Firewall data source reads all defined rules for a particular VDC Group.
 ---
 
 # vcd\_nsxt\_distributed\_firewall
 
-The distributed firewall data source reads all defined rules for a particular VDC Group.
+The Distributed Firewall data source reads all defined rules for a particular VDC Group.
 
 ## Example Usage
 
@@ -17,6 +17,7 @@ data "vcd_vdc_group" "g1" {
   org  = "my-org"
   name = "my-vdc-group"
 }
+
 data "vcd_nsxt_distributed_firewall" "t1" {
   org          = "my-org"
   vdc_group_id = data.vcd_vdc_group.g1.id

--- a/website/docs/d/nsxt_network_context_profile.html.markdown
+++ b/website/docs/d/nsxt_network_context_profile.html.markdown
@@ -15,9 +15,8 @@ Firewall.
 ## Example Usage (SYSTEM scope network context profile lookup in a VDC Group)
 
 ```hcl
-
 data "vcd_vdc_group" "existing" {
-  org  = "my-org"
+  org  = "my-org" # Optional, can be inherited from Provider configuration
   name = "main-vdc-group"
 }
 

--- a/website/docs/d/nsxt_network_context_profile.html.markdown
+++ b/website/docs/d/nsxt_network_context_profile.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_network_context_profile"
+sidebar_current: "docs-vcd-data-source-nsxt-network-context-profile"
+description: |-
+  Provider a data source for NSX-T Network Context Profile lookup to later be used in Distributed
+  Firewall.
+---
+
+# vcd\_nsxt\_network\_context\_profile
+
+Provider a data source for NSX-T Network Context Profile lookup to later be used in Distributed
+Firewall.
+
+## Example Usage (SYSTEM scope network context profile lookup in a VDC Group)
+
+```hcl
+
+data "vcd_vdc_group" "existing" {
+  org  = "my-org"
+  name = "main-vdc-group"
+}
+
+data "vcd_nsxt_network_context_profile" "cp1" {
+  context_id = data.vcd_vdc_group.existing.id
+  name       = "CTRXICA"
+  scope      = "SYSTEM"
+}
+```
+
+## Example Usage (SYSTEM profile lookup in an NSX-T Manager)
+```hcl
+data "vcd_nsxt_manager" "main" {
+  name = "first-nsxt-manager"
+}
+
+data "vcd_nsxt_network_context_profile" "p" {
+  context_id = data.vcd_nsxt_manager.main.id
+  name       = "CTRXICA"
+  scope      = "SYSTEM"
+}
+``` 
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `context_id` - (Required) Context ID specifies the context for Network Context Profile look up.
+  This ID can be one of `VDC Group ID` (data source `vcd_vdc_group`), `Org VDC ID` (data source
+  `vcd_org_vdc`), or `NSX-T Manager ID` (data source `vcd_nsxt_manager`)
+* `scope` - (Optional) Can be one of `SYSTEM`, `TENANT`, `PROVIDER`. (default `SYSTEM`)
+* `name` - (Required) Name of Network Context Profile
+
+## Attribute Reference
+
+`id` - can be used in `vcd_nsxt_distributed_firewall` resource field `network_context_profile_ids`

--- a/website/docs/d/nsxt_network_context_profile.html.markdown
+++ b/website/docs/d/nsxt_network_context_profile.html.markdown
@@ -3,13 +3,13 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_network_context_profile"
 sidebar_current: "docs-vcd-data-source-nsxt-network-context-profile"
 description: |-
-  Provider a data source for NSX-T Network Context Profile lookup to later be used in Distributed
+  Provides a data source for NSX-T Network Context Profile lookup to later be used in Distributed
   Firewall.
 ---
 
 # vcd\_nsxt\_network\_context\_profile
 
-Provider a data source for NSX-T Network Context Profile lookup to later be used in Distributed
+Provides a data source for NSX-T Network Context Profile lookup to later be used in Distributed
 Firewall.
 
 ## Example Usage (SYSTEM scope network context profile lookup in a VDC Group)

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -15,6 +15,10 @@ virtual machines, based on virtual machine names and attributes.
 ## Example Usage
 
 ```hcl
+data "vcd_vdc_group" "existing" {
+  org  = "my-org" # Optional, can be inherited from Provider configuration
+  name = "main-vdc-group"
+}
 
 data "vcd_nsxt_network_context_profile" "cp1" {
   context_id = vcd_vdc_group.test1.id
@@ -23,8 +27,8 @@ data "vcd_nsxt_network_context_profile" "cp1" {
 }
 
 resource "vcd_nsxt_distributed_firewall" "t1" {
-  org          = "datacloud"
-  vdc_group_id = vcd_vdc_group.test1.id
+  org          = "my-org" # Optional, can be inherited from Provider configuration
+  vdc_group_id = vcd_vdc_group.existing.id
 
   rule {
     name        = "rule1"
@@ -83,12 +87,13 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `vdc_group_id` - (Required) The ID of VDC Group to manage Distributed Firewall in. Can be looked
   up using `vcd_vdc_group` resource or data source.
-* `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
+* `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions. **Order**
+  defines firewall rule precedence
 
 <a id="firewall-rule"></a>
 ## Firwall Rule
 
-Each Firewall Rule contains following attributes:
+Each Firewall Rule contains following attributes (**order defines rule precedence**):
 
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
 * `comment` - (Optional; *VCD 10.3.2+*)) Comment field shown in UI
@@ -122,8 +127,8 @@ the full dot separated path for your VDC Group Name. An example is below:
 [docs-import]: https://www.terraform.io/docs/import/
 
 ```
-terraform import vcd_nsxt_distributed_firewall.imported my-org.my-vdc-group
+terraform import vcd_nsxt_distributed_firewall.imported my-org-name.my-vdc-group-name
 ```
 
-The above would import all firewall rules defined on VDC Group `my-vdc-group` which is configured in
-organization named `my-org`.
+The above would import all firewall rules defined on VDC Group `my-vdc-group-name` which is
+configured in organization named `my-org-name`.

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -3,13 +3,13 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_distributed_firewall"
 sidebar_current: "docs-vcd-resource-nsxt-distributed-firewall"
 description: |-
-  The distributed firewall allows you to segment organization virtual data center entities, such as
+  The Distributed Firewall allows user to segment organization virtual data center entities, such as
   virtual machines, based on virtual machine names and attributes. 
 ---
 
 # vcd\_nsxt\_distributed\_firewall
 
-The distributed firewall allows you to segment organization virtual data center entities, such as
+The Distributed Firewall allows user to segment organization virtual data center entities, such as
 virtual machines, based on virtual machine names and attributes. 
 
 ## Example Usage
@@ -58,8 +58,8 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
     direction   = "OUT"
 
     # Below two fields are supported in VCD 10.3.2+
-    source_groups_excluded      =
-    destination_groups_excluded =
+    source_groups_excluded      = false
+    destination_groups_excluded = false
   }
 
   rule {

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -91,12 +91,12 @@ The following arguments are supported:
   defines firewall rule precedence
 
 <a id="firewall-rule"></a>
-## Firwall Rule
+## Firewall Rule
 
 Each Firewall Rule contains following attributes (**order defines rule precedence**):
 
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
-* `comment` - (Optional; *VCD 10.3.2+*)) Comment field shown in UI
+* `comment` - (Optional; *VCD 10.3.2+*) Comment field shown in UI
 * `description` - (Optional) Description of firewall rule (not shown in UI)
 * `direction` - (Optional) One of `IN`, `OUT`, or `IN_OUT`. (default `IN_OUT`)
 * `ip_protocol` - (Optional) One of `IPV4`,  `IPV6`, or `IPV4_IPV6` (default `IPV4_IPV6`)

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -32,6 +32,10 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
     description = "description"
     # 'comment' field is only supported in VCD 10.3.2+
     comment = "My first rule to allow everything"
+
+    source_ids             = [data.vcd_nsxt_ip_set.set1.id, data.vcd_nsxt_ip_set.set2.id]
+    source_groups_excluded = true # Negates value of 'source_id' (VCD 10.3.2+)
+    app_port_profile_ids   = [data.vcd_nsxt_app_port_profile.WINS.id, data.vcd_nsxt_app_port_profile.FTP.id]
   }
 
   rule {
@@ -46,7 +50,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
 
   rule {
     name = "rule3"
-    # 'REJECT' is only supported in VCD 10.3.2+
+    # 'REJECT' is only supported in VCD 10.2.2+
     action      = "REJECT"
     ip_protocol = "IPV4"
   }
@@ -87,22 +91,21 @@ The following arguments are supported:
 Each Firewall Rule contains following attributes:
 
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
-* `description` - (Optional) Explanatory name for firewall rule (uniqueness not enforced)
-* `comment` - (Optional; VCD 10.3.2+)) Comment field
+* `comment` - (Optional; *VCD 10.3.2+*)) Comment field shown in UI
+* `description` - (Optional) Description of firewall rule (not shown in UI)
 * `direction` - (Optional) One of `IN`, `OUT`, or `IN_OUT`. (default `IN_OUT`)
 * `ip_protocol` - (Optional) One of `IPV4`,  `IPV6`, or `IPV4_IPV6` (default `IPV4_IPV6`)
 * `action` - (Required) Defines if it should `ALLOW`, `DROP`, `REJECT` traffic. `REJECT` is only
-  supported in VCD 10.3.2+
+  supported in VCD 10.2.2+
 * `enabled` - (Optional) Defines if the rule is enabled (default `true`)
 * `logging` - (Optional) Defines if logging for this rule is enabled (default `false`)
 * `source_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security groups`).
 Leaving it empty matches `Any` (all)
 * `destination_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security
 groups`). Leaving it empty matches `Any` (all)
-* `app_port_profile_ids` - (Optional) A set of Application Port Profiles. Leaving it empty matches
-  `Any` (all)
-* `network_context_profile_ids` - (Optional) A set of Network Context Profiles. Leaving it empty
-  matches none. Can be looked up using `vcd_nsxt_network_context_profile` data source.
+* `app_port_profile_ids` - (Optional) An optional set of Application Port Profiles.
+* `network_context_profile_ids` - (Optional) An optional set of Network Context Profiles. Can be
+  looked up using `vcd_nsxt_network_context_profile` data source.
 * `source_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `source_ids` for the rule to
   match everything except specified IDs.
 * `destination_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `destination_ids` for
@@ -113,8 +116,8 @@ groups`). Leaving it empty matches `Any` (all)
 ~> The current implementation of Terraform import can only import resources into the state.
 It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
 
-Existing Firewall Rules can be [imported][docs-import] into this resource via supplying the full dot
-separated path for your VDC Group Name. An example is below:
+Existing Distributed Firewall Rules can be [imported][docs-import] into this resource via supplying
+the full dot separated path for your VDC Group Name. An example is below:
 
 [docs-import]: https://www.terraform.io/docs/import/
 

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -93,7 +93,9 @@ The following arguments are supported:
 <a id="firewall-rule"></a>
 ## Firewall Rule
 
-Each Firewall Rule contains following attributes (**order defines rule precedence**):
+-> Order of `rule` blocks defines order of firewall rules in the system.
+
+Each Firewall Rule contains following attributes:
 
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
 * `comment` - (Optional; *VCD 10.3.2+*) Comment field shown in UI

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -1,0 +1,126 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_distributed_firewall"
+sidebar_current: "docs-vcd-resource-nsxt-distributed-firewall"
+description: |-
+  The distributed firewall allows you to segment organization virtual data center entities, such as
+  virtual machines, based on virtual machine names and attributes. 
+---
+
+# vcd\_nsxt\_distributed\_firewall
+
+The distributed firewall allows you to segment organization virtual data center entities, such as
+virtual machines, based on virtual machine names and attributes. 
+
+## Example Usage
+
+```hcl
+
+data "vcd_nsxt_network_context_profile" "cp1" {
+  context_id = vcd_vdc_group.test1.id
+  name       = "CTRXICA"
+  scope      = "SYSTEM"
+}
+
+resource "vcd_nsxt_distributed_firewall" "t1" {
+  org          = "datacloud"
+  vdc_group_id = vcd_vdc_group.test1.id
+
+  rule {
+    name        = "rule1"
+    action      = "ALLOW"
+    description = "description"
+    # 'comment' field is only supported in VCD 10.3.2+
+    comment     = "My first rule to allow everything"
+  }
+
+  rule {
+    name      = "rule2"
+    action    = "DROP"
+    enabled   = false
+    logging   = true
+    direction = "IN_OUT"
+
+    network_context_profile_ids = [vcd_nsxt_network_context_profile.cp1.id]
+  }
+
+  rule {
+    name        = "rule3"
+    # 'REJECT' is only supported in VCD 10.3.2+
+    action      = "REJECT"
+    ip_protocol = "IPV4"
+  }
+
+  rule {
+    name        = "rule4"
+    action      = "ALLOW"
+    ip_protocol = "IPV6"
+    direction   = "OUT"
+
+    # Below two fields are supported in VCD 10.3.2+
+    source_groups_excluded      =
+    destination_groups_excluded =
+  }
+
+  rule {
+    name        = "rule5"
+    action      = "ALLOW"
+    ip_protocol = "IPV6"
+    direction   = "IN"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc_group_id` - (Required) The ID of VDC Group to manage Distributed Firewall in. Can be looked
+  up using `vcd_vdc_group` resource or data source.
+* `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
+
+<a id="firewall-rule"></a>
+## Firwall Rule
+
+Each Firewall Rule contains following attributes:
+
+* `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
+* `description` - (Optional) Explanatory name for firewall rule (uniqueness not enforced)
+* `comment` - (Optional; VCD 10.3.2+)) Comment field
+* `direction` - (Optional) One of `IN`, `OUT`, or `IN_OUT`. (default `IN_OUT`)
+* `ip_protocol` - (Optional) One of `IPV4`,  `IPV6`, or `IPV4_IPV6` (default `IPV4_IPV6`)
+* `action` - (Required) Defines if it should `ALLOW`, `DROP`, `REJECT` traffic. `REJECT` is only
+  supported in VCD 10.3.2+
+* `enabled` - (Optional) Defines if the rule is enabled (default `true`)
+* `logging` - (Optional) Defines if logging for this rule is enabled (default `false`)
+* `source_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security groups`).
+Leaving it empty matches `Any` (all)
+* `destination_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security
+groups`). Leaving it empty matches `Any` (all)
+* `app_port_profile_ids` - (Optional) A set of Application Port Profiles. Leaving it empty matches
+  `Any` (all)
+* `network_context_profile_ids` - (Optional) A set of Network Context Profiles. Leaving it empty
+  matches none. Can be looked up using `vcd_nsxt_network_context_profile` data source.
+* `source_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `source_ids` for the rule to
+  match everything except specified IDs.
+* `destination_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `destination_ids` for
+  the rule to match everything except specified IDs.
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+Existing Firewall Rules can be [imported][docs-import] into this resource via supplying the full dot
+separated path for your VDC Group Name. An example is below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_distributed_firewall.imported my-org.my-vdc-group
+```
+
+The above would import all firewall rules defined on VDC Group `my-vdc-group` which is configured in
+organization named `my-org`.

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -31,7 +31,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
     action      = "ALLOW"
     description = "description"
     # 'comment' field is only supported in VCD 10.3.2+
-    comment     = "My first rule to allow everything"
+    comment = "My first rule to allow everything"
   }
 
   rule {
@@ -45,7 +45,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
   }
 
   rule {
-    name        = "rule3"
+    name = "rule3"
     # 'REJECT' is only supported in VCD 10.3.2+
     action      = "REJECT"
     ip_protocol = "IPV4"

--- a/website/docs/r/nsxt_firewall.html.markdown
+++ b/website/docs/r/nsxt_firewall.html.markdown
@@ -92,7 +92,7 @@ Each Firewall Rule contains following attributes:
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
 * `direction` - (Required) One of `IN`, `OUT`, or `IN_OUT`
 * `ip_protocol` - (Required) One of `IPV4`,  `IPV6`, or `IPV4_IPV6`
-* `action` - (Required) Defines if it should `ALLOW`, `DROP`, `REJECT` traffic
+* `action` - (Required) Defines if it should `ALLOW` or `DROP` traffic
 * `enabled` - (Optional) Defines if the rule is enabled (default `true`)
 * `logging` - (Optional) Defines if logging for this rule is enabled (default `false`)
 * `source_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security groups`). 

--- a/website/docs/r/nsxt_firewall.html.markdown
+++ b/website/docs/r/nsxt_firewall.html.markdown
@@ -92,7 +92,7 @@ Each Firewall Rule contains following attributes:
 * `name` - (Required) Explanatory name for firewall rule (uniqueness not enforced)
 * `direction` - (Required) One of `IN`, `OUT`, or `IN_OUT`
 * `ip_protocol` - (Required) One of `IPV4`,  `IPV6`, or `IPV4_IPV6`
-* `action` - (Required) Defines if it should `ALLOW` or `DROP` traffic
+* `action` - (Required) Defines if it should `ALLOW`, `DROP`, `REJECT` traffic
 * `enabled` - (Optional) Defines if the rule is enabled (default `true`)
 * `logging` - (Optional) Defines if logging for this rule is enabled (default `false`)
 * `source_ids` - (Optional) A set of source object Firewall Groups (`IP Sets` or `Security groups`). 

--- a/website/docs/r/nsxt_firewall.html.markdown
+++ b/website/docs/r/nsxt_firewall.html.markdown
@@ -85,7 +85,7 @@ The following arguments are supported:
 * `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
 
 <a id="firewall-rule"></a>
-## Firwall Rule
+## Firewall Rule
 
 Each Firewall Rule contains following attributes:
 

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -229,6 +229,12 @@
             <li<%= sidebar_current("docs-vcd-data-source-vdc-group") %>>
               <a href="/docs/providers/vcd/d/vdc_group.html">vcd_vdc_group</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-nsxt-distributed-firewall") %>>
+              <a href="/docs/providers/vcd/d/nsxt_distributed_firewall.html">vcd_nsxt_distributed_firewall</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-data-source-nsxt-network-context-profile") %>>
+              <a href="/docs/providers/vcd/d/nsxt_network_context_profile.html">vcd_nsxt_network_context_profile</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -419,6 +425,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-vdc-group") %>>
               <a href="/docs/providers/vcd/r/vdc_group.html">vcd_vdc_group</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-distributed-firewall") %>>
+              <a href="/docs/providers/vcd/r/nsxt_distributed_firewall.html">vcd_nsxt_distributed_firewall</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This code adds support for Distributed Firewall in VDC Groups by adding:
* **New Resource:** `vcd_nsxt_distributed_firewall` allows to manage Distributed Firewall Rules in VDC Groups
* **New Data Source:** `vcd_nsxt_distributed_firewall` allows to lookup firewall rules in VDC Groups
* **New Data Source:** `vcd_nsxt_network_context_profile` allows to lookup ID for usage in `vcd_nsxt_distributed_firewall` (I could not find a relevant doc in VCD documentation, but here is [one from NSX-T ](https://docs.vmware.com/en/VMware-NSX-T-Data-Center/3.2/administration/GUID-5A73D94A-1B37-4D3C-9E09-E6936F39AEE3.html). Network Context Profile is DPI (Deep Packet Inspection) definition.


Additionally it fixes incorect version check for independent disk check `TestAccVcdIndependentDiskBasic`

Ref #659
Closes #808, #144
