### PR TITLE
Add NSX-T VDC Group support for vcd_nsxt_security_group

### DIFF
--- a/.changes/v3.6.0/814-improvements.md
+++ b/.changes/v3.6.0/814-improvements.md
@@ -1,0 +1,2 @@
+* `resource/vcd_nsxt_security_group` and `datasource/vcd_nsxt_security_group` support VDC Groups by inheriting parent VDC
+or VDC Group from Edge Gateway  [GH-814]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.10
+	github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.1
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.10
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34

--- a/go.sum
+++ b/go.sum
@@ -314,13 +314,13 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34 h1:ntQz+xWvXt5EZ0hMZdWqFGAVlMV0208+hNuU3A76TVw=
-github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.1 h1:iCHO1KZU7ISvFOsZv2BuJXOgalMJK4OWils3fPQEtVQ=
+github.com/vmware/go-vcloud-director/v2 v2.15.0-beta.1/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -314,13 +314,13 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34 h1:ntQz+xWvXt5EZ0hMZdWqFGAVlMV0208+hNuU3A76TVw=
+github.com/vbauzysvmware/go-vcloud-director/v2 v2.0.0-20220401150125-848b4812cb34/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.10 h1:TDBuCXPZ4VvQUi0tCj0nC5AKgFelwyOZbsqTYdDHyTk=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.10/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_nsxt_security_group.go
+++ b/vcd/datasource_vcd_nsxt_security_group.go
@@ -75,13 +75,13 @@ func datasourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("[nsxt security group read] error retrieving Org: %s", err)
 	}
 
-	ipSetName := d.Get("name").(string)
+	securityGroupName := d.Get("name").(string)
 	edgeGatewayId := d.Get("edge_gateway_id").(string)
 
 	var securityGroup *govcd.NsxtFirewallGroup
 	var parentVdcOrVdcGroupId string
 
-	if ipSetName == "" || edgeGatewayId == "" {
+	if securityGroupName == "" || edgeGatewayId == "" {
 		return diag.Errorf("error - not all parameters specified for NSX-T Security Group lookup")
 	}
 	// Lookup Edge Gateway to know parent VDC or VDC Group
@@ -90,7 +90,7 @@ func datasourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("[nsxt security group read] error retrieving Edge Gateway structure: %s", err)
 	}
 	if anyEdgeGateway.IsNsxv() {
-		return diag.Errorf("[nsxt security group read] NSX-V edge gateway not supported")
+		return diag.Errorf("[nsxt security group read] NSX-V Edge Gateway not supported")
 	}
 
 	parentVdcOrVdcGroupId = anyEdgeGateway.EdgeGateway.OwnerRef.ID
@@ -101,7 +101,7 @@ func datasourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData,
 			return diag.Errorf("could not retrieve VDC Group with ID '%s': %s", d.Id(), err)
 		}
 
-		// Name uniqueness is enforced by VCD for types.FirewallGroupTypeIpSet
+		// Name uniqueness is enforced by VCD for types.FirewallGroupTypeSecurityGroup
 		securityGroup, err = vdcGroup.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeSecurityGroup)
 		if err != nil {
 			return diag.Errorf("[nsxt security group read] error getting NSX-T Security Group with Name '%s': %s", d.Get("name").(string), err)

--- a/vcd/datasource_vcd_nsxt_security_group.go
+++ b/vcd/datasource_vcd_nsxt_security_group.go
@@ -26,7 +26,7 @@ func datasourceVcdNsxtSecurityGroup() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
-				Deprecated:  "Deprecated in favor of `edge_gateway_id`. IP Set will inherit VDC from parent Edge Gateway.",
+				Deprecated:  "Deprecated in favor of `edge_gateway_id`. Security Group will inherit VDC from parent Edge Gateway.",
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/vcd/datasource_vcd_nsxt_security_group.go
+++ b/vcd/datasource_vcd_nsxt_security_group.go
@@ -24,7 +24,6 @@ func datasourceVcdNsxtSecurityGroup() *schema.Resource {
 			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 				Deprecated:  "Deprecated in favor of `edge_gateway_id`. Security Group will inherit VDC from parent Edge Gateway.",
 			},
@@ -36,7 +35,6 @@ func datasourceVcdNsxtSecurityGroup() *schema.Resource {
 			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 				Description: "Edge Gateway ID in which security group is located",
 			},
 			"owner_id": {

--- a/vcd/datasource_vcd_nsxt_security_group.go
+++ b/vcd/datasource_vcd_nsxt_security_group.go
@@ -2,6 +2,7 @@ package vcd
 
 import (
 	"context"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -25,19 +26,25 @@ func datasourceVcdNsxtSecurityGroup() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
+				Deprecated:  "Deprecated in favor of `edge_gateway_id`. IP Set will inherit VDC from parent Edge Gateway.",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Security Group name",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge Gateway ID in which security group is located",
 			},
-			"description": &schema.Schema{
+			"owner_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of VDC or VDC Group",
+			},
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Security Group description",
@@ -63,34 +70,72 @@ func datasourceVcdNsxtSecurityGroup() *schema.Resource {
 func datasourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	nsxtEdgeGateway, err := vcdClient.GetNsxtEdgeGatewayFromResourceById(d, "edge_gateway_id")
+	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf(errorUnableToFindEdgeGateway, err)
+		return diag.Errorf("[nsxt security group read] error retrieving Org: %s", err)
 	}
 
-	// Name uniqueness is enforce by VCD for types.FirewallGroupTypeSecurityGroup
-	secGroup, err := nsxtEdgeGateway.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeSecurityGroup)
+	ipSetName := d.Get("name").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	var securityGroup *govcd.NsxtFirewallGroup
+	var parentVdcOrVdcGroupId string
+
+	if ipSetName == "" || edgeGatewayId == "" {
+		return diag.Errorf("error - not all parameters specified for NSX-T Security Group lookup")
+	}
+	// Lookup Edge Gateway to know parent VDC or VDC Group
+	anyEdgeGateway, err := org.GetAnyTypeEdgeGatewayById(edgeGatewayId)
 	if err != nil {
-		return diag.Errorf("error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+		return diag.Errorf("[nsxt security group read] error retrieving Edge Gateway structure: %s", err)
+	}
+	if anyEdgeGateway.IsNsxv() {
+		return diag.Errorf("[nsxt security group read] NSX-V edge gateway not supported")
 	}
 
-	err = setNsxtSecurityGroupData(d, secGroup.NsxtFirewallGroup)
+	parentVdcOrVdcGroupId = anyEdgeGateway.EdgeGateway.OwnerRef.ID
+
+	if govcd.OwnerIsVdcGroup(parentVdcOrVdcGroupId) {
+		vdcGroup, err := org.GetVdcGroupById(parentVdcOrVdcGroupId)
+		if err != nil {
+			return diag.Errorf("could not retrieve VDC Group with ID '%s': %s", d.Id(), err)
+		}
+
+		// Name uniqueness is enforced by VCD for types.FirewallGroupTypeIpSet
+		securityGroup, err = vdcGroup.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeSecurityGroup)
+		if err != nil {
+			return diag.Errorf("[nsxt security group read] error getting NSX-T Security Group with Name '%s': %s", d.Get("name").(string), err)
+		}
+	} else {
+		nsxtEdgeGateway, err := anyEdgeGateway.GetNsxtEdgeGateway()
+		if err != nil {
+			return diag.Errorf("could not retrieve NSX-T Edge Gateway with ID '%s': %s", d.Id(), err)
+		}
+
+		// Name uniqueness is enforced by VCD for types.FirewallGroupTypeSecurityGroup
+		securityGroup, err = nsxtEdgeGateway.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeSecurityGroup)
+		if err != nil {
+			return diag.Errorf("[nsxt security group read] error getting NSX-T Security Group with Name '%s': %s", d.Get("name").(string), err)
+		}
+	}
+
+	err = setNsxtSecurityGroupData(d, securityGroup.NsxtFirewallGroup, parentVdcOrVdcGroupId)
 	if err != nil {
-		return diag.Errorf("error reading NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt security group read] error setting NSX-T Security Group: %s", err)
 	}
 
 	// A separate GET call is required to get all associated VMs
-	associatedVms, err := secGroup.GetAssociatedVms()
+	associatedVms, err := securityGroup.GetAssociatedVms()
 	if err != nil {
-		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", secGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
 	if err != nil {
-		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", secGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
-	d.SetId(secGroup.NsxtFirewallGroup.ID)
+	d.SetId(securityGroup.NsxtFirewallGroup.ID)
 
 	return nil
 }

--- a/vcd/nsxt_common.go
+++ b/vcd/nsxt_common.go
@@ -1,0 +1,31 @@
+package vcd
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+// getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway returns VDC or VDC group ID and NSX-T Edge Gateway type
+func getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient *VCDClient, d *schema.ResourceData, action string) (string, *govcd.NsxtEdgeGateway, error) {
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return "", nil, fmt.Errorf("[%s] error retrieving Org: %s", action, err)
+	}
+
+	// Lookup Edge Gateway to know parent VDC or VDC Group
+	anyEdgeGateway, err := org.GetAnyTypeEdgeGatewayById(d.Get("edge_gateway_id").(string))
+	if err != nil {
+		return "", nil, fmt.Errorf("[%s] error retrieving Edge Gateway structure: %s", action, err)
+	}
+	if anyEdgeGateway.IsNsxv() {
+		return "", nil, fmt.Errorf("[nsxt ip set %s] NSX-V edge gateway not supported", action)
+	}
+
+	nsxtEdgeGateway, err := anyEdgeGateway.GetNsxtEdgeGateway()
+	if err != nil {
+		return "", nil, fmt.Errorf("[%s] could not retrieve NSX-T Edge Gateway with ID '%s': %s", action, d.Id(), err)
+	}
+
+	return anyEdgeGateway.EdgeGateway.OwnerRef.ID, nsxtEdgeGateway, nil
+}

--- a/vcd/nsxt_common.go
+++ b/vcd/nsxt_common.go
@@ -7,24 +7,24 @@ import (
 )
 
 // getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway returns VDC or VDC group ID and NSX-T Edge Gateway type
-func getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient *VCDClient, d *schema.ResourceData, action string) (string, *govcd.NsxtEdgeGateway, error) {
+func getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient *VCDClient, d *schema.ResourceData, actionMessage string) (string, *govcd.NsxtEdgeGateway, error) {
 	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return "", nil, fmt.Errorf("[%s] error retrieving Org: %s", action, err)
+		return "", nil, fmt.Errorf("[%s] error retrieving Org: %s", actionMessage, err)
 	}
 
 	// Lookup Edge Gateway to know parent VDC or VDC Group
 	anyEdgeGateway, err := org.GetAnyTypeEdgeGatewayById(d.Get("edge_gateway_id").(string))
 	if err != nil {
-		return "", nil, fmt.Errorf("[%s] error retrieving Edge Gateway structure: %s", action, err)
+		return "", nil, fmt.Errorf("[%s] error retrieving Edge Gateway structure: %s", actionMessage, err)
 	}
 	if anyEdgeGateway.IsNsxv() {
-		return "", nil, fmt.Errorf("[nsxt ip set %s] NSX-V edge gateway not supported", action)
+		return "", nil, fmt.Errorf("[%s] NSX-V edge gateway not supported", actionMessage)
 	}
 
 	nsxtEdgeGateway, err := anyEdgeGateway.GetNsxtEdgeGateway()
 	if err != nil {
-		return "", nil, fmt.Errorf("[%s] could not retrieve NSX-T Edge Gateway with ID '%s': %s", action, d.Id(), err)
+		return "", nil, fmt.Errorf("[%s] could not retrieve NSX-T Edge Gateway with ID '%s': %s", actionMessage, d.Id(), err)
 	}
 
 	return anyEdgeGateway.EdgeGateway.OwnerRef.ID, nsxtEdgeGateway, nil

--- a/vcd/resource_vcd_nsxt_ip_set.go
+++ b/vcd/resource_vcd_nsxt_ip_set.go
@@ -72,7 +72,7 @@ func resourceVcdNsxtIpSet() *schema.Resource {
 func resourceVcdNsxtIpSetCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "create")
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "nsxt ip set create")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -99,33 +99,10 @@ func resourceVcdNsxtIpSetCreate(ctx context.Context, d *schema.ResourceData, met
 	return resourceVcdNsxtIpSetRead(ctx, d, meta)
 }
 
-func getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient *VCDClient, d *schema.ResourceData, action string) (string, *govcd.NsxtEdgeGateway, error) {
-	org, err := vcdClient.GetOrgFromResource(d)
-	if err != nil {
-		return "", nil, fmt.Errorf("[nsxt ip set create] error retrieving Org: %s", err)
-	}
-
-	// Lookup Edge Gateway to know parent VDC or VDC Group
-	anyEdgeGateway, err := org.GetAnyTypeEdgeGatewayById(d.Get("edge_gateway_id").(string))
-	if err != nil {
-		return "", nil, fmt.Errorf("[nsxt ip set %s] error retrieving Edge Gateway structure: %s", action, err)
-	}
-	if anyEdgeGateway.IsNsxv() {
-		return "", nil, fmt.Errorf("[nsxt ip set %s] NSX-V edge gateway not supported", action)
-	}
-
-	nsxtEdgeGateway, err := anyEdgeGateway.GetNsxtEdgeGateway()
-	if err != nil {
-		return "", nil, fmt.Errorf("[nsxt ip set %s] could not retrieve NSX-T Edge Gateway with ID '%s': %s", action, d.Id(), err)
-	}
-
-	return anyEdgeGateway.EdgeGateway.OwnerRef.ID, nsxtEdgeGateway, nil
-}
-
 func resourceVcdNsxtIpSetUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "update")
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "nsxt ip set update")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -165,7 +142,7 @@ func resourceVcdNsxtIpSetRead(_ context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("[nsxt ip set read] error retrieving Org: %s", err)
 	}
 
-	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "read")
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "nsxt ip set read")
 	if err != nil {
 		if govcd.ContainsNotFound(err) {
 			d.SetId("")
@@ -210,7 +187,7 @@ func resourceVcdNsxtIpSetRead(_ context.Context, d *schema.ResourceData, meta in
 
 func resourceVcdNsxtIpSetDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
-	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "delete")
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "nsxt ip set delete")
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -280,7 +257,7 @@ func resourceVcdNsxtIpSetImport(_ context.Context, d *schema.ResourceData, meta 
 
 		ipSet, err = vdcGroup.GetNsxtFirewallGroupByName(ipSetName, types.FirewallGroupTypeIpSet)
 		if err != nil {
-			return nil, fmt.Errorf("[nsxt ip set resource import] error getting NSX-T IP Set with ID '%s': %s", d.Id(), err)
+			return nil, fmt.Errorf("[nsxt ip set resource import] error getting NSX-T IP Set '%s': %s", ipSetName, err)
 		}
 	} else {
 		ipSet, err = nsxtEdgeGateway.GetNsxtFirewallGroupByName(ipSetName, types.FirewallGroupTypeIpSet)

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -2,7 +2,6 @@ package vcd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -33,21 +32,27 @@ func resourceVcdSecurityGroup() *schema.Resource {
 			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				Computed:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
+				Deprecated:  "Deprecated in favor of `edge_gateway_id`. IP Sets will inherit VDC from parent Edge Gateway.",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge Gateway ID in which security group is located",
 			},
-			"name": &schema.Schema{
+			"owner_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of VDC or VDC Group",
+			},
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Security Group name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Security Group description",
@@ -97,22 +102,39 @@ var nsxtFirewallGroupMemberVms = &schema.Resource{
 
 func resourceVcdSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.lockParentEdgeGtw(d)
-	defer vcdClient.unLockParentEdgeGtw(d)
 
-	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "security group create")
 	if err != nil {
-		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+		return diag.FromErr(err)
 	}
 
-	fwGroup := getNsxtSecurityGroupType(d)
+	var securityGroup *types.NsxtFirewallGroup
+	var vdcOrVdcGroup vdcOrVdcGroupHandler
 
-	createdFwGroup, err := vdc.CreateNsxtFirewallGroup(fwGroup)
-	err = improveErrorMessageOnIncorrectMembership(err, fwGroup, vdc)
+	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf("error creating NSX-T Security Group '%s': %s", fwGroup.Name, err)
+		return diag.Errorf("[nsxt security group create] error retrieving Org: %s", err)
 	}
 
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+		securityGroup = getNsxtSecurityGroupType(d, parentEdgeGatewayOwnerId)
+		vdcOrVdcGroup, err = org.GetVdcGroupById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+		securityGroup = getNsxtSecurityGroupType(d, d.Get("edge_gateway_id").(string))
+		vdcOrVdcGroup, err = org.GetVDCById(parentEdgeGatewayOwnerId, false)
+	}
+
+	createdFwGroup, err := nsxtEdgeGateway.CreateNsxtFirewallGroup(securityGroup)
+	err = improveErrorMessageOnIncorrectMembership(err, securityGroup, vdcOrVdcGroup)
+	if err != nil {
+		return diag.Errorf("[nsxt security group create] error creating NSX-T Security Group '%s': %s", securityGroup.Name, err)
+	}
+
+	dSet(d, "edge_gateway_id", nsxtEdgeGateway.EdgeGateway.ID)
 	d.SetId(createdFwGroup.NsxtFirewallGroup.ID)
 
 	return resourceVcdSecurityGroupRead(ctx, d, meta)
@@ -120,27 +142,44 @@ func resourceVcdSecurityGroupCreate(ctx context.Context, d *schema.ResourceData,
 
 func resourceVcdSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.lockParentEdgeGtw(d)
-	defer vcdClient.unLockParentEdgeGtw(d)
 
-	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "security group create")
 	if err != nil {
-		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+		return diag.FromErr(err)
 	}
 
-	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
+	var updateSecurityGroup *types.NsxtFirewallGroup
+	var vdcOrVdcGroup vdcOrVdcGroupHandler
+
+	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf("error getting NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt security group update] error retrieving Org: %s", err)
 	}
 
-	updateFwGroup := getNsxtSecurityGroupType(d)
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+		updateSecurityGroup = getNsxtSecurityGroupType(d, parentEdgeGatewayOwnerId)
+		vdcOrVdcGroup, err = org.GetVdcGroupById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+		updateSecurityGroup = getNsxtSecurityGroupType(d, d.Get("edge_gateway_id").(string))
+		vdcOrVdcGroup, err = org.GetVDCById(parentEdgeGatewayOwnerId, false)
+	}
+
+	securityGroup, err := nsxtEdgeGateway.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		return diag.Errorf("[nsxt security group update] error getting NSX-T Security Group: %s", err)
+	}
+
 	// Inject existing ID for update
-	updateFwGroup.ID = d.Id()
+	updateSecurityGroup.ID = d.Id()
 
-	_, err = fwGroup.Update(updateFwGroup)
-	err = improveErrorMessageOnIncorrectMembership(err, updateFwGroup, vdc)
+	_, err = securityGroup.Update(updateSecurityGroup)
+	err = improveErrorMessageOnIncorrectMembership(err, updateSecurityGroup, vdcOrVdcGroup)
 	if err != nil {
-		return diag.Errorf("error updating NSX-T Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt security group update] error updating NSX-T Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	return resourceVcdSecurityGroupRead(ctx, d, meta)
@@ -149,34 +188,60 @@ func resourceVcdSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+		return diag.Errorf("[nsxt security group read] error retrieving Org: %s", err)
 	}
 
-	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "read")
 	if err != nil {
 		if govcd.ContainsNotFound(err) {
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+		return diag.FromErr(err)
 	}
 
-	err = setNsxtSecurityGroupData(d, fwGroup.NsxtFirewallGroup)
+	var securityGroup *govcd.NsxtFirewallGroup
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vdcGroup, err := adminOrg.GetVdcGroupById(parentEdgeGatewayOwnerId)
+		if err != nil {
+			return diag.Errorf("[nsxt security group resource read] error finding VDC Group by ID '%s': %s", parentEdgeGatewayOwnerId, err)
+		}
+
+		securityGroup, err = vdcGroup.GetNsxtFirewallGroupById(d.Id())
+		if err != nil {
+			if govcd.ContainsNotFound(err) {
+				d.SetId("")
+				return nil
+			}
+			return diag.Errorf("[nsxt security group resource read] error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+		}
+	} else {
+		securityGroup, err = nsxtEdgeGateway.GetNsxtFirewallGroupById(d.Id())
+		if err != nil {
+			if govcd.ContainsNotFound(err) {
+				d.SetId("")
+				return nil
+			}
+			return diag.Errorf("[nsxt security group resource read] error getting NSX-T Security Group with ID '%s': %s", d.Id(), err)
+		}
+	}
+
+	err = setNsxtSecurityGroupData(d, securityGroup.NsxtFirewallGroup, parentEdgeGatewayOwnerId)
 	if err != nil {
-		return diag.Errorf("error reading NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt security group resource read] error reading NSX-T Security Group: %s", err)
 	}
 
 	// A separate GET call is required to get all associated VMs
-	associatedVms, err := fwGroup.GetAssociatedVms()
+	associatedVms, err := securityGroup.GetAssociatedVms()
 	if err != nil {
-		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt security group resource read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
 	if err != nil {
-		return diag.Errorf("error getting associated VMs for Security Group '%s': %s", fwGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt security group resource read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	return nil
@@ -184,22 +249,27 @@ func resourceVcdSecurityGroupRead(ctx context.Context, d *schema.ResourceData, m
 
 func resourceVcdSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
-	vcdClient.lockParentEdgeGtw(d)
-	defer vcdClient.unLockParentEdgeGtw(d)
-
-	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	parentEdgeGatewayOwnerId, nsxtEdgeGateway, err := getParentEdgeGatewayOwnerIdAndNsxtEdgeGateway(vcdClient, d, "security group create")
 	if err != nil {
-		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+		return diag.FromErr(err)
 	}
 
-	fwGroup, err := vdc.GetNsxtFirewallGroupById(d.Id())
-	if err != nil {
-		return diag.Errorf("error getting NSX-T Security Group: %s", err)
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
 	}
 
-	err = fwGroup.Delete()
+	securityGroup, err := nsxtEdgeGateway.GetNsxtFirewallGroupById(d.Id())
 	if err != nil {
-		return diag.Errorf("error deleting NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt security group resource delete] error getting NSX-T Security Group: %s", err)
+	}
+
+	err = securityGroup.Delete()
+	if err != nil {
+		return diag.Errorf("[nsxt security group resource delete] error deleting NSX-T Security Group: %s", err)
 	}
 
 	d.SetId("")
@@ -207,51 +277,69 @@ func resourceVcdSecurityGroupDelete(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceVcdSecurityGroupImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVcdSecurityGroupImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 4 {
-		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.edge_gateway_name.security_group_name")
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.edge_gateway_name.security_group_name or" +
+			"as org-name.vdc-group-name.edge_gateway_name.security_group_name")
 	}
-	orgName, vdcName, edgeGatewayName, securityGroupName := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
+	orgName, vdcOrVdcGroupName, edgeGatewayName, securityGroupName := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
 
 	vcdClient := meta.(*VCDClient)
-	org, err := vcdClient.GetAdminOrg(orgName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to find Org %s: %s", orgName, err)
-	}
-	vdc, err := org.GetVDCByName(vdcName, false)
-	if err != nil {
-		return nil, fmt.Errorf("unable to find VDC %s: %s", vdcName, err)
+
+	// define an interface type to match VDC and VDC Groups
+	var vdcOrVdcGroup vdcOrVdcGroupHandler
+	var adminOrg *govcd.AdminOrg
+	_, vdcOrVdcGroup, err := vcdClient.GetOrgAndVdc(orgName, vdcOrVdcGroupName)
+	if govcd.ContainsNotFound(err) {
+		adminOrg, err = vcdClient.GetAdminOrg(orgName)
+		if err != nil {
+			return nil, fmt.Errorf("[nsxt security group resource import] error retrieving Admin Org for '%s': %s", orgName, err)
+		}
+
+		vdcOrVdcGroup, err = adminOrg.GetVdcGroupByName(vdcOrVdcGroupName)
+		if err != nil {
+			return nil, fmt.Errorf("[nsxt security group resource import] error finding VDC or VDC Group by name '%s': %s", vdcOrVdcGroupName, err)
+		}
 	}
 
-	if !vdc.IsNsxt() {
-		return nil, errors.New("security groups are only supported by NSX-T VDCs")
+	// Lookup Edge Gateway to know parent VDC or VDC Group
+	nsxtEdgeGateway, err := vdcOrVdcGroup.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if err != nil {
+		return nil, fmt.Errorf("[nsxt security group import] error retrieving Edge Gateway structure: %s", err)
 	}
 
-	edgeGateway, err := vdc.GetNsxtEdgeGatewayByName(edgeGatewayName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to find Edge Gateway '%s': %s", edgeGatewayName, err)
-	}
+	var securityGroup *govcd.NsxtFirewallGroup
+	parentEdgeGatewayOwnerId := nsxtEdgeGateway.EdgeGateway.OwnerRef.ID
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vdcGroup, err := adminOrg.GetVdcGroupById(parentEdgeGatewayOwnerId)
+		if err != nil {
+			return nil, fmt.Errorf("[nsxt security group resource import] error finding VDC Group by ID '%s': %s", parentEdgeGatewayOwnerId, err)
+		}
 
-	securityGroup, err := edgeGateway.GetNsxtFirewallGroupByName(securityGroupName, types.FirewallGroupTypeSecurityGroup)
-	if err != nil {
-		return nil, fmt.Errorf("unable to find Security Group '%s': %s", securityGroupName, err)
+		securityGroup, err = vdcGroup.GetNsxtFirewallGroupByName(securityGroupName, types.FirewallGroupTypeSecurityGroup)
+		if err != nil {
+			return nil, fmt.Errorf("[nsxt security group resource import] error getting NSX-T Security Group '%s': %s", securityGroupName, err)
+		}
+	} else {
+		securityGroup, err = nsxtEdgeGateway.GetNsxtFirewallGroupByName(securityGroupName, types.FirewallGroupTypeSecurityGroup)
+		if err != nil {
+			return nil, fmt.Errorf("[nsxt security group resource import] unable to find NSX-T Security Group '%s': %s", securityGroupName, err)
+		}
 	}
 
 	if !securityGroup.IsSecurityGroup() {
 		return nil, fmt.Errorf("firewall group '%s' is not a Security Group, but '%s'",
 			securityGroup.NsxtFirewallGroup.Name, securityGroup.NsxtFirewallGroup.Type)
 	}
-
 	dSet(d, "org", orgName)
-	dSet(d, "vdc", vdcName)
-	dSet(d, "edge_gateway_id", edgeGateway.EdgeGateway.ID)
+	dSet(d, "edge_gateway_id", nsxtEdgeGateway.EdgeGateway.ID)
 	d.SetId(securityGroup.NsxtFirewallGroup.ID)
 
 	return []*schema.ResourceData{d}, nil
 }
 
-func setNsxtSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGroup) error {
+func setNsxtSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGroup, parentVdcOrVdcGroupId string) error {
 	dSet(d, "name", fw.Name)
 	dSet(d, "description", fw.Description)
 
@@ -267,6 +355,8 @@ func setNsxtSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGrou
 	if err != nil {
 		return fmt.Errorf("error setting 'member_org_network_ids': %s", err)
 	}
+
+	dSet(d, "owner_id", parentVdcOrVdcGroupId)
 
 	return nil
 }
@@ -293,14 +383,12 @@ func setNsxtSecurityGroupAssociatedVmsData(d *schema.ResourceData, fw []*types.N
 	return d.Set("member_vms", memberVmSet)
 }
 
-func getNsxtSecurityGroupType(d *schema.ResourceData) *types.NsxtFirewallGroup {
+func getNsxtSecurityGroupType(d *schema.ResourceData, ownerId string) *types.NsxtFirewallGroup {
 	fwGroup := &types.NsxtFirewallGroup{
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
-		EdgeGatewayRef: &types.OpenApiReference{
-			ID: d.Get("edge_gateway_id").(string),
-		},
-		Type: types.FirewallGroupTypeSecurityGroup,
+		OwnerRef:    &types.OpenApiReference{ID: ownerId},
+		Type:        types.FirewallGroupTypeSecurityGroup,
 	}
 
 	// Expand member networks
@@ -319,12 +407,12 @@ func getNsxtSecurityGroupType(d *schema.ResourceData) *types.NsxtFirewallGroup {
 
 // improveErrorMessageOnIncorrectMembership checks if error message is similar to the one that is returned when a
 // non Routed Org VDC network ID is passed for Security Group membership and adds additional hint.
-func improveErrorMessageOnIncorrectMembership(err error, fwGroup *types.NsxtFirewallGroup, vdc *govcd.Vdc) error {
+func improveErrorMessageOnIncorrectMembership(err error, fwGroup *types.NsxtFirewallGroup, vdcOrVdcGroup vdcOrVdcGroupHandler) error {
 	// See if error message contains an indication to non Routed networks
 	if err != nil && strings.Contains(err.Error(), `No access to entity "com.vmware.vcloud.entity.gateway`) {
 		hasAtLeastOneNonRoutedNetwork := false
 		for i := range fwGroup.Members {
-			orgNet, err2 := vdc.GetOpenApiOrgVdcNetworkById(fwGroup.Members[i].ID)
+			orgNet, err2 := vdcOrVdcGroup.GetOpenApiOrgVdcNetworkById(fwGroup.Members[i].ID)
 
 			// when unable to validate network types - just return the original API error `err`
 			if err2 != nil {

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -121,11 +121,13 @@ func resourceVcdSecurityGroupCreate(ctx context.Context, d *schema.ResourceData,
 		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
 		securityGroup = getNsxtSecurityGroupType(d, parentEdgeGatewayOwnerId)
 		vdcOrVdcGroup, err = org.GetVdcGroupById(parentEdgeGatewayOwnerId)
+		diag.Errorf("[nsxt security group create] error retrieving VDC Group with ID %s: %s", parentEdgeGatewayOwnerId, err)
 	} else {
 		vcdClient.lockParentEdgeGtw(d)
 		defer vcdClient.unLockParentEdgeGtw(d)
 		securityGroup = getNsxtSecurityGroupType(d, d.Get("edge_gateway_id").(string))
 		vdcOrVdcGroup, err = org.GetVDCById(parentEdgeGatewayOwnerId, false)
+		diag.Errorf("[nsxt security group create] error retrieving VDC with ID %s: %s", parentEdgeGatewayOwnerId, err)
 	}
 
 	createdFwGroup, err := nsxtEdgeGateway.CreateNsxtFirewallGroup(securityGroup)
@@ -161,11 +163,13 @@ func resourceVcdSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData,
 		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
 		updateSecurityGroup = getNsxtSecurityGroupType(d, parentEdgeGatewayOwnerId)
 		vdcOrVdcGroup, err = org.GetVdcGroupById(parentEdgeGatewayOwnerId)
+		diag.Errorf("[nsxt security group update] error retrieving VDC Group with ID %s: %s", parentEdgeGatewayOwnerId, err)
 	} else {
 		vcdClient.lockParentEdgeGtw(d)
 		defer vcdClient.unLockParentEdgeGtw(d)
 		updateSecurityGroup = getNsxtSecurityGroupType(d, d.Get("edge_gateway_id").(string))
 		vdcOrVdcGroup, err = org.GetVDCById(parentEdgeGatewayOwnerId, false)
+		diag.Errorf("[nsxt security group update] error retrieving VDC with ID %s: %s", parentEdgeGatewayOwnerId, err)
 	}
 
 	securityGroup, err := nsxtEdgeGateway.GetNsxtFirewallGroupById(d.Id())

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -34,7 +34,7 @@ func resourceVcdSecurityGroup() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
-				Deprecated:  "Deprecated in favor of `edge_gateway_id`. IP Sets will inherit VDC from parent Edge Gateway.",
+				Deprecated:  "Deprecated in favor of `edge_gateway_id`. Security Group will inherit VDC from parent Edge Gateway.",
 			},
 			"edge_gateway_id": {
 				Type:        schema.TypeString,

--- a/vcd/vdc_group_common.go
+++ b/vcd/vdc_group_common.go
@@ -15,6 +15,7 @@ type vdcOrVdcGroupHandler interface {
 	GetNsxtImportableSwitchByName(name string) (*govcd.NsxtImportableSwitch, error)
 	GetNsxtFirewallGroupByName(name, firewallGroupType string) (*govcd.NsxtFirewallGroup, error)
 	GetNsxtFirewallGroupById(id string) (*govcd.NsxtFirewallGroup, error)
+	GetOpenApiOrgVdcNetworkById(id string) (*govcd.OpenApiOrgVdcNetwork, error)
 }
 
 // getVdcOrVdcGroupVerifierByOwnerId helps to find VDC or VDC Group by ownerId field and returns an

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -3,7 +3,7 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_security_group"
 sidebar_current: "docs-vcd-data-source-nsxt-security-group"
 description: |-
-  Provides a data source to access NSX-T Security Group configuration. Security groups are groups of
+  Provides a data source to access NSX-T Security Group configuration. Security Groups are groups of
   data center group networks to which distributed firewall rules apply. Grouping networks helps you 
   to reduce the total number of distributed firewall rules to be created. 
 ---
@@ -12,18 +12,23 @@ description: |-
 
 Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
-Provides a data source to access NSX-T Security Group configuration. Security groups are groups of
+Provides a data source to access NSX-T Security Group configuration. Security Groups are groups of
 data center group networks to which distributed firewall rules apply. Grouping networks helps you to
 reduce the total number of distributed firewall rules to be created.
 
 ## Example Usage 1
 
 ```hcl
-data "vcd_nsxt_security_group" "group1" {
-  org = "my-org"
-  vdc = "my-org-vdc"
 
-  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+data "vcd_nsxt_edgegateway" "main" {
+  org  = "my-org" # Optional
+  name = "main-edge"
+}
+
+data "vcd_nsxt_security_group" "group1" {
+  org = "my-org" # Optional
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.main.id
 
   name = "test-security-group-changed"
 }
@@ -35,11 +40,13 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `vdc` - (Deprecated; Optional) The name of VDC to use, optional if defined at provider level. **Deprecated**
+  in favor of `edge_gateway_id` field.
 * `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
 * `name` - (Required)  - Unique name of existing Security Group.
 
 ## Attribute Reference
-
+* `owner_id` - Parent VDC or VDC Group ID.
+ 
 All the arguments and attributes defined in
 [`vcd_nsxt_security_group`](/providers/vmware/vcd/latest/docs/resources/nsxt_security_group) resource are available.

--- a/website/docs/guides/vdc_groups.html.markdown
+++ b/website/docs/guides/vdc_groups.html.markdown
@@ -67,6 +67,7 @@ NSX-V VDC Group support is provided):
 * [vcd_network_isolated_v2](/providers/vmware/vcd/latest/docs/resources/network_isolated_v2)
 * [vcd_nsxt_network_imported](/providers/vmware/vcd/latest/docs/resources/nsxt_network_imported)
 * [vcd_nsxt_ip_set](/providers/vmware/vcd/latest/docs/resources/nsxt_ip_set)
+* [vcd_nsxt_security_group](/providers/vmware/vcd/latest/docs/resources/nsxt_security_group)
 
 The next sub-sections will cover some specifics for resources that have it. Resources that are not
 explicitly mentioned here simply introduce `owner_id` field over deprecated `vdc` field.

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -3,7 +3,7 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_security_group"
 sidebar_current: "docs-vcd-resource-nsxt-security-group"
 description: |-
-  Provides a resource to manage NSX-T Security Group. Security groups are groups of data center
+  Provides a resource to manage NSX-T Security Group. Security Groups are groups of data center
   group networks to which distributed firewall rules apply. Grouping networks helps you to reduce
   the total number of distributed firewall rules to be created.
 ---
@@ -12,19 +12,28 @@ description: |-
 
 Supported in provider *v3.3+* and VCD 10.1+ with NSX-T backed VDCs.
 
-Provides a resource to manage NSX-T Security Group. Security groups are groups of data center group
+Provides a resource to manage NSX-T Security Group. Security Groups are groups of data center group
 networks to which distributed firewall rules apply. Grouping networks helps you to reduce the total
 number of distributed firewall rules to be created.
+
+-> Starting with **v3.6.0** `vcd_nsxt_security_group` added support for VDC Groups.
+The `vdc` field (in resource or inherited from provider configuration) is deprecated, as `vcd_nsxt_security_group` will
+inherit the VDC Group or VDC membership from a parent Edge Gateway specified in the `edge_gateway_id` field.
+More about VDC Group support in a [VDC Groups guide](/providers/vmware/vcd/latest/docs/guides/vdc_groups).
 
 ## Example Usage 1 (Security Group with member networks)
 
 ```hcl
+data "vcd_nsxt_edgegateway" "main" {
+  org  = "my-org" # Optional
+  name = "main-edge"
+}
+
 resource "vcd_nsxt_security_group" "frontend-servers" {
-  org = "my-org"
-  vdc = "my-nsxt-vdc"
+  org = "my-org" # Optional
 
   # Referring to a data source for existing NSX-T Edge Gateway
-  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  edge_gateway_id = data.vcd_nsxt_edgegateway.main.id
 
   name        = "frontend-servers"
   description = "Security Group for a network connecting the frontend servers"
@@ -35,9 +44,13 @@ resource "vcd_nsxt_security_group" "frontend-servers" {
 
 ## Example Usage 2 (Empty Security Group)
 ```hcl
+data "vcd_nsxt_edgegateway" "main" {
+  org  = "my-org" # Optional
+  name = "main-edge"
+}
+
 resource "vcd_nsxt_security_group" "group1" {
-  org = "my-org"
-  vdc = "my-nsxt-vdc"
+  org = "my-org" # Optional
 
   # Referring to a data source for existing NSX-T Edge Gateway
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
@@ -53,7 +66,8 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.
+* `vdc` - (Deprecated; Optional) The name of VDC to use, optional if defined at provider level. **Deprecated**
+  in favor of `edge_gateway_id` field.
 * `name` - (Required) A unique name for Security Group
 * `description` - (Optional) An optional description of the Security Group
 * `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
@@ -90,8 +104,10 @@ below:
 
 ```
 terraform import vcd_nsxt_security_group.imported my-org.my-org-vdc.my-nsxt-edge-gateway.my-security-group-name
+or
+terraform import vcd_nsxt_security_group.imported my-org.my-org-vdc-group-name.my-nsxt-edge-gateway.my-security-group-name
 ```
 
 The above would import the `my-security-group-name` Security Group config settings that are defined
 on NSX-T Edge Gateway `my-nsxt-edge-gateway` which is configured in organization named `my-org` and
-VDC named `my-org-vdc`.
+VDC named `my-org-vdc` or VDC Group `my-vdc-group-name.


### PR DESCRIPTION
Dep: https://github.com/vmware/go-vcloud-director/pull/456

This PR adds VDC Group support for:

* vcd_nsxt_security_group (deprecates `vdc` field and instead inherits parent VDC / VDC Group from NSX-T Edge Gateway)

There is a major difference in how these resources support it. Security group follows the location of parent Edge Gateway ID - move together to VDC Group and back.

Note. The goal of this PR is to preserve backward compatibility and not break anything for existing users. `vdc` fields are deprecated in favor of `edge_gateway_id`.

Additionally:

Ran tests on 10.3.1 and 10.2.2 and upgrade tests