### PR TITLE
Add dns_servers option to vcd_nsxt_network_dhcp resource

### DIFF
--- a/.changes/v3.7.0/830-features.md
+++ b/.changes/v3.7.0/830-features.md
@@ -1,0 +1,1 @@
+* `vcd_nsxt_network_dhcp` resource now supports `dns_servers` [GH-830]

--- a/.changes/v3.7.0/830-features.md
+++ b/.changes/v3.7.0/830-features.md
@@ -1,1 +1,1 @@
-* `vcd_nsxt_network_dhcp` resource now supports `dns_servers` [GH-830]
+* `vcd_nsxt_network_dhcp` resource and datasource now supports `dns_servers` [GH-830]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.15.0
+	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.1
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.15.0
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a h1:LV0z5VFK9y6+BtYsQb1/rOsEN4UJdqaBBp/0m/C6jWk=
+github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -319,8 +321,6 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.15.0 h1:idQ9NsHLr2dOSLBC8KIdBMq7XOvPiWmfxgWNaf580mk=
-github.com/vmware/go-vcloud-director/v2 v2.15.0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a h1:LV0z5VFK9y6+BtYsQb1/rOsEN4UJdqaBBp/0m/C6jWk=
-github.com/mikeletux/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220419145744-892ed305a32a/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/cli v1.1.2/go.mod h1:6iaV0fGdElS6dPBx0EApTxHrcWvmJphyh2n8YBLPPZ4=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
@@ -321,6 +319,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaU
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.1 h1:+vCRgZ5JAc+TUSzsIiq9FdVgCAUEMgHPrnre2UBwasI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.1/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_nsxt_network_dhcp.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp.go
@@ -52,6 +52,15 @@ func datasourceVcdOpenApiDhcp() *schema.Resource {
 				Description: "IP ranges used for DHCP pool allocation in the network",
 				Elem:        datasourceNsxtDhcpPoolSetSchema,
 			},
+			"dns_servers": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "The DNS server IPs to be assigned by this DHCP service. 2 values maximum.",
+				MaxItems:    2,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -100,8 +100,9 @@ func resourceVcdOpenApiDhcpCreate(ctx context.Context, d *schema.ResourceData, m
 	dhcpType := getOpenAPIOrgVdcNetworkDhcpType(d)
 
 	// DnsServers is a feature added from API 36.1. If API is lower, this attribute is set to empty to avoid sending it
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
-		dhcpType.DnsServers = []string{}
+	_, ok := d.GetOk("dns_servers")
+	if ok && vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+		return diag.Errorf("`dns_servers` is supported from VCD 10.3.1+ version")
 	}
 
 	_, err = vdc.UpdateOpenApiOrgVdcNetworkDhcp(orgNetworkId, dhcpType)

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -270,7 +270,9 @@ func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdc *types.OpenApiO
 		}
 	}
 
-	d.Set("dns_servers", orgVdc.DnsServers)
+	if len(orgVdc.DnsServers) > 0 {
+		d.Set("dns_servers", orgVdc.DnsServers)
+	}
 
 	return nil
 }

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -80,7 +80,7 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:   configText2,
 				SkipFunc: vcdVersionIsLowerThan1031,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -48,6 +48,9 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 						"start_address": "7.1.1.100",
 						"end_address":   "7.1.1.110",
 					}),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.1", "8.8.4.4"),
 				),
 			},
 			{
@@ -62,6 +65,9 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 						"start_address": "7.1.1.130",
 						"end_address":   "7.1.1.140",
 					}),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.0", "8.8.8.8"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.1", "8.8.4.4"),
 				),
 			},
 			{
@@ -111,6 +117,8 @@ resource "vcd_nsxt_network_dhcp" "pools" {
     start_address = "7.1.1.100"
     end_address   = "7.1.1.110"
   }
+
+  dns_servers = ["8.8.8.8", "8.8.4.4"]
 }
 `
 
@@ -130,5 +138,7 @@ resource "vcd_nsxt_network_dhcp" "pools" {
     start_address = "7.1.1.130"
     end_address   = "7.1.1.140"
   }
+
+  dns_servers = ["8.8.8.8", "8.8.4.4"]
 }
 `

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -66,8 +66,8 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 						"end_address":   "7.1.1.140",
 					}),
 					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.#", "2"),
-					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.0", "8.8.8.8"),
-					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.1", "8.8.4.4"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.0", "8.8.4.4"),
+					resource.TestCheckResourceAttr("vcd_nsxt_network_dhcp.pools", "dns_servers.1", "8.8.8.8"),
 				),
 			},
 			{
@@ -139,6 +139,6 @@ resource "vcd_nsxt_network_dhcp" "pools" {
     end_address   = "7.1.1.140"
   }
 
-  dns_servers = ["8.8.8.8", "8.8.4.4"]
+  dns_servers = ["8.8.4.4", "8.8.8.8"]
 }
 `

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -87,6 +87,8 @@ The following arguments are supported:
 * `org_network_id` - (Required) ID of parent Org VDC Routed network
 * `pool` - (Required) One or more blocks to define DHCP pool ranges. See [Pools](#pools) and example 
 for usage details.
+* `dns_servers` - (Optional; *v3.7+*) - The DNS server IPs to be assigned by this DHCP service. Maximum two values. 
+This argument is supported from VCD 10.3.1+.
 
 ## Pools
 


### PR DESCRIPTION
This PR relays on https://github.com/vmware/go-vcloud-director/pull/465

# Description
On issue #753 it is suggested to implement DNS servers to `vcd_nsxt_network_dhcp`, as it is available from VCD 10.3.1.

# Detailed description
This PR introduces the possibility of adding `dns_servers` to the `vcd_nsxt_network_dhcp`resource.
Since `dns_servers` is a feature introduced on VCD 10.3.1 (API v36.1), if these are set and the VCD version the user is working on is below that, it will error. 
 
Successfully tested on VCD 10.3.2 with system administrator as well as org administrator