### PR TITLE
Bump staticheck to latest for go1.18 support  and fix new errors

### DIFF
--- a/.changes/v3.6.0/813-notes.md
+++ b/.changes/v3.6.0/813-notes.md
@@ -1,0 +1,1 @@
+* Bump `staticheck` tool to `2022.1` to support Go 1.18 and fix newly detected errors [GH-813]

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,4 +1,4 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=2020.2.1
+export STATICCHECK_VERSION=2022.1
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
 

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1505,13 +1505,13 @@ func preTestChecks(t *testing.T) {
 	}
 	if fileExists(vcdSkipAllFile) {
 		vcdSkipCount += 1
-		t.Skip(fmt.Sprintf("File '%s' found at %s. Test %s skipped", vcdSkipAllFile, timeStamp(), t.Name()))
+		t.Skipf("File '%s' found at %s. Test %s skipped", vcdSkipAllFile, timeStamp(), t.Name())
 	}
 	if vcdSkipPattern != "" {
 		re := regexp.MustCompile(vcdSkipPattern)
 		if re.MatchString(t.Name()) {
 			vcdSkipCount += 1
-			t.Skip(fmt.Sprintf("Skip pattern '%s' matches test name '%s'", vcdSkipPattern, t.Name()))
+			t.Skipf("Skip pattern '%s' matches test name '%s'", vcdSkipPattern, t.Name())
 		}
 	}
 	skipEnvVar := fmt.Sprintf("skip-%s", t.Name())
@@ -1521,12 +1521,12 @@ func preTestChecks(t *testing.T) {
 	}
 	if os.Getenv(skipEnvVar) != "" {
 		vcdSkipCount += 1
-		t.Skip(fmt.Sprintf("variable '%s' was set.", skipEnvVar))
+		t.Skipf("variable '%s' was set.", skipEnvVar)
 	}
 	// If this test has run already, we skip it
 	if isTestInFile(t.Name(), "pass") {
 		vcdSkipCount += 1
-		t.Skip(fmt.Sprintf("test '%s' found in '%s' ", t.Name(), getTestListFile("pass")))
+		t.Skipf("test '%s' found in '%s' ", t.Name(), getTestListFile("pass"))
 	}
 	if vcdReRunFailed {
 		if !isTestInFile(t.Name(), "fail") {

--- a/vcd/datasource_filter_test.go
+++ b/vcd/datasource_filter_test.go
@@ -328,7 +328,7 @@ func runSearchTest(entityType, label string, t *testing.T) {
 	}
 	filters, err := getFiltersForAvailableEntities(entityType, generateData)
 	if err != nil {
-		t.Skip(fmt.Sprintf("error getting available %s : %s", label, err))
+		t.Skipf("error getting available %s : %s", label, err)
 		return
 	}
 

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -4,7 +4,6 @@
 package vcd
 
 import (
-	"fmt"
 	"regexp"
 	"testing"
 
@@ -27,19 +26,19 @@ func TestAccVcdVdcDatasource(t *testing.T) {
 
 	vcdClient, err := getTestVCDFromJson(testConfig)
 	if err != nil {
-		t.Skip(fmt.Sprintf("unable to get vcdClient: %s", err))
+		t.Skipf("unable to get vcdClient: %s", err)
 	}
 	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg, testConfig.Provider.ApiToken)
 	if err != nil {
-		t.Skip(fmt.Sprintf("authentication error: %s", err))
+		t.Skipf("authentication error: %s", err)
 	}
 	org, err := vcdClient.GetAdminOrgByName(testConfig.VCD.Org)
 	if err != nil {
-		t.Skip(fmt.Sprintf("unable to get Org: %s, err: %s", testConfig.VCD.Org, err))
+		t.Skipf("unable to get Org: %s, err: %s", testConfig.VCD.Org, err)
 	}
 	vdc, err := org.GetVDCByName(testConfig.VCD.Vdc, false)
 	if err != nil {
-		t.Skip(fmt.Sprintf("unable to get VDC: %s, err: %s", testConfig.VCD.Vdc, err))
+		t.Skipf("unable to get VDC: %s, err: %s", testConfig.VCD.Vdc, err)
 	}
 
 	var configText string

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -111,7 +111,7 @@ func runResourceInfoTest(def listDef, t *testing.T) {
 	if !usingSysAdmin() && (def.resourceType == "vcd_external_network" ||
 		def.resourceType == "vcd_global_role" ||
 		def.resourceType == "vcd_rights_bundle") {
-		t.Skip(fmt.Sprintf("test with %s requires system administrator privileges", def.resourceType))
+		t.Skipf("test with %s requires system administrator privileges", def.resourceType)
 	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 

--- a/vcd/resource_vcd_org_user_test.go
+++ b/vcd/resource_vcd_org_user_test.go
@@ -41,16 +41,16 @@ func prepareUserData(t *testing.T) []userTestData {
 		password := []byte(orgUserPasswordText)
 		file, err := os.Create(orgUserPasswordFile)
 		if err != nil {
-			t.Skip(fmt.Sprintf("error creating file %s: %s", orgUserPasswordFile, err))
+			t.Skipf("error creating file %s: %s", orgUserPasswordFile, err)
 		}
 		writer := bufio.NewWriter(file)
 		count, err := writer.Write(password)
 		if err != nil || count == 0 {
-			t.Skip(fmt.Sprintf("error writing to file %s (written bytes %d): %s", orgUserPasswordFile, count, err))
+			t.Skipf("error writing to file %s (written bytes %d): %s", orgUserPasswordFile, count, err)
 		}
 		err = writer.Flush()
 		if err != nil {
-			t.Skip(fmt.Sprintf("error flushing file %s: %s", orgUserPasswordFile, err))
+			t.Skipf("error flushing file %s: %s", orgUserPasswordFile, err)
 		}
 		_ = file.Close()
 	}

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -70,7 +70,7 @@ func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 
 	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg, testConfig.Provider.ApiToken)
 	if err != nil {
-		t.Skip(fmt.Sprintf("authentication error: %s", err))
+		t.Skipf("authentication error: %s", err)
 	}
 	if !vcdClient.Client.IsSysAdmin {
 		t.Skip("Test can only run as System admin")

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -67,7 +67,7 @@ func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
 
 	err = ProviderAuthenticate(vcdClient, testConfig.Provider.User, testConfig.Provider.Password, testConfig.Provider.Token, testConfig.Provider.SysOrg, testConfig.Provider.ApiToken)
 	if err != nil {
-		t.Skip(fmt.Sprintf("authentication error: %s", err))
+		t.Skipf("authentication error: %s", err)
 	}
 	if !vcdClient.Client.IsSysAdmin {
 		t.Skip("Test can only run as System admin")


### PR DESCRIPTION
Go 1.18 appeared today in GitHub actions and our `make static` command started failing.
This PR bumps `staticcheck` version to the latest (with go 1.18 support) and fixes its newly found errors. Until we have this PR in master - our `make static` command (run as a Github action) will always fail.

Errors fixed are very trivial `t.Skip(fmt.Sprintf` -> `t.Skipf(` therefore compilation success is enough to validate this didn't break anything.

**Note.** No changelog as we usually don't put anything when it is not relevant for users (happy to change if any reviewer requires it)

Sample error:
```sh
## Found /home/runner/work/terraform-provider-vcd/terraform-provider-vcd/vcd/staticcheck/staticcheck
## staticcheck 2020.2.1 (v0.1.1)
## Checking /home/runner/work/terraform-provider-vcd/terraform-provider-vcd/vcd
-: cannot import "internal/cpu" (unknown iexport format version 2), export data is newer version - update tool (compile)
-: cannot import "internal/goarch" (unknown iexport format version 2), export data is newer version - update tool (compile)
-: cannot import "math/bits" (unknown iexport format version 2), export data is newer version - update tool (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:27:8: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:103:30: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:134:35: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:144:28: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:150:27: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:158:31: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/container/list/list.go:169:30: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/internal/nettrace/nettrace.go:33:24: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:17:4: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:28:29: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:47:27: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:90:26: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:90:36: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:135:41: undeclared name: any (compile)
Error: /opt/hostedtoolcache/go/1.18.0/x64/src/sync/atomic/value.go:182:9: undeclared name: any (compile)
make: *** [GNUmakefile:66: static] Error 1
Error: Process completed with exit code 2.
```