### PR TITLE
Fix issue when retrieving catalogs using filter

### DIFF
--- a/.changes/v3.6.0/817-bug-fixes.md
+++ b/.changes/v3.6.0/817-bug-fixes.md
@@ -1,1 +1,0 @@
-* Fix bug regarding `getCatalogByFilter` function [GH-817]

--- a/.changes/v3.6.0/817-bug-fixes.md
+++ b/.changes/v3.6.0/817-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix bug regarding `getCatalogByFilter` function [GH-817]

--- a/vcd/filter_get.go
+++ b/vcd/filter_get.go
@@ -52,7 +52,7 @@ func getCatalogByFilter(org *govcd.AdminOrg, filter interface{}, isSysAdmin bool
 		return nil, err
 	}
 
-	catalog, err := org.GetAdminCatalogByHref(queryItem.GetHref())
+	catalog, err := org.GetAdminCatalogByNameOrId(queryItem.GetName(), false)
 	if err != nil {
 		return nil, fmt.Errorf("[getCatalogByFilter] error retrieving catalog %s: %s", queryItem.GetName(), err)
 	}


### PR DESCRIPTION
No issues associated with this PR

# Description 
Small bug fix regarding `getCatalogByFilter` function.

# Detailed description
Since the function `getCatalogByFilter` now retrieves `adminCatalog`, the previous implementation was trying to retrieve an `adminCatalog` from a `catalog` HREF, and that was causing the issue.

Signed-off-by: Miguel Sama <msama@vmware.com>