### PR TITLE
Add metadata to v2 Org VDC networks

### DIFF
--- a/.changes/v3.6.0/816-improvements.md
+++ b/.changes/v3.6.0/816-improvements.md
@@ -1,4 +1,4 @@
-* `resource/vcd_network_isolated_v2` add support for `metadata` so this field can be set when creating/updating isolated networks. [GH-816]
-* `datasource/vcd_network_isolated_v2` add support for `metadata` so this field can be retrieved when reading from isolated networks. [GH-816]
-* `resource/vcd_network_routed_v2` add support for `metadata` so this field can be set when creating/updating routed networks. [GH-816]
-* `datasource/vcd_network_routed_v2` add support for `metadata` so this field can be retrieved when reading from routed networks. [GH-816]
+* `resource/vcd_network_isolated_v2` add support for `metadata` so this field can be set when creating/updating isolated NSX-T networks. [GH-816]
+* `datasource/vcd_network_isolated_v2` add support for `metadata` so this field can be retrieved when reading from isolated NSX-T networks. [GH-816]
+* `resource/vcd_network_routed_v2` add support for `metadata` so this field can be set when creating/updating routed NSX-T networks. [GH-816]
+* `datasource/vcd_network_routed_v2` add support for `metadata` so this field can be retrieved when reading from routed NSX-T networks. [GH-816]

--- a/.changes/v3.6.0/816-improvements.md
+++ b/.changes/v3.6.0/816-improvements.md
@@ -1,0 +1,4 @@
+* `resource/vcd_network_isolated_v2` add support for `metadata` so this field can be set when creating/updating isolated networks. [GH-816]
+* `datasource/vcd_network_isolated_v2` add support for `metadata` so this field can be retrieved when reading from isolated networks. [GH-816]
+* `resource/vcd_network_routed_v2` add support for `metadata` so this field can be set when creating/updating routed networks. [GH-816]
+* `datasource/vcd_network_routed_v2` add support for `metadata` so this field can be retrieved when reading from routed networks. [GH-816]

--- a/go.mod
+++ b/go.mod
@@ -10,4 +10,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f
+replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220405074407-7b8364380832

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f h1:/NhRT7CJeYVNWZKv1OmnMVo0vGW8MTT99KSFGdkOeik=
-github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220405074407-7b8364380832 h1:lzt13NSVRvee94H/AjPrYdoRf1Gin5BcwgFu8lO/xWA=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220405074407-7b8364380832/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f h1:/NhRT7CJeYVNWZKv1OmnMVo0vGW8MTT99KSFGdkOeik=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220401135345-cc195cbd973f/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9 h1:4bmhpu6116aDka6yqHC4Qw2LJXf4SC4hm9jgrARZ4Ws=
-github.com/vmware/go-vcloud-director/v2 v2.15.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -177,14 +177,17 @@ func datasourceVcdNetworkIsolatedV2Read(_ context.Context, d *schema.ResourceDat
 		return diag.Errorf("[isolated network read v2] error setting Org VDC network data: %s", err)
 	}
 
-	metadata, err := network.GetMetadata()
-	if err != nil {
-		log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
-		return diag.Errorf("[isolated network read v2] unable to find Org VDC network metadata %s", err)
-	}
-	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
-	if err != nil {
-		return diag.Errorf("[isolated network read v2] unable to set Org VDC network metadata %s", err)
+	// Metadata is not supported when the network is in a VDC Group
+	if !govcd.OwnerIsVdcGroup(network.OpenApiOrgVdcNetwork.OwnerRef.ID) {
+		metadata, err := network.GetMetadata()
+		if err != nil {
+			log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
+			return diag.Errorf("[isolated network read v2] unable to find Org VDC network metadata %s", err)
+		}
+		err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+		if err != nil {
+			return diag.Errorf("[isolated network read v2] unable to set Org VDC network metadata %s", err)
+		}
 	}
 
 	d.SetId(network.OpenApiOrgVdcNetwork.ID)

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -97,6 +97,11 @@ func datasourceVcdNetworkIsolatedV2() *schema.Resource {
 				Description: "IP ranges used for static pool allocation in the network",
 				Elem:        networkV2IpRangeComputed,
 			},
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Key value map of metadata assigned to this network. Key and value can be any string",
+			},
 		},
 	}
 }

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -182,7 +182,7 @@ func datasourceVcdNetworkIsolatedV2Read(ctx context.Context, d *schema.ResourceD
 		log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
 		return diag.Errorf("[isolated network read v2] unable to find Org VDC network metadata %s", err)
 	}
-	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
+	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
 	if err != nil {
 		return diag.Errorf("[isolated network read v2] unable to set Org VDC network metadata %s", err)
 	}

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -107,7 +107,7 @@ func datasourceVcdNetworkIsolatedV2() *schema.Resource {
 	}
 }
 
-func datasourceVcdNetworkIsolatedV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceVcdNetworkIsolatedV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	org, err := vcdClient.GetOrgFromResource(d)

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -2,6 +2,7 @@ package vcd
 
 import (
 	"context"
+	"log"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 
@@ -174,6 +175,16 @@ func datasourceVcdNetworkIsolatedV2Read(ctx context.Context, d *schema.ResourceD
 	err = setOpenApiOrgVdcIsolatedNetworkData(d, network.OpenApiOrgVdcNetwork)
 	if err != nil {
 		return diag.Errorf("[isolated network read v2] error setting Org VDC network data: %s", err)
+	}
+
+	metadata, err := network.GetMetadata()
+	if err != nil {
+		log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
+		return diag.Errorf("[isolated network read v2] unable to find Org VDC network metadata %s", err)
+	}
+	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
+	if err != nil {
+		return diag.Errorf("[isolated network read v2] unable to set Org VDC network metadata %s", err)
 	}
 
 	d.SetId(network.OpenApiOrgVdcNetwork.ID)

--- a/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
@@ -47,13 +47,13 @@ func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-isolated-test-initial"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id")),
 			},
 
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
@@ -61,7 +61,7 @@ func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
 					resourceFieldsEqual("vcd_network_isolated_v2.net1", "data.vcd_network_isolated_v2.ds", []string{"%"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
@@ -69,7 +69,7 @@ func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
 					resourceFieldsEqual("vcd_network_isolated_v2.net1", "data.vcd_network_isolated_v2.ds", []string{"%"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),

--- a/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_nsxt_test.go
@@ -20,10 +20,14 @@ func TestAccVcdNetworkIsolatedV2NsxtDS(t *testing.T) {
 
 	// String map to fill the template
 	var params = StringMap{
-		"Org":         testConfig.VCD.Org,
-		"NsxtVdc":     testConfig.Nsxt.Vdc,
-		"NetworkName": t.Name(),
-		"Tags":        "network nsxt",
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"NetworkName":          t.Name(),
+		"Tags":                 "network nsxt",
+		"MetadataKey":          "key1",
+		"MetadataValue":        "value1",
+		"MetadataKeyUpdated":   "key2",
+		"MetadataValueUpdated": "value2",
 	}
 
 	params["FuncName"] = t.Name() + "-DS"

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -229,14 +229,17 @@ func datasourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData,
 		return diag.Errorf("[routed network read v2] error setting Org VDC network data: %s", err)
 	}
 
-	metadata, err := network.GetMetadata()
-	if err != nil {
-		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
-		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
-	}
-	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
-	if err != nil {
-		return diag.Errorf("[routed network read v2] unable to set Org VDC network metadata %s", err)
+	// Metadata is not supported when the network is in a VDC Group
+	if !govcd.OwnerIsVdcGroup(network.OpenApiOrgVdcNetwork.OwnerRef.ID) {
+		metadata, err := network.GetMetadata()
+		if err != nil {
+			log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
+			return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
+		}
+		err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+		if err != nil {
+			return diag.Errorf("[routed network read v2] unable to set Org VDC network metadata %s", err)
+		}
 	}
 
 	d.SetId(network.OpenApiOrgVdcNetwork.ID)

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -102,6 +102,11 @@ func datasourceVcdNetworkRoutedV2() *schema.Resource {
 				Description: "IP ranges used for static pool allocation in the network",
 				Elem:        networkV2IpRangeComputed,
 			},
+			"metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Key value map of metadata assigned to this network. Key and value can be any string",
+			},
 		},
 	}
 }

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -2,6 +2,7 @@ package vcd
 
 import (
 	"context"
+	"log"
 
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 
@@ -226,6 +227,16 @@ func datasourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceDat
 	err = setOpenApiOrgVdcRoutedNetworkData(d, network.OpenApiOrgVdcNetwork)
 	if err != nil {
 		return diag.Errorf("[routed network read v2] error setting Org VDC network data: %s", err)
+	}
+
+	metadata, err := network.GetMetadata()
+	if err != nil {
+		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
+		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
+	}
+	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
+	if err != nil {
+		return diag.Errorf("[routed network read v2] unable to set Org VDC network metadata %s", err)
 	}
 
 	d.SetId(network.OpenApiOrgVdcNetwork.ID)

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -127,7 +127,7 @@ var networkV2IpRangeComputed = &schema.Resource{
 	},
 }
 
-func datasourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func datasourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	org, err := vcdClient.GetOrgFromResource(d)
@@ -234,7 +234,7 @@ func datasourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
 		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
 	}
-	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
+	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
 	if err != nil {
 		return diag.Errorf("[routed network read v2] unable to set Org VDC network metadata %s", err)
 	}

--- a/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
@@ -20,11 +20,15 @@ func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
 
 	// String map to fill the template
 	var params = StringMap{
-		"Org":         testConfig.VCD.Org,
-		"NsxtVdc":     testConfig.Nsxt.Vdc,
-		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
-		"NetworkName": t.Name(),
-		"Tags":        "network nsxt",
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"EdgeGw":               testConfig.Nsxt.EdgeGateway,
+		"NetworkName":          t.Name(),
+		"Tags":                 "network nsxt",
+		"MetadataKey":          "key1",
+		"MetadataValue":        "value1",
+		"MetadataKeyUpdated":   "key2",
+		"MetadataValueUpdated": "value2",
 	}
 
 	params["FuncName"] = t.Name() + "-DS"

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -216,7 +216,7 @@ func resourceVcdNetworkIsolatedV2Read(ctx context.Context, d *schema.ResourceDat
 		log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
 		return diag.Errorf("[isolated network v2 read] unable to find Org VDC network metadata %s", err)
 	}
-	err = d.Set("metadata", getMetadataStruct(metadata))
+	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
 	if err != nil {
 		return diag.Errorf("[isolated network v2 read] unable to set Org VDC network metadata %s", err)
 	}

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -170,7 +170,7 @@ func resourceVcdNetworkIsolatedV2Update(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	// Explicitly add ID to the newValue type because function `getOpenApiOrgVdcIsolatedNetworkType` only sets other fields
+	// Explicitly add ID to the new type because function `getOpenApiOrgVdcIsolatedNetworkType` only sets other fields
 	networkType.ID = d.Id()
 
 	_, err = orgNetwork.Update(networkType)

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -122,14 +122,14 @@ func resourceVcdNetworkIsolatedV2Create(ctx context.Context, d *schema.ResourceD
 
 	orgNetwork, err := org.CreateOpenApiOrgVdcNetwork(networkType)
 	if err != nil {
-		return diag.Errorf("[isolated network v2 create] error creating Org VDC isolated network: %s", err)
+		return diag.Errorf("[isolated network v2 create] error creating Isolated network: %s", err)
 	}
 
 	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
 
 	err = createOrUpdateOpenApiNetworkMetadata(d, orgNetwork)
 	if err != nil {
-		return diag.Errorf("[isolated network v2 create] error adding metadata to Org VDC isolated network: %s", err)
+		return diag.Errorf("[isolated network v2 create] error adding metadata to Isolated network: %s", err)
 	}
 
 	return resourceVcdNetworkIsolatedV2Read(ctx, d, meta)
@@ -162,7 +162,7 @@ func resourceVcdNetworkIsolatedV2Update(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("[isolated network v2 update] error getting Org VDC network: %s", err)
+		return diag.Errorf("[isolated network v2 update] error getting Isolated network: %s", err)
 	}
 
 	networkType, err := getOpenApiOrgVdcIsolatedNetworkType(d, vcdClient)
@@ -175,12 +175,12 @@ func resourceVcdNetworkIsolatedV2Update(ctx context.Context, d *schema.ResourceD
 
 	_, err = orgNetwork.Update(networkType)
 	if err != nil {
-		return diag.Errorf("[isolated network v2 update] error updating Org VDC network: %s", err)
+		return diag.Errorf("[isolated network v2 update] error updating Isolated network: %s", err)
 	}
 
 	err = createOrUpdateOpenApiNetworkMetadata(d, orgNetwork)
 	if err != nil {
-		return diag.Errorf("[isolated network v2 update] error updating Org VDC network metadata: %s", err)
+		return diag.Errorf("[isolated network v2 update] error updating Isolated network metadata: %s", err)
 	}
 
 	return resourceVcdNetworkIsolatedV2Read(ctx, d, meta)
@@ -201,12 +201,12 @@ func resourceVcdNetworkIsolatedV2Read(_ context.Context, d *schema.ResourceData,
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("[isolated network v2 read] error getting Org VDC network: %s", err)
+		return diag.Errorf("[isolated network v2 read] error getting Isolated network: %s", err)
 	}
 
 	err = setOpenApiOrgVdcIsolatedNetworkData(d, orgNetwork.OpenApiOrgVdcNetwork)
 	if err != nil {
-		return diag.Errorf("[isolated network v2 read] error setting Org VDC network data: %s", err)
+		return diag.Errorf("[isolated network v2 read] error setting Isolated network data: %s", err)
 	}
 
 	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
@@ -214,11 +214,11 @@ func resourceVcdNetworkIsolatedV2Read(_ context.Context, d *schema.ResourceData,
 	metadata, err := orgNetwork.GetMetadata()
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find isolated network v2 metadata: %s", err)
-		return diag.Errorf("[isolated network v2 read] unable to find Org VDC network metadata %s", err)
+		return diag.Errorf("[isolated network v2 read] unable to find Isolated network metadata %s", err)
 	}
 	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
 	if err != nil {
-		return diag.Errorf("[isolated network v2 read] unable to set Org VDC network metadata %s", err)
+		return diag.Errorf("[isolated network v2 read] unable to set Isolated network metadata %s", err)
 	}
 
 	return nil
@@ -239,12 +239,12 @@ func resourceVcdNetworkIsolatedV2Delete(_ context.Context, d *schema.ResourceDat
 
 	orgNetwork, err := org.GetOpenApiOrgVdcNetworkById(d.Id())
 	if err != nil {
-		return diag.Errorf("[isolated network v2 delete] error getting Org VDC network: %s", err)
+		return diag.Errorf("[isolated network v2 delete] error getting Isolated network: %s", err)
 	}
 
 	err = orgNetwork.Delete()
 	if err != nil {
-		return diag.Errorf("[isolated network v2 delete] error deleting Org VDC network: %s", err)
+		return diag.Errorf("[isolated network v2 delete] error deleting Isolated network: %s", err)
 	}
 
 	return nil
@@ -275,7 +275,7 @@ func resourceVcdNetworkIsolatedV2Import(_ context.Context, d *schema.ResourceDat
 
 	orgNetwork, err := vdcOrVdcGroup.GetOpenApiOrgVdcNetworkByName(networkName)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Org VDC network '%s': %s", networkName, err)
+		return nil, fmt.Errorf("error retrieving Isolated network '%s': %s", networkName, err)
 	}
 
 	if !orgNetwork.IsIsolated() {

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -29,7 +29,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 		"Tags":                 "network nsxt",
 		"MetadataKey":          "key1",
 		"MetadataValue":        "value1",
-		"MetadataKeyUpdated":   "key1",
+		"MetadataKeyUpdated":   "key2",
 		"MetadataValueUpdated": "value2",
 	}
 
@@ -66,7 +66,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata"+params["MetadataKey"].(string), params["MetadataValue"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{ // step 2
@@ -87,8 +87,8 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.30",
 						"end_address":   "1.1.1.40",
 					}),
-					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKey"].(string)),
-					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata"+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
+					resource.TestCheckNoResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 				),
 			},
 			// Check that import works

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -209,8 +209,9 @@ func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 		"ExternalNetwork":           testConfig.Nsxt.ExternalNetwork,
 		"TestName":                  t.Name(),
 		"NsxtEdgeGatewayVcd":        t.Name() + "-edge",
-
-		"Tags": "network",
+		"MetadataKey":               "key1",
+		"MetadataValue":             "value1",
+		"Tags":                      "network",
 	}
 
 	params["FuncName"] = t.Name() + "-newVdc"
@@ -255,6 +256,7 @@ func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
 					resource.TestMatchResourceAttr("vcd_network_isolated_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:`)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "is_shared", "false"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
@@ -264,6 +266,7 @@ func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
 					resource.TestMatchResourceAttr("vcd_network_isolated_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:`)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "is_shared", "false"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
@@ -273,13 +276,15 @@ func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
 					resource.TestMatchResourceAttr("vcd_network_isolated_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdcGroup:`)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "is_shared", "true"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
-				ResourceName:      "vcd_network_isolated_v2.net1",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: importStateIdOrgNsxtVdcGroupObject(testConfig, t.Name(), t.Name()),
+				ResourceName:            "vcd_network_isolated_v2.net1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata"}, // Network is in a VDC Group, so it can't import metadata
+				ImportStateIdFunc:       importStateIdOrgNsxtVdcGroupObject(testConfig, t.Name(), t.Name()),
 			},
 			{
 				Config: configText6,
@@ -288,6 +293,7 @@ func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
 					resource.TestMatchResourceAttr("vcd_network_isolated_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:`)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "is_shared", "false"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
@@ -314,6 +320,10 @@ resource "vcd_network_isolated_v2" "net1" {
 	start_address = "1.1.1.10"
     end_address = "1.1.1.20"
   }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
+  }
 }
 `
 
@@ -330,6 +340,10 @@ resource "vcd_network_isolated_v2" "net1" {
   static_ip_pool {
 	start_address = "1.1.1.10"
 	end_address = "1.1.1.20"
+  }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
   }
 }
 `
@@ -349,7 +363,11 @@ resource "vcd_network_isolated_v2" "net1" {
 	  start_address = "1.1.1.10"
 	  end_address = "1.1.1.20"
 	}
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
   }
+}
 `
 
 const testAccVcdNetworkIsolatedV2NsxtMigrationStep6 = testAccVcdVdcGroupNew + `
@@ -365,6 +383,10 @@ resource "vcd_network_isolated_v2" "net1" {
   static_ip_pool {
 	start_address = "1.1.1.10"
 	end_address = "1.1.1.20"
+  }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
   }
 }
 `

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -102,8 +102,8 @@ func resourceVcdNetworkRoutedV2() *schema.Resource {
 			},
 			"metadata": {
 				Type:        schema.TypeMap,
-				Computed:    true,
-				Description: "Key value map of metadata assigned to this network. Key and value can be any string",
+				Optional:    true,
+				Description: "Key value map of metadata to assign to this network. Key and value can be any string",
 			},
 		},
 	}
@@ -202,7 +202,7 @@ func resourceVcdNetworkRoutedV2Update(ctx context.Context, d *schema.ResourceDat
 	return resourceVcdNetworkRoutedV2Read(ctx, d, meta)
 }
 
-func resourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	org, err := vcdClient.GetOrgFromResource(d)
@@ -232,7 +232,7 @@ func resourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
 		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
 	}
-	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
+	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
 	if err != nil {
 		return diag.Errorf("[routed network v2 read] unable to set Org VDC network metadata %s", err)
 	}
@@ -240,7 +240,7 @@ func resourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceData,
 	return nil
 }
 
-func resourceVcdNetworkRoutedV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func resourceVcdNetworkRoutedV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
 	// Handling locks on a routed network is conditional. There are two scenarios:
@@ -274,7 +274,7 @@ func resourceVcdNetworkRoutedV2Delete(ctx context.Context, d *schema.ResourceDat
 	return nil
 }
 
-func resourceVcdNetworkRoutedV2Import(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceVcdNetworkRoutedV2Import(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	resourceURI := strings.Split(d.Id(), ImportSeparator)
 	if len(resourceURI) != 3 {
 		return nil, fmt.Errorf("[routed network import v2] resource name must be specified as org-name.vdc-name.network-name")

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -232,7 +232,7 @@ func resourceVcdNetworkRoutedV2Read(ctx context.Context, d *schema.ResourceData,
 		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
 		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
 	}
-	err = d.Set("metadata", getMetadataStruct(metadata))
+	err = d.Set("metadata", getOpenApiMetadataStruct(metadata))
 	if err != nil {
 		return diag.Errorf("[routed network v2 read] unable to set Org VDC network metadata %s", err)
 	}

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -227,14 +227,17 @@ func resourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData, m
 
 	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
 
-	metadata, err := orgNetwork.GetMetadata()
-	if err != nil {
-		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
-		return diag.Errorf("[routed network read v2] unable to find Routed network metadata %s", err)
-	}
-	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
-	if err != nil {
-		return diag.Errorf("[routed network v2 read] unable to set Routed network metadata %s", err)
+	// Metadata is not supported when the network is in a VDC Group
+	if !govcd.OwnerIsVdcGroup(orgNetwork.OpenApiOrgVdcNetwork.OwnerRef.ID) {
+		metadata, err := orgNetwork.GetMetadata()
+		if err != nil {
+			log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
+			return diag.Errorf("[routed network read v2] unable to find Routed network metadata %s", err)
+		}
+		err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
+		if err != nil {
+			return diag.Errorf("[routed network v2 read] unable to set Routed network metadata %s", err)
+		}
 	}
 
 	return nil

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -137,14 +137,14 @@ func resourceVcdNetworkRoutedV2Create(ctx context.Context, d *schema.ResourceDat
 
 	orgNetwork, err := org.CreateOpenApiOrgVdcNetwork(networkType)
 	if err != nil {
-		return diag.Errorf("[routed network create v2] error creating Org VDC routed network: %s", err)
+		return diag.Errorf("[routed network create v2] error creating Routed network: %s", err)
 	}
 
 	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
 
 	err = createOrUpdateOpenApiNetworkMetadata(d, orgNetwork)
 	if err != nil {
-		return diag.Errorf("[routed network create v2] error adding metadata to Org VDC routed network: %s", err)
+		return diag.Errorf("[routed network create v2] error adding metadata to Routed network: %s", err)
 	}
 
 	return resourceVcdNetworkRoutedV2Read(ctx, d, meta)
@@ -178,7 +178,7 @@ func resourceVcdNetworkRoutedV2Update(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("[routed network update v2] error getting Org VDC network: %s", err)
+		return diag.Errorf("[routed network update v2] error getting Routed network: %s", err)
 	}
 
 	networkType, err := getOpenApiOrgVdcRoutedNetworkType(d, vcdClient)
@@ -191,12 +191,12 @@ func resourceVcdNetworkRoutedV2Update(ctx context.Context, d *schema.ResourceDat
 
 	_, err = orgNetwork.Update(networkType)
 	if err != nil {
-		return diag.Errorf("[routed network update v2] error updating Org VDC network: %s", err)
+		return diag.Errorf("[routed network update v2] error updating Routed network: %s", err)
 	}
 
 	err = createOrUpdateOpenApiNetworkMetadata(d, orgNetwork)
 	if err != nil {
-		return diag.Errorf("[routed network v2 update] error updating Org VDC network metadata: %s", err)
+		return diag.Errorf("[routed network v2 update] error updating Routed network metadata: %s", err)
 	}
 
 	return resourceVcdNetworkRoutedV2Read(ctx, d, meta)
@@ -217,12 +217,12 @@ func resourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData, m
 		return nil
 	}
 	if err != nil {
-		return diag.Errorf("[routed network read v2] error getting Org VDC network: %s", err)
+		return diag.Errorf("[routed network read v2] error getting Routed network: %s", err)
 	}
 
 	err = setOpenApiOrgVdcRoutedNetworkData(d, orgNetwork.OpenApiOrgVdcNetwork)
 	if err != nil {
-		return diag.Errorf("[routed network read v2] error setting Org VDC network data: %s", err)
+		return diag.Errorf("[routed network read v2] error setting Routed network data: %s", err)
 	}
 
 	d.SetId(orgNetwork.OpenApiOrgVdcNetwork.ID)
@@ -230,11 +230,11 @@ func resourceVcdNetworkRoutedV2Read(_ context.Context, d *schema.ResourceData, m
 	metadata, err := orgNetwork.GetMetadata()
 	if err != nil {
 		log.Printf("[DEBUG] Unable to find routed network v2 metadata: %s", err)
-		return diag.Errorf("[routed network read v2] unable to find Org VDC network metadata %s", err)
+		return diag.Errorf("[routed network read v2] unable to find Routed network metadata %s", err)
 	}
 	err = d.Set("metadata", getMetadataStruct(metadata.MetadataEntry))
 	if err != nil {
-		return diag.Errorf("[routed network v2 read] unable to set Org VDC network metadata %s", err)
+		return diag.Errorf("[routed network v2 read] unable to set Routed network metadata %s", err)
 	}
 
 	return nil
@@ -263,12 +263,12 @@ func resourceVcdNetworkRoutedV2Delete(_ context.Context, d *schema.ResourceData,
 
 	orgNetwork, err := org.GetOpenApiOrgVdcNetworkById(d.Id())
 	if err != nil {
-		return diag.Errorf("[routed network delete v2] error getting Org VDC network: %s", err)
+		return diag.Errorf("[routed network delete v2] error getting Routed network: %s", err)
 	}
 
 	err = orgNetwork.Delete()
 	if err != nil {
-		return diag.Errorf("[routed network delete v2] error deleting Org VDC network: %s", err)
+		return diag.Errorf("[routed network delete v2] error deleting Routed network: %s", err)
 	}
 
 	return nil
@@ -299,7 +299,7 @@ func resourceVcdNetworkRoutedV2Import(_ context.Context, d *schema.ResourceData,
 
 	orgNetwork, err := vdcOrVdcGroup.GetOpenApiOrgVdcNetworkByName(networkName)
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving Org VDC network '%s': %s", networkName, err)
+		return nil, fmt.Errorf("error retrieving Routed network '%s': %s", networkName, err)
 	}
 
 	if !orgNetwork.IsRouted() {

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -18,11 +18,15 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 
 	// String map to fill the template
 	var params = StringMap{
-		"Org":         testConfig.VCD.Org,
-		"NsxtVdc":     testConfig.Nsxt.Vdc,
-		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
-		"NetworkName": t.Name(),
-		"Tags":        "network",
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"EdgeGw":               testConfig.Nsxt.EdgeGateway,
+		"NetworkName":          t.Name(),
+		"Tags":                 "network",
+		"MetadataKey":          "key1",
+		"MetadataValue":        "value1",
+		"MetadataKeyUpdated":   "key1",
+		"MetadataValueUpdated": "value2",
 	}
 
 	configText := templateFill(TestAccVcdNetworkRoutedV2NsxtStep1, params)
@@ -65,6 +69,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
 			},
@@ -93,6 +98,9 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.60",
 						"end_address":   "1.1.1.70",
 					}),
+					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKey"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
+
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
 			},
@@ -146,6 +154,10 @@ resource "vcd_network_routed_v2" "net1" {
 	start_address = "1.1.1.10"
     end_address = "1.1.1.20"
   }
+
+  metadata = {
+    {{.MetadataKey}} = "{{.MetadataValue}}"
+  }
 }
 `
 
@@ -180,6 +192,10 @@ resource "vcd_network_routed_v2" "net1" {
   static_ip_pool {
 	start_address = "1.1.1.60"
     end_address = "1.1.1.70"
+  }
+
+  metadata = {
+    {{.MetadataKeyUpdated}} = "{{.MetadataValueUpdated}}"
   }
 }
 `

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -362,7 +362,8 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 		"ExternalNetwork":           testConfig.Nsxt.ExternalNetwork,
 		"TestName":                  t.Name(),
 		"NsxtEdgeGatewayVcd":        t.Name() + "-edge",
-
+		"MetadataKey":          "key1",
+		"MetadataValue":        "value1",
 		"Tags": "network",
 	}
 
@@ -424,6 +425,7 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttrPair("vcd_nsxt_edgegateway.nsxt-edge", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 					resource.TestMatchResourceAttr("vcd_network_routed_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:`)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
@@ -453,6 +455,7 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 					}),
 					resource.TestCheckResourceAttrPair("vcd_nsxt_edgegateway.nsxt-edge", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 					resource.TestMatchResourceAttr("vcd_network_routed_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:`)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{
@@ -480,6 +483,7 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 						"start_address": "1.1.1.60",
 						"end_address":   "1.1.1.70",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 			{ // Applying the same step once more to be sure that vcd_network_routed_v2 has refreshed its fields after edge gateway was moved
@@ -487,6 +491,7 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair("vcd_nsxt_edgegateway.nsxt-edge", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 					resource.TestMatchResourceAttr("vcd_network_routed_v2.net1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdcGroup:`)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
 
@@ -495,6 +500,7 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 				ResourceName:      "vcd_network_routed_v2.net1",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"metadata"}, // Network is in a VDC Group as the Edge Gateway moved, so it can't import metadata
 				ImportStateId:     fmt.Sprintf("%s.%s.%s", testConfig.VCD.Org, params["Name"].(string), params["Name"].(string)),
 			},
 		},
@@ -552,6 +558,10 @@ resource "vcd_network_routed_v2" "net1" {
 	start_address = "1.1.1.60"
     end_address = "1.1.1.70"
   }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
+  }
 }
 `
 
@@ -605,6 +615,10 @@ resource "vcd_network_routed_v2" "net1" {
 	start_address = "1.1.1.60"
     end_address = "1.1.1.70"
   }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
+  }
 }
 `
 
@@ -657,6 +671,10 @@ resource "vcd_network_routed_v2" "net1" {
   static_ip_pool {
 	start_address = "1.1.1.60"
     end_address = "1.1.1.70"
+  }
+
+  metadata = {
+   {{.MetadataKey}}  = "{{.MetadataValue}}"
   }
 }
 `

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -362,9 +362,9 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 		"ExternalNetwork":           testConfig.Nsxt.ExternalNetwork,
 		"TestName":                  t.Name(),
 		"NsxtEdgeGatewayVcd":        t.Name() + "-edge",
-		"MetadataKey":          "key1",
-		"MetadataValue":        "value1",
-		"Tags": "network",
+		"MetadataKey":               "key1",
+		"MetadataValue":             "value1",
+		"Tags":                      "network",
 	}
 
 	params["FuncName"] = t.Name() + "-newVdc"
@@ -497,11 +497,11 @@ func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 
 			// Check that import works
 			{ // step 3
-				ResourceName:      "vcd_network_routed_v2.net1",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "vcd_network_routed_v2.net1",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"metadata"}, // Network is in a VDC Group as the Edge Gateway moved, so it can't import metadata
-				ImportStateId:     fmt.Sprintf("%s.%s.%s", testConfig.VCD.Org, params["Name"].(string), params["Name"].(string)),
+				ImportStateId:           fmt.Sprintf("%s.%s.%s", testConfig.VCD.Org, params["Name"].(string), params["Name"].(string)),
 			},
 		},
 	})

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -25,7 +25,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 		"Tags":                 "network",
 		"MetadataKey":          "key1",
 		"MetadataValue":        "value1",
-		"MetadataKeyUpdated":   "key1",
+		"MetadataKeyUpdated":   "key2",
 		"MetadataValueUpdated": "value2",
 	}
 
@@ -55,8 +55,6 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 			{ // step 1
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// stateDumper(),
-					// sleepTester(),
 					cachedId.cacheTestResourceFieldValue("vcd_network_routed_v2.net1", "id"),
 					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id"),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "name", "nsxt-routed-test-initial"),
@@ -69,7 +67,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKey"].(string), params["MetadataValue"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
 			},
@@ -98,8 +96,8 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.60",
 						"end_address":   "1.1.1.70",
 					}),
-					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKey"].(string)),
-					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata"+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
+					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -520,15 +520,6 @@ func getMetadataStruct(metadata []*types.MetadataEntry) StringMap {
 	return metadataMap
 }
 
-// Converts to terraform understandable structure
-func getOpenApiMetadataStruct(metadata []*types.OpenApiMetadata) StringMap {
-	metadataMap := make(StringMap, len(metadata))
-	for _, metadataEntry := range metadata {
-		metadataMap[metadataEntry.KeyValue.Key] = metadataEntry.KeyValue.Value.Value
-	}
-	return metadataMap
-}
-
 //resourceVcdVdcUpdate function updates resource with found configurations changes
 func resourceVcdVdcUpdate(d *schema.ResourceData, meta interface{}) error {
 	vdcName := d.Get("name").(string)

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -520,6 +520,15 @@ func getMetadataStruct(metadata []*types.MetadataEntry) StringMap {
 	return metadataMap
 }
 
+// Converts to terraform understandable structure
+func getOpenApiMetadataStruct(metadata []*types.OpenApiMetadata) StringMap {
+	metadataMap := make(StringMap, len(metadata))
+	for _, metadataEntry := range metadata {
+		metadataMap[metadataEntry.KeyValue.Key] = metadataEntry.KeyValue.Value.Value
+	}
+	return metadataMap
+}
+
 //resourceVcdVdcUpdate function updates resource with found configurations changes
 func resourceVcdVdcUpdate(d *schema.ResourceData, meta interface{}) error {
 	vdcName := d.Get("name").(string)

--- a/website/docs/r/network_direct.html.markdown
+++ b/website/docs/r/network_direct.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `external_network` - (Required) The name of the external network.
 * `shared` - (Optional) Defines if this network is shared between multiple VDCs
   in the Org.  Defaults to `false`.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
 
 ## Attribute reference
 

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
   have a static IP; see [IP Pools](#ip-pools) below for details.
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
 
 <a id="ip-pools"></a>
 ## IP Pools

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -97,6 +97,7 @@ and inherited from provider configuration)
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
 
 <a id="ip-pools"></a>
 ## IP Pools

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -97,7 +97,7 @@ and inherited from provider configuration)
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network. **Not supported** if the network belongs to a VDC Group.
 
 <a id="ip-pools"></a>
 ## IP Pools

--- a/website/docs/r/network_routed.html.markdown
+++ b/website/docs/r/network_routed.html.markdown
@@ -63,6 +63,7 @@ The following arguments are supported:
   have a static IP; see [IP Pools](#ip-pools) below for details.
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
 
 <a id="ip-pools"></a>
 ## IP Pools

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -119,6 +119,7 @@ The following arguments are supported:
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
 
 <a id="ip-pools"></a>
 ## IP Pools

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -119,7 +119,7 @@ The following arguments are supported:
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network.
+* `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this network. **Not supported** if the owner edge gateway belongs to a VDC Group.
 
 <a id="ip-pools"></a>
 ## IP Pools


### PR DESCRIPTION
Created by #372

Depends on https://github.com/vmware/go-vcloud-director/pull/459

This PR adds `metadata` support for the **v2** VDC networks.