### PR TITLE
Add metadata support for storage profile datasource

### DIFF
--- a/.changes/v3.6.0/811-improvements.md
+++ b/.changes/v3.6.0/811-improvements.md
@@ -1,0 +1,1 @@
+* Data source `vcd_storage_profile` supports `metadata` so this field can be populated when reading VDC storage profiles. [GH-811]

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220330125812-56960032ba02

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220330125812-56960032ba02 h1:KpbYtwJP9wrrwqRC8skB3DGGq5eKGWVi2w9xg1ByLR8=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220330125812-56960032ba02/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9 h1:4bmhpu6116aDka6yqHC4Qw2LJXf4SC4hm9jgrARZ4Ws=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_storage_profile.go
+++ b/vcd/datasource_vcd_storage_profile.go
@@ -27,68 +27,73 @@ func datasourceVcdStorageProfile() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of storage profile",
 			},
-			"limit": &schema.Schema{
+			"limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum number of storage bytes (scaled by 'units' field) allocated for this profile. `0` means `maximum possible`",
 			},
-			"used_storage": &schema.Schema{
+			"used_storage": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Storage used, in Megabytes, by the storage profile",
 			},
-			"default": &schema.Schema{
+			"default": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this is default storage profile for this VDC. The default storage profile is used when an object that can specify a storage profile is created with no storage profile specified",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this storage profile is enabled for use in the VDC",
 			},
-			"iops_allocated": &schema.Schema{
+			"iops_allocated": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Total IOPS currently allocated to this storage profile",
 			},
-			"units": &schema.Schema{
+			"units": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Scale used to define Limit",
 			},
-			"iops_settings": &schema.Schema{
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Key value map of metadata retrieved from this storage profile. Key and value can be any string.",
+			},
+			"iops_settings": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "IOPs related settings",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"iops_limiting_enabled": &schema.Schema{
+						"iops_limiting_enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "True if this storage profile is IOPS-based placement enabled",
 						},
-						"maximum_disk_iops": &schema.Schema{
+						"maximum_disk_iops": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "The maximum IOPS value that this storage profile is permitted to deliver. Value of 0 means this max setting is disabled and there is no max disk IOPS restriction",
 						},
-						"default_disk_iops": &schema.Schema{
+						"default_disk_iops": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Value of 0 for disk IOPS means that no IOPS would be reserved or provisioned for that virtual disk",
 						},
-						"disk_iops_per_gb_max": &schema.Schema{
+						"disk_iops_per_gb_max": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "The maximum disk IOPs per GB value that this storage profile is permitted to deliver. A value of 0 means there is no per GB IOPS restriction",
 						},
-						"iops_limit": &schema.Schema{
+						"iops_limit": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Maximum number of IOPs that can be allocated for this profile. `0` means `maximum possible`",
@@ -100,7 +105,7 @@ func datasourceVcdStorageProfile() *schema.Resource {
 	}
 }
 
-func datasourceVcdStorageProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceVcdStorageProfileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
@@ -142,6 +147,15 @@ func datasourceVcdStorageProfileRead(ctx context.Context, d *schema.ResourceData
 		if err != nil {
 			return diag.FromErr(err)
 		}
+	}
+
+	metadata, err := vcdClient.GetMetadataByHref(storageProfileReference.HREF)
+	if err != nil {
+		return diag.Errorf("Unable to find metadata for storage profile: %s", err)
+	}
+	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -5,10 +5,9 @@ package vcd
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"testing"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 
@@ -57,7 +56,7 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.default_disk_iops", regexp.MustCompile(`\d*`)),
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.disk_iops_per_gb_max", regexp.MustCompile(`\d*`)),
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.iops_limit", regexp.MustCompile(`\d*`)),
-					resource.TestCheckResourceAttr("data.vcd_storage_profile.sp", "metadata.#", "0"),
+					resource.TestCheckResourceAttr("data.vcd_storage_profile.sp", "metadata.%", "0"),
 					checkStorageProfileOriginatesInParentVdc("data.vcd_storage_profile.sp",
 						params["StorageProfileName"].(string),
 						params["Org"].(string),

--- a/vcd/datasource_vcd_storage_profile_test.go
+++ b/vcd/datasource_vcd_storage_profile_test.go
@@ -39,7 +39,7 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 		PreCheck:          func() { preRunChecks(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					// Ensure that ID matches storage profile URN format (e.g. urn:vcloud:vdcstorageProfile:db4aaa49-7593-4416-93df-37235a1a2c68)
@@ -57,6 +57,7 @@ func TestAccVcdStorageProfileDS(t *testing.T) {
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.default_disk_iops", regexp.MustCompile(`\d*`)),
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.disk_iops_per_gb_max", regexp.MustCompile(`\d*`)),
 					resource.TestMatchResourceAttr("data.vcd_storage_profile.sp", "iops_settings.iops_limit", regexp.MustCompile(`\d*`)),
+					resource.TestCheckResourceAttr("data.vcd_storage_profile.sp", "metadata.#", "0"),
 					checkStorageProfileOriginatesInParentVdc("data.vcd_storage_profile.sp",
 						params["StorageProfileName"].(string),
 						params["Org"].(string),


### PR DESCRIPTION
Created by #372

:warn: Depends on https://github.com/vmware/go-vcloud-director/pull/454

This PR adds metadata support (read) for the storage profile datasource. This was tested manually, as there is no `vcd_storage_profile` resource to manipulate metadata. The manual test is as follows:

- Go to the target VDC as System administrator, Provider view.
- Select a target storage profile
- Click on "Metadata" and add some string value.
- Execute a Terraform apply with the datasource. Metadata should have been retrieved.