### PR TITLE
gofmt -s -w .

### DIFF
--- a/.changes/v3.7.0/833-notes.md
+++ b/.changes/v3.7.0/833-notes.md
@@ -1,0 +1,1 @@
+* Apply `gofmt -s -w .` to cleanup code [GH-833]

--- a/scripts/gofmtcheck.sh
+++ b/scripts/gofmtcheck.sh
@@ -2,7 +2,7 @@
 
 # Check gofmt
 echo "==> Checking that code complies with gofmt requirements..."
-gofmt_files=$(gofmt -l `find . -name '*.go' | grep -v vendor`)
+gofmt_files=$(gofmt -s -l `find . -name '*.go' | grep -v vendor`)
 if [[ -n ${gofmt_files} ]]; then
     echo 'gofmt needs running on the following files:'
     echo "${gofmt_files}"

--- a/vcd/auth_saml_test.go
+++ b/vcd/auth_saml_test.go
@@ -96,7 +96,7 @@ func TestAccVcdSamlAuth(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_org.auth", "id"),

--- a/vcd/auth_test.go
+++ b/vcd/auth_test.go
@@ -278,7 +278,7 @@ func runAuthTest(t *testing.T, configText string) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText + dataSource,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_org.auth", "id"),

--- a/vcd/datasource_filter_test.go
+++ b/vcd/datasource_filter_test.go
@@ -356,7 +356,7 @@ func runSearchTest(entityType, label string, t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check:  makeCheckFuncsFromMap(expectedResults),
 			},

--- a/vcd/datasource_nsxt_manager_test.go
+++ b/vcd/datasource_nsxt_manager_test.go
@@ -38,7 +38,7 @@ func TestAccVcdDatasourceNsxtManager(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					// ID must match URN 'urn:vcloud:nsxtmanager:09722307-aee0-4623-af95-7f8e577c9ebc'

--- a/vcd/datasource_nsxt_tier0_router.go
+++ b/vcd/datasource_nsxt_tier0_router.go
@@ -14,17 +14,17 @@ func datasourceVcdNsxtTier0Router() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceNsxtTier0RouterRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NSX-T Tier-0 router.",
 			},
-			"nsxt_manager_id": &schema.Schema{
+			"nsxt_manager_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "ID of NSX-T manager.",
 			},
-			"is_assigned": &schema.Schema{
+			"is_assigned": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if Tier-0 router is already assigned to external network.",

--- a/vcd/datasource_nsxt_tier0_router_test.go
+++ b/vcd/datasource_nsxt_tier0_router_test.go
@@ -54,7 +54,7 @@ func testAccVcdDatasourceNsxtTier0Router(t *testing.T, tier0RouterName string) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					// ID must match URN 'urn:vcloud:nsxtmanager:09722307-aee0-4623-af95-7f8e577c9ebc'

--- a/vcd/datasource_test.go
+++ b/vcd/datasource_test.go
@@ -93,7 +93,7 @@ func testSpecificDataSourceNotFound(t *testing.T, dataSourceName string, vcdClie
 		resource.Test(t, resource.TestCase{
 			ProviderFactories: testAccProviders,
 			Steps: []resource.TestStep{
-				resource.TestStep{
+				{
 					Config:      configText,
 					ExpectError: regexp.MustCompile(`.*` + regexp.QuoteMeta(govcd.ErrorEntityNotFound.Error()) + `.*`),
 				},

--- a/vcd/datasource_vcd_catalog.go
+++ b/vcd/datasource_vcd_catalog.go
@@ -20,39 +20,39 @@ func datasourceVcdCatalog() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Name of the catalog. (Optional if 'filter' is used)",
 				ExactlyOneOf: []string{"name", "filter"},
 			},
-			"storage_profile_id": &schema.Schema{
+			"storage_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Storage profile ID",
 			},
-			"created": &schema.Schema{
+			"created": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Time stamp of when the catalog was created",
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"publish_enabled": &schema.Schema{
+			"publish_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation. Default is `false`.",
 			},
-			"cache_enabled": &schema.Schema{
+			"cache_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True enables early catalog export to optimize synchronization",
 			},
-			"preserve_identity_information": &schema.Schema{
+			"preserve_identity_information": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary.",
@@ -97,7 +97,7 @@ func datasourceVcdCatalog() *schema.Resource {
 				Computed:    true,
 				Description: "PUBLISHED if published externally, SUBSCRIBED if subscribed to an external catalog, UNPUBLISHED otherwise.",
 			},
-			"filter": &schema.Schema{
+			"filter": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				MinItems:    1,

--- a/vcd/datasource_vcd_catalog_item.go
+++ b/vcd/datasource_vcd_catalog_item.go
@@ -16,22 +16,22 @@ func datasourceVcdCatalogItem() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"catalog": &schema.Schema{
+			"catalog": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "catalog containing the item",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Name of the item. It is optional when a filter is provided",
 				ExactlyOneOf: []string{"name", "filter"},
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"created": &schema.Schema{
+			"created": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Time stamp of when the item was created",
@@ -41,7 +41,7 @@ func datasourceVcdCatalogItem() *schema.Resource {
 				Computed:    true,
 				Description: "Key and value pairs for catalog item metadata",
 			},
-			"filter": &schema.Schema{
+			"filter": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				MinItems:    1,

--- a/vcd/datasource_vcd_catalog_item_test.go
+++ b/vcd/datasource_vcd_catalog_item_test.go
@@ -45,7 +45,7 @@ func TestAccVcdCatalogAndItemDatasource(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      catalogItemDestroyed(testSuiteCatalogName, TestCatalogItemDS),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogItemExists("vcd_catalog_item."+TestCatalogItemDS),
@@ -65,7 +65,7 @@ func TestAccVcdCatalogAndItemDatasource(t *testing.T) {
 						resourceCatalogItem, "metadata.catalogItem_metadata2", "catalogItem Metadata2"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_catalog_item." + TestCatalogItemDS,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/datasource_vcd_catalog_media.go
+++ b/vcd/datasource_vcd_catalog_media.go
@@ -17,18 +17,18 @@ func datasourceVcdCatalogMedia() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"catalog": &schema.Schema{
+			"catalog": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "catalog name where upload the Media file",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "filter"},
 				Description:  "media name (Optional when 'filter' is used)",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -39,42 +39,42 @@ func datasourceVcdCatalogMedia() *schema.Resource {
 				// For now underlying go-vcloud-director repo only supports
 				// a value of type String in this map.
 			},
-			"is_iso": &schema.Schema{
+			"is_iso": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this media file is ISO",
 			},
-			"owner_name": &schema.Schema{
+			"owner_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Owner name",
 			},
-			"is_published": &schema.Schema{
+			"is_published": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this media file is in a published catalog",
 			},
-			"creation_date": &schema.Schema{
+			"creation_date": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Creation date",
 			},
-			"size": &schema.Schema{
+			"size": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Media storage in Bytes",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Media status",
 			},
-			"storage_profile_name": &schema.Schema{
+			"storage_profile_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Storage profile name",
 			},
-			"filter": &schema.Schema{
+			"filter": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				MinItems:    1,

--- a/vcd/datasource_vcd_catalog_media_test.go
+++ b/vcd/datasource_vcd_catalog_media_test.go
@@ -48,7 +48,7 @@ func TestAccVcdCatalogAndMediaDatasource(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      catalogMediaDestroyed(testConfig.VCD.Catalog.Name, TestCatalogMediaDS),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogMediaExists("vcd_catalog_media."+TestAccVcdDataSourceMedia),

--- a/vcd/datasource_vcd_certificate_library_test.go
+++ b/vcd/datasource_vcd_certificate_library_test.go
@@ -80,7 +80,7 @@ func TestAccVcdLibraryCertificateDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check:  resource.ComposeAggregateTestCheckFunc(checkFunctions...),
 			},

--- a/vcd/datasource_vcd_edgegateway.go
+++ b/vcd/datasource_vcd_edgegateway.go
@@ -7,35 +7,35 @@ func datasourceVcdEdgeGateway() *schema.Resource {
 		Read: datasourceVcdEdgeGatewayRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "filter"},
 				Description:  "name of the edge gateway. (Optional when 'filter' is used)",
 			},
-			"org": &schema.Schema{
+			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"configuration": &schema.Schema{
+			"configuration": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: `Configuration of the vShield edge VM for this gateway. One of: compact, full ("Large"), full4 ("Quad Large"), x-large`,
 			},
-			"ha_enabled": &schema.Schema{
+			"ha_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable high availability on this edge gateway",
 			},
-			"default_external_network_ip": &schema.Schema{
+			"default_external_network_ip": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address of edge gateway interface which is used as default.",
@@ -48,53 +48,53 @@ func datasourceVcdEdgeGateway() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"distributed_routing": &schema.Schema{
+			"distributed_routing": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable distributed routing",
 			},
-			"lb_enabled": &schema.Schema{
+			"lb_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable load balancing. (Disabled by default)",
 			},
-			"lb_acceleration_enabled": &schema.Schema{
+			"lb_acceleration_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable load balancer acceleration. (Disabled by default)",
 			},
-			"lb_logging_enabled": &schema.Schema{
+			"lb_logging_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable load balancer logging. (Disabled by default)",
 			},
-			"lb_loglevel": &schema.Schema{
+			"lb_loglevel": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Log level. One of 'emergency', 'alert', 'critical', 'error', " +
 					"'warning', 'notice', 'info', 'debug'. ('info' by default)",
 			},
-			"fw_enabled": &schema.Schema{
+			"fw_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable firewall. Default 'true'",
 			},
-			"fw_default_rule_logging_enabled": &schema.Schema{
+			"fw_default_rule_logging_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable logging for default rule. Default 'false'",
 			},
-			"fw_default_rule_action": &schema.Schema{
+			"fw_default_rule_action": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "'accept' or 'deny'. Default 'deny'",
 			},
-			"fips_mode_enabled": &schema.Schema{
+			"fips_mode_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable FIPS mode. FIPS mode turns on the cipher suites that comply with FIPS. (False by default)",
 			},
-			"use_default_route_for_dns_relay": &schema.Schema{
+			"use_default_route_for_dns_relay": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "If true, default gateway will be used for the edge gateways' default routing and DNS forwarding.(False by default)",
@@ -173,7 +173,7 @@ func datasourceVcdEdgeGateway() *schema.Resource {
 					},
 				},
 			},
-			"filter": &schema.Schema{
+			"filter": {
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				MinItems:    1,

--- a/vcd/datasource_vcd_external_network.go
+++ b/vcd/datasource_vcd_external_network.go
@@ -8,57 +8,57 @@ func datasourceVcdExternalNetwork() *schema.Resource {
 	return &schema.Resource{
 		Read: resourceVcdExternalNetworkRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ip_scope": &schema.Schema{
+			"ip_scope": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "A list of IP scopes for the network",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"gateway": &schema.Schema{
+						"gateway": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Gateway of the network",
 						},
-						"netmask": &schema.Schema{
+						"netmask": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Network mask",
 						},
-						"dns1": &schema.Schema{
+						"dns1": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Primary DNS server",
 						},
-						"dns2": &schema.Schema{
+						"dns2": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Secondary DNS server",
 						},
-						"dns_suffix": &schema.Schema{
+						"dns_suffix": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "DNS suffix",
 						},
-						"static_ip_pool": &schema.Schema{
+						"static_ip_pool": {
 							Type:        schema.TypeList,
 							Computed:    true,
 							Description: "IP ranges used for static pool allocation in the network",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"start_address": &schema.Schema{
+									"start_address": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "Start address of the IP range",
 									},
-									"end_address": &schema.Schema{
+									"end_address": {
 										Type:        schema.TypeString,
 										Computed:    true,
 										Description: "End address of the IP range",
@@ -69,23 +69,23 @@ func datasourceVcdExternalNetwork() *schema.Resource {
 					},
 				},
 			},
-			"vsphere_network": &schema.Schema{
+			"vsphere_network": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "A list of port groups that back this network. Each referenced DV_PORTGROUP or NETWORK must exist on a vCenter server registered with the system.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vcenter": &schema.Schema{
+						"vcenter": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The vCenter server name",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The name of the port group",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The vSphere port group type. One of: DV_PORTGROUP (distributed virtual port group), NETWORK",
@@ -93,7 +93,7 @@ func datasourceVcdExternalNetwork() *schema.Resource {
 					},
 				},
 			},
-			"retain_net_info_across_deployments": &schema.Schema{
+			"retain_net_info_across_deployments": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Default is false.",

--- a/vcd/datasource_vcd_external_network_v2.go
+++ b/vcd/datasource_vcd_external_network_v2.go
@@ -13,32 +13,32 @@ func datasourceVcdExternalNetworkV2() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceVcdExternalNetworkV2Read,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ip_scope": &schema.Schema{
+			"ip_scope": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "A set of IP scopes for the network",
 				Elem:        networkV2IpScope,
 			},
-			"vsphere_network": &schema.Schema{
+			"vsphere_network": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "A list of port groups that back this network. Each referenced DV_PORTGROUP or NETWORK must exist on a vCenter server registered with the system.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vcenter_id": &schema.Schema{
+						"vcenter_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The vCenter server ID",
 						},
-						"portgroup_id": &schema.Schema{
+						"portgroup_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "The portgroup ID",
@@ -46,23 +46,23 @@ func datasourceVcdExternalNetworkV2() *schema.Resource {
 					},
 				},
 			},
-			"nsxt_network": &schema.Schema{
+			"nsxt_network": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"nsxt_manager_id": &schema.Schema{
+						"nsxt_manager_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "ID of NSX-T manager",
 						},
-						"nsxt_tier0_router_id": &schema.Schema{
+						"nsxt_tier0_router_id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "ID of NSX-T Tier-0 router (for T0 gateway backed external network)",
 						},
-						"nsxt_segment_name": &schema.Schema{
+						"nsxt_segment_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Name of NSX-T segment (for NSX-T segment backed external network)",

--- a/vcd/datasource_vcd_external_network_v2_test.go
+++ b/vcd/datasource_vcd_external_network_v2_test.go
@@ -41,7 +41,7 @@ func TestAccVcdExternalNetworkV2Datasource(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr(datasourceName, "id", regexp.MustCompile(`^urn:vcloud:network:.*`)),

--- a/vcd/datasource_vcd_global_role.go
+++ b/vcd/datasource_vcd_global_role.go
@@ -11,38 +11,38 @@ func datasourceVcdGlobalRole() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceGlobalRoleRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of global role.",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Global role description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this global role is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of rights assigned to this global role",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"publish_to_all_tenants": &schema.Schema{
+			"publish_to_all_tenants": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "When true, publishes the global role to all tenants",
 			},
-			"tenants": &schema.Schema{
+			"tenants": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of tenants to which this global role is published",

--- a/vcd/datasource_vcd_ipset.go
+++ b/vcd/datasource_vcd_ipset.go
@@ -20,17 +20,17 @@ func datasourceVcdIpSet() *schema.Resource {
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "IP set name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP set description",
 			},
-			"is_inheritance_allowed": &schema.Schema{
+			"is_inheritance_allowed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Allows visibility in underlying scopes (Default is true)",

--- a/vcd/datasource_vcd_lb_app_profile.go
+++ b/vcd/datasource_vcd_lb_app_profile.go
@@ -23,42 +23,42 @@ func datasourceVcdLBAppProfile() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Application Profile is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "LB Application Profile name for lookup",
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Protocol type used to send requests to the server. One of 'TCP', " +
 					"'UDP', 'HTTP' org 'HTTPS'",
 			},
-			"enable_ssl_passthrough": &schema.Schema{
+			"enable_ssl_passthrough": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Description: "Enable SSL authentication to be passed through to the virtual " +
 					"server. Otherwise SSL authentication takes place at the destination address.",
 			},
-			"http_redirect_url": &schema.Schema{
+			"http_redirect_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "The URL to which traffic that arrives at the destination address " +
 					"should be redirected. Only applies for types HTTP and HTTPS",
 			},
-			"persistence_mechanism": &schema.Schema{
+			"persistence_mechanism": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Persistence mechanism for the profile. One of 'cookie', " +
 					"'ssl-sessionid', 'sourceip'",
 			},
-			"cookie_name": &schema.Schema{
+			"cookie_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Used to uniquely identify the session the first time a client " +
@@ -66,18 +66,18 @@ func datasourceVcdLBAppProfile() *schema.Resource {
 					"subsequent requests in the session, so that they all go to the same virtual " +
 					"server. Only applies for persistence_mechanism 'cookie'",
 			},
-			"cookie_mode": &schema.Schema{
+			"cookie_mode": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "The mode by which the cookie should be inserted. One of 'insert', " +
 					"'prefix', or 'appsession'",
 			},
-			"expiration": &schema.Schema{
+			"expiration": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Length of time in seconds that persistence stays in effect",
 			},
-			"insert_x_forwarded_http_header": &schema.Schema{
+			"insert_x_forwarded_http_header": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Description: "Enables 'X-Forwarded-For' header for identifying the originating IP" +
@@ -86,7 +86,7 @@ func datasourceVcdLBAppProfile() *schema.Resource {
 			},
 			// TODO https://github.com/vmware/terraform-provider-vcd/issues/258
 			// This will not give much use without SSL certs being available
-			"enable_pool_side_ssl": &schema.Schema{
+			"enable_pool_side_ssl": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Description: "Enable to define the certificate, CAs, or CRLs used to authenticate" +

--- a/vcd/datasource_vcd_lb_app_rule.go
+++ b/vcd/datasource_vcd_lb_app_rule.go
@@ -23,13 +23,13 @@ func datasourceVcdLBAppRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Application Rule is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "LB Application Rule name for lookup",

--- a/vcd/datasource_vcd_lb_server_pool.go
+++ b/vcd/datasource_vcd_lb_server_pool.go
@@ -23,23 +23,23 @@ func datasourceVcdLbServerPool() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Server Pool is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Server Pool name for lookup",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Server pool description",
 			},
-			"algorithm": &schema.Schema{
+			"algorithm": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Balancing method for the service",
@@ -49,12 +49,12 @@ func datasourceVcdLbServerPool() *schema.Resource {
 				Computed:    true,
 				Description: "Additional options for load balancing algorithm for http-header or url algorithms",
 			},
-			"monitor_id": &schema.Schema{
+			"monitor_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Load Balancer Service Monitor ID",
 			},
-			"enable_transparency": &schema.Schema{
+			"enable_transparency": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Makes client IP addresses visible to the backend servers",
@@ -69,7 +69,7 @@ func datasourceVcdLbServerPool() *schema.Resource {
 							Computed:    true,
 							Description: "Pool member id (formatted as member-xx, where xx is a number)",
 						},
-						"condition": &schema.Schema{
+						"condition": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Defines member state. One of enabled, drain, disabled.",

--- a/vcd/datasource_vcd_lb_service_monitor.go
+++ b/vcd/datasource_vcd_lb_service_monitor.go
@@ -21,57 +21,57 @@ func datasourceVcdLbServiceMonitor() *schema.Resource {
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Edge gateway name in which the LB Service Monitor is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "LB Service Monitor name",
 			},
-			"interval": &schema.Schema{
+			"interval": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Interval in seconds at which a server is to be monitored",
 			},
-			"timeout": &schema.Schema{
+			"timeout": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum time in seconds within which a response from the server must be received",
 			},
-			"max_retries": &schema.Schema{
+			"max_retries": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of times the specified monitoring Method must fail sequentially before the server is declared down",
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Way in which you want to send the health check request to the server. One of http, https, tcp, icmp, or udp",
 			},
-			"expected": &schema.Schema{
+			"expected": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "String that the monitor expects to match in the status line of the http or https response (for example, HTTP/1.1)",
 			},
-			"method": &schema.Schema{
+			"method": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Method to be used to detect server status. One of OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, or CONNECT",
 			},
-			"url": &schema.Schema{
+			"url": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "URL to be used in the server status request",
 			},
-			"send": &schema.Schema{
+			"send": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Data to be sent",
 			},
-			"receive": &schema.Schema{
+			"receive": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "String to be matched in the response content",

--- a/vcd/datasource_vcd_lb_virtual_server.go
+++ b/vcd/datasource_vcd_lb_virtual_server.go
@@ -23,24 +23,24 @@ func datasourceVcdLbVirtualServer() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the Virtual Server is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Virtual Server name for lookup",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Virtual Server description",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if the virtual server is enabled",
@@ -50,42 +50,42 @@ func datasourceVcdLbVirtualServer() *schema.Resource {
 				Computed:    true,
 				Description: "IP address that the load balancer listens on",
 			},
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Protocol that the virtual server accepts",
 			},
-			"port": &schema.Schema{
+			"port": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Port number that the load balancer listens on",
 			},
-			"enable_acceleration": &schema.Schema{
+			"enable_acceleration": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable virtual server acceleration",
 			},
-			"connection_limit": &schema.Schema{
+			"connection_limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum concurrent connections that the virtual server can process",
 			},
-			"connection_rate_limit": &schema.Schema{
+			"connection_rate_limit": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum incoming new connection requests per second",
 			},
-			"app_profile_id": &schema.Schema{
+			"app_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Application profile ID to be associated with the virtual server",
 			},
-			"server_pool_id": &schema.Schema{
+			"server_pool_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The server pool that the load balancer will use",
 			},
-			"app_rule_ids": &schema.Schema{
+			"app_rule_ids": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "List of attached application rule IDs",

--- a/vcd/datasource_vcd_network_isolated_v2_test.go
+++ b/vcd/datasource_vcd_network_isolated_v2_test.go
@@ -56,7 +56,7 @@ func TestAccVcdNetworkIsolatedV2NsxvDS(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_network_isolated_v2.ds", "id"),
@@ -66,7 +66,7 @@ func TestAccVcdNetworkIsolatedV2NsxvDS(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.vcd_network_isolated_v2.ds", "prefix_length"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_network_isolated_v2.ds", "id"),

--- a/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_nsxt_test.go
@@ -52,13 +52,13 @@ func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-routed-test-initial"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id")),
 			},
 
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id"),
@@ -66,7 +66,7 @@ func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
 					resourceFieldsEqual("vcd_network_routed_v2.net1", "data.vcd_network_routed_v2.ds", []string{"%"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id"),
@@ -74,7 +74,7 @@ func TestAccVcdNetworkRoutedV2NsxtDS(t *testing.T) {
 					resourceFieldsEqual("vcd_network_routed_v2.net1", "data.vcd_network_routed_v2.ds", []string{"%"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id"),

--- a/vcd/datasource_vcd_network_routed_v2_test.go
+++ b/vcd/datasource_vcd_network_routed_v2_test.go
@@ -57,14 +57,14 @@ func TestAccVcdNetworkRoutedV2NsxvDS(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		PreCheck:          func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_network_routed_v2.ds", "id"),
 					resource.TestCheckResourceAttr("data.vcd_network_routed_v2.ds", "id", data.network.ID),
 					resource.TestCheckResourceAttr("data.vcd_network_routed_v2.ds", "name", data.network.Name)),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_network_routed_v2.ds", "id"),

--- a/vcd/datasource_vcd_network_test.go
+++ b/vcd/datasource_vcd_network_test.go
@@ -147,7 +147,7 @@ func TestAccVcdNetworkDirectDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 
@@ -207,7 +207,7 @@ func TestAccVcdNetworkRoutedDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 
@@ -265,7 +265,7 @@ func TestAccVcdNetworkIsolatedDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 

--- a/vcd/datasource_vcd_nsxt_alb_cloud.go
+++ b/vcd/datasource_vcd_nsxt_alb_cloud.go
@@ -11,43 +11,43 @@ func datasourceVcdAlbCloud() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVcdAlbCloudRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Cloud name",
 			},
-			"controller_id": &schema.Schema{
+			"controller_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Importable Cloud ID",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Cloud description",
 			},
-			"importable_cloud_id": &schema.Schema{
+			"importable_cloud_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Importable Cloud ID",
 			},
-			"network_pool_name": &schema.Schema{
+			"network_pool_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network pool name of NSX-T ALB Cloud",
 			},
-			"network_pool_id": &schema.Schema{
+			"network_pool_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network pool ID NSX-T ALB Cloud",
 			},
-			"health_status": &schema.Schema{
+			"health_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Cloud health status",
 			},
-			"health_message": &schema.Schema{
+			"health_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Cloud detailed health message",

--- a/vcd/datasource_vcd_nsxt_alb_controller.go
+++ b/vcd/datasource_vcd_nsxt_alb_controller.go
@@ -12,32 +12,32 @@ func datasourceVcdAlbController() *schema.Resource {
 		ReadContext: datasourceVcdAlbControllerRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Controller name",
 			},
-			"url": &schema.Schema{
+			"url": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Controller URL",
 			},
-			"username": &schema.Schema{
+			"username": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Controller Username",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Controller description",
 			},
-			"license_type": &schema.Schema{
+			"license_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB License type. One of 'BASIC', 'ENTERPRISE'",
 			},
-			"version": &schema.Schema{
+			"version": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Controller version",

--- a/vcd/datasource_vcd_nsxt_alb_edgegateway_service_engine_group.go
+++ b/vcd/datasource_vcd_nsxt_alb_edgegateway_service_engine_group.go
@@ -29,7 +29,7 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroup() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -40,7 +40,7 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroup() *schema.Resource {
 			// data source would require Provider level access and this would break workflow when tenant needs to
 			// reference service engine group ID in `vcd_nsxt_alb_virtual_service`. Because of that
 			// `service_engine_group_id` and `service_engine_group_name` are both supported but only one required.
-			"service_engine_group_name": &schema.Schema{
+			"service_engine_group_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
@@ -48,7 +48,7 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroup() *schema.Resource {
 				Description:  "Service Engine Group Name which is attached to NSX-T Edge Gateway",
 				ExactlyOneOf: []string{"service_engine_group_name", "service_engine_group_id"},
 			},
-			"service_engine_group_id": &schema.Schema{
+			"service_engine_group_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
@@ -56,17 +56,17 @@ func datasourceVcdAlbEdgeGatewayServiceEngineGroup() *schema.Resource {
 				Description:  "Service Engine Group ID which is attached to NSX-T Edge Gateway",
 				ExactlyOneOf: []string{"service_engine_group_name", "service_engine_group_id"},
 			},
-			"max_virtual_services": &schema.Schema{
+			"max_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum number of virtual services to be used in this Service Engine Group",
 			},
-			"reserved_virtual_services": &schema.Schema{
+			"reserved_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of reserved virtual services for this Service Engine Group",
 			},
-			"deployed_virtual_services": &schema.Schema{
+			"deployed_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of reserved deployed virtual services for this Service Engine Group",

--- a/vcd/datasource_vcd_nsxt_alb_importable_cloud.go
+++ b/vcd/datasource_vcd_nsxt_alb_importable_cloud.go
@@ -12,34 +12,34 @@ func datasourceVcdAlbImportableCloud() *schema.Resource {
 		ReadContext: datasourceVcdAlbImportableCloudRead,
 
 		Schema: map[string]*schema.Schema{
-			"controller_id": &schema.Schema{
+			"controller_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Controller ID",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Importable Cloud Name",
 			},
-			"already_imported": &schema.Schema{
+			"already_imported": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Flags if the NSX-T ALB Importable Cloud is already imported",
 			},
-			"network_pool_name": &schema.Schema{
+			"network_pool_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network pool name of NSX-T ALB Importable Cloud",
 			},
-			"network_pool_id": &schema.Schema{
+			"network_pool_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network pool ID NSX-T ALB Importable Cloud",
 			},
-			"transport_zone_name": &schema.Schema{
+			"transport_zone_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Transport zone name NSX-T ALB Importable Cloud",

--- a/vcd/datasource_vcd_nsxt_alb_importable_cloud_test.go
+++ b/vcd/datasource_vcd_nsxt_alb_importable_cloud_test.go
@@ -42,7 +42,7 @@ func TestAccVcdNsxtAlbImportableCloudDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdAlbControllerDestroy("vcd_nsxt_alb_controller.first"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("data.vcd_nsxt_alb_importable_cloud.cld", "id", regexp.MustCompile(`\d*`)),

--- a/vcd/datasource_vcd_nsxt_alb_pool.go
+++ b/vcd/datasource_vcd_nsxt_alb_pool.go
@@ -25,39 +25,39 @@ func datasourceVcdAlbPool() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID in which ALB Pool should be created",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of ALB Pool",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if NSX-T ALB Pool is enabled or disabled",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of ALB Pool",
 			},
-			"algorithm": &schema.Schema{
+			"algorithm": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Algorithm for choosing pool members (default LEAST_CONNECTIONS)",
 			},
 
-			"default_port": &schema.Schema{
+			"default_port": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Default Port defines destination server port used by the traffic sent to the member (default 80)",
 			},
-			"graceful_timeout_period": &schema.Schema{
+			"graceful_timeout_period": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum time in minutes to gracefully disable pool member (default 1)",
@@ -68,7 +68,7 @@ func datasourceVcdAlbPool() *schema.Resource {
 				Description: "ALB Pool Members",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"enabled": &schema.Schema{
+						"enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Shows is the member is enabled or not",
@@ -114,16 +114,16 @@ func datasourceVcdAlbPool() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of health monitor",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"system_defined": &schema.Schema{
+						"system_defined": {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
@@ -135,17 +135,17 @@ func datasourceVcdAlbPool() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "System generated name of persistence profile",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Type of persistence strategy",
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Value of attribute based on persistence type",
@@ -161,7 +161,7 @@ func datasourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"cn_check_enabled": &schema.Schema{
+			"cn_check_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Boolean flag if common name check of the certificate should be enabled",
@@ -174,7 +174,7 @@ func datasourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"passive_monitoring_enabled": &schema.Schema{
+			"passive_monitoring_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
@@ -197,22 +197,22 @@ func datasourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"member_count": &schema.Schema{
+			"member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of members in the pool",
 			},
-			"up_member_count": &schema.Schema{
+			"up_member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of members in the pool serving the traffic",
 			},
-			"enabled_member_count": &schema.Schema{
+			"enabled_member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of enabled members in the pool",
 			},
-			"health_message": &schema.Schema{
+			"health_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Health message",

--- a/vcd/datasource_vcd_nsxt_alb_service_engine_group.go
+++ b/vcd/datasource_vcd_nsxt_alb_service_engine_group.go
@@ -12,53 +12,53 @@ func datasourceVcdAlbServiceEngineGroup() *schema.Resource {
 		ReadContext: datasourceVcdAlbServiceEngineGroupRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Service Engine Group name",
 			},
-			"sync_on_refresh": &schema.Schema{
+			"sync_on_refresh": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Boolean value that shows if sync should be performed on every refresh",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group description",
 			},
-			"alb_cloud_id": &schema.Schema{
+			"alb_cloud_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB backing Cloud ID",
 			},
-			"reservation_model": &schema.Schema{
+			"reservation_model": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group reservation model. One of 'DEDICATED', 'SHARED'",
 			},
-			"max_virtual_services": &schema.Schema{
+			"max_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group maximum virtual services",
 			},
-			"reserved_virtual_services": &schema.Schema{
+			"reserved_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group reserved virtual services",
 			},
-			"deployed_virtual_services": &schema.Schema{
+			"deployed_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group deployed virtual services",
 			},
-			"ha_mode": &schema.Schema{
+			"ha_mode": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group HA mode",
 			},
-			"overallocated": &schema.Schema{
+			"overallocated": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Boolean value that shows if virtual services are overallocated",

--- a/vcd/datasource_vcd_nsxt_alb_settings.go
+++ b/vcd/datasource_vcd_nsxt_alb_settings.go
@@ -25,18 +25,18 @@ func datasourceVcdAlbSettings() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID",
 			},
-			"is_active": &schema.Schema{
+			"is_active": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if ALB is enabled on Edge Gateway",
 			},
-			"service_network_specification": &schema.Schema{
+			"service_network_specification": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,

--- a/vcd/datasource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/datasource_vcd_nsxt_alb_settings_test.go
@@ -36,7 +36,7 @@ func TestAccVcdNsxtAlbSettingsDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vcd_nsxt_alb_settings.test", "is_active", "false"),

--- a/vcd/datasource_vcd_nsxt_alb_virtual_service.go
+++ b/vcd/datasource_vcd_nsxt_alb_virtual_service.go
@@ -25,28 +25,28 @@ func datasourceVcdAlbVirtualService() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID in which ALB Virtual Service is",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of ALB Virtual Service",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of ALB Virtual Service",
 			},
-			"pool_id": &schema.Schema{
+			"pool_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Pool ID to use for this Virtual Service",
 			},
-			"service_engine_group_id": &schema.Schema{
+			"service_engine_group_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Service Engine Group ID",
@@ -56,17 +56,17 @@ func datasourceVcdAlbVirtualService() *schema.Resource {
 				Computed:    true,
 				Description: "ID of certificate in library if used",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Virtual Service is enabled or disabled (default true)",
 			},
-			"virtual_ip_address": &schema.Schema{
+			"virtual_ip_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Virtual IP address (VIP) for Virtual Service",
 			},
-			"application_profile_type": &schema.Schema{
+			"application_profile_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "HTTP, HTTPS, L4, L4_TLS",
@@ -76,22 +76,22 @@ func datasourceVcdAlbVirtualService() *schema.Resource {
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_port": &schema.Schema{
+						"start_port": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Starting port in the range",
 						},
-						"end_port": &schema.Schema{
+						"end_port": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Last port in the range",
 						},
-						"ssl_enabled": &schema.Schema{
+						"ssl_enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Starting port in the range",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "One of 'TCP_PROXY', 'TCP_FAST_PATH', 'UDP_FAST_PATH'",

--- a/vcd/datasource_vcd_nsxt_edge_cluster.go
+++ b/vcd/datasource_vcd_nsxt_edge_cluster.go
@@ -21,27 +21,27 @@ func datasourceVcdNsxtEdgeCluster() *schema.Resource {
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NSX-T Edge Cluster",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of NSX-T Edge Cluster",
 			},
-			"node_count": &schema.Schema{
+			"node_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of nodes in NSX-T Edge Cluster",
 			},
-			"node_type": &schema.Schema{
+			"node_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Node type of NSX-T Edge Cluster",
 			},
-			"deployment_type": &schema.Schema{
+			"deployment_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Deployment type of NSX-T Edge Cluster",

--- a/vcd/datasource_vcd_nsxt_edge_cluster_test.go
+++ b/vcd/datasource_vcd_nsxt_edge_cluster_test.go
@@ -56,7 +56,7 @@ func TestAccVcdNsxtEdgeCluster(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// Check if result is UUID (e.g. 6c188839-ba06-4ceb-8255-2622fe69ce7c)

--- a/vcd/datasource_vcd_nsxt_firewall.go
+++ b/vcd/datasource_vcd_nsxt_firewall.go
@@ -25,49 +25,49 @@ func datasourceVcdNsxtFirewall() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge Gateway ID in which Firewall Rules are located",
 			},
-			"rule": &schema.Schema{
+			"rule": {
 				Type:        schema.TypeList, // Firewall rule order matters
 				Computed:    true,
 				Description: "List of firewall rules",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
+						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Firewall Rule ID",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Firewall Rule name",
 						},
-						"direction": &schema.Schema{
+						"direction": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "IN OUT IN_OUT",
 						},
-						"ip_protocol": &schema.Schema{
+						"ip_protocol": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "IPV4,  IPV6, IPV4_IPV6",
 						},
-						"enabled": &schema.Schema{
+						"enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Firewall Rule name",
 						},
-						"logging": &schema.Schema{
+						"logging": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Firewall Rule name",
 						},
-						"action": &schema.Schema{
+						"action": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/vcd/datasource_vcd_nsxt_ipsec_vpn_tunnel.go
+++ b/vcd/datasource_vcd_nsxt_ipsec_vpn_tunnel.go
@@ -25,33 +25,33 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which IP Sec VPN configuration is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of IP Sec VPN configuration",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enables or disables this configuration (default true)",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of NAT rule",
 			},
-			"pre_shared_key": &schema.Schema{
+			"pre_shared_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Pre-Shared Key (PSK)",
 			},
-			"local_ip_address": &schema.Schema{
+			"local_ip_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IPv4 Address for the endpoint. This has to be a sub-allocated IP on the Edge Gateway.",
@@ -64,7 +64,7 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"remote_ip_address": &schema.Schema{
+			"remote_ip_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Public IPv4 Address of the remote device terminating the VPN connection",
@@ -77,23 +77,23 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"logging": &schema.Schema{
+			"logging": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Sets whether logging for the tunnel is enabled or not. (default - false)",
 			},
-			"security_profile_customization": &schema.Schema{
+			"security_profile_customization": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Security profile customization",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"ike_version": &schema.Schema{
+						"ike_version": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "IKE version one of IKE_V1, IKE_V2, IKE_FLEX",
 						},
-						"ike_encryption_algorithms": &schema.Schema{
+						"ike_encryption_algorithms": {
 							Type:        schema.TypeSet,
 							Computed:    true,
 							Description: "Encryption algorithms. One of SHA1, SHA2_256, SHA2_384, SHA2_512",
@@ -101,7 +101,7 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_digest_algorithms": &schema.Schema{
+						"ike_digest_algorithms": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Description: "Secure hashing algorithms to use during the IKE negotiation. One of SHA1, " +
@@ -110,7 +110,7 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_dh_groups": &schema.Schema{
+						"ike_dh_groups": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Description: "Diffie-Hellman groups to be used if Perfect Forward Secrecy is enabled. One " +
@@ -119,26 +119,26 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_sa_lifetime": &schema.Schema{
+						"ike_sa_lifetime": {
 							Type:     schema.TypeInt,
 							Computed: true,
 							Description: "Security Association life time (in seconds). It is number of seconds " +
 								"before the IPsec tunnel needs to reestablish",
 						},
 
-						"tunnel_pfs_enabled": &schema.Schema{
+						"tunnel_pfs_enabled": {
 							Type:        schema.TypeBool,
 							Computed:    true,
 							Description: "Perfect Forward Secrecy Enabled or Disabled. Default (enabled)",
 						},
 
-						"tunnel_df_policy": &schema.Schema{
+						"tunnel_df_policy": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Policy for handling defragmentation bit. One of COPY, CLEAR",
 						},
 
-						"tunnel_encryption_algorithms": &schema.Schema{
+						"tunnel_encryption_algorithms": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Description: "Encryption algorithms to use in IPSec tunnel establishment. One of AES_128, " +
@@ -148,7 +148,7 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_digest_algorithms": &schema.Schema{
+						"tunnel_digest_algorithms": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Description: "Digest algorithms to be used for message digest. One of SHA1, SHA2_256, " +
@@ -157,7 +157,7 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_dh_groups": &schema.Schema{
+						"tunnel_dh_groups": {
 							Type:     schema.TypeSet,
 							Computed: true,
 							Description: "Diffie-Hellman groups to be used is PFS is enabled. One of GROUP2, GROUP5, " +
@@ -166,12 +166,12 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_sa_lifetime": &schema.Schema{
+						"tunnel_sa_lifetime": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "Security Association life time (in seconds)",
 						},
-						"dpd_probe_internal": &schema.Schema{
+						"dpd_probe_internal": {
 							Type:     schema.TypeInt,
 							Computed: true,
 							Description: "Value in seconds of dead probe detection interval. Minimum is 3 seconds and " +
@@ -180,23 +180,23 @@ func datasourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 					},
 				},
 			},
-			"security_profile": &schema.Schema{
+			"security_profile": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Security type which is use for IPsec VPN Tunnel. It will be 'DEFAULT' if nothing is " +
 					"customized and 'CUSTOM' if some changes are applied",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Overall IPsec VPN Tunnel Status",
 			},
-			"ike_service_status": &schema.Schema{
+			"ike_service_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Status for the actual IKE Session for the given tunnel",
 			},
-			"ike_fail_reason": &schema.Schema{
+			"ike_fail_reason": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Provides more details of failure if the IKE service is not UP",

--- a/vcd/datasource_vcd_nsxt_manager.go
+++ b/vcd/datasource_vcd_nsxt_manager.go
@@ -11,7 +11,7 @@ func datasourceVcdNsxtManager() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceNsxtManagerRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NSX-T manager.",

--- a/vcd/datasource_vcd_nsxt_nat.go
+++ b/vcd/datasource_vcd_nsxt_nat.go
@@ -25,68 +25,68 @@ func datasourceVcdNsxtNatRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which NAT Rule is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NAT rule",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Rule type - one of 'DNAT', 'NO_DNAT', 'SNAT', 'NO_SNAT'",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of NAT rule",
 			},
-			"external_address": &schema.Schema{
+			"external_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address or CIDR of external network",
 			},
-			"internal_address": &schema.Schema{
+			"internal_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
 			},
-			"app_port_profile_id": &schema.Schema{
+			"app_port_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Application Port Profile ID applied for this rule",
 			},
-			"dnat_external_port": &schema.Schema{
+			"dnat_external_port": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "For DNAT only. Port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
 			},
-			"snat_destination_address": &schema.Schema{
+			"snat_destination_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "For SNAT only. Limits SNAT rule by destination IP address or range in CIDR format.",
 			},
-			"logging": &schema.Schema{
+			"logging": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enable logging when this rule is applied",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Enables or disables this rule",
 			},
-			"firewall_match": &schema.Schema{
+			"firewall_match": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. One of 'MATCH_INTERNAL_ADDRESS', 'MATCH_EXTERNAL_ADDRESS', 'BYPASS'",
 			},
-			"priority": &schema.Schema{
+			"priority": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "VCD 10.2.2+ If an address has multiple NAT rules, the rule with the highest priority is applied. A lower value means a higher precedence for this rule.",

--- a/vcd/datasource_vcd_nsxt_network_dhcp.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp.go
@@ -9,12 +9,12 @@ import (
 
 var datasourceNsxtDhcpPoolSetSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"start_address": &schema.Schema{
+		"start_address": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Start address of DHCP pool IP range",
 		},
-		"end_address": &schema.Schema{
+		"end_address": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "End address of DHCP pool IP range",
@@ -40,13 +40,13 @@ func datasourceVcdOpenApiDhcp() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"org_network_id": &schema.Schema{
+			"org_network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Parent Org VDC network name",
 			},
-			"pool": &schema.Schema{
+			"pool": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "IP ranges used for DHCP pool allocation in the network",

--- a/vcd/datasource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/datasource_vcd_nsxt_network_dhcp_test.go
@@ -42,7 +42,7 @@ func TestAccVcdOpenApiDhcpNsxtRoutedDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-routed-dhcp"),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // Define network and DHCP pools
+			{ // Define network and DHCP pools
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
@@ -52,7 +52,7 @@ func TestAccVcdOpenApiDhcpNsxtRoutedDS(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),

--- a/vcd/datasource_vcd_nsxt_network_imported.go
+++ b/vcd/datasource_vcd_nsxt_network_imported.go
@@ -36,13 +36,13 @@ func datasourceVcdNsxtNetworkImported() *schema.Resource {
 				Description:   "ID of VDC or VDC Group",
 				ConflictsWith: []string{"vdc"},
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "filter"},
 				Description:  "A unique name for this network (optional if 'filter' is used)",
 			},
-			"filter": &schema.Schema{
+			"filter": {
 				Type:         schema.TypeList,
 				MaxItems:     1,
 				MinItems:     1,
@@ -56,42 +56,42 @@ func datasourceVcdNsxtNetworkImported() *schema.Resource {
 					},
 				},
 			},
-			"nsxt_logical_switch_id": &schema.Schema{
+			"nsxt_logical_switch_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "ID of existing NSX-T Logical Switch",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network description",
 			},
-			"gateway": &schema.Schema{
+			"gateway": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Gateway IP address",
 			},
-			"prefix_length": &schema.Schema{
+			"prefix_length": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Network prefix",
 			},
-			"dns1": &schema.Schema{
+			"dns1": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "DNS server 1",
 			},
-			"dns2": &schema.Schema{
+			"dns2": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "DNS server 1",
 			},
-			"dns_suffix": &schema.Schema{
+			"dns_suffix": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "DNS suffix",
 			},
-			"static_ip_pool": &schema.Schema{
+			"static_ip_pool": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "IP ranges used for static pool allocation in the network",

--- a/vcd/datasource_vcd_nsxt_network_imported_test.go
+++ b/vcd/datasource_vcd_nsxt_network_imported_test.go
@@ -54,13 +54,13 @@ func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-imported-test-initial"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_network_imported.net1", "id")),
 			},
 
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_network_imported.net1", "id"),
@@ -68,7 +68,7 @@ func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxt_network_imported.net1", "data.vcd_nsxt_network_imported.ds", []string{"%", "nsxt_logical_switch_name"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_network_imported.net1", "id"),
@@ -76,7 +76,7 @@ func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxt_network_imported.net1", "data.vcd_nsxt_network_imported.ds", []string{"%", "nsxt_logical_switch_name"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_network_imported.net1", "id"),

--- a/vcd/datasource_vcd_nsxv_dhcp_relay.go
+++ b/vcd/datasource_vcd_nsxv_dhcp_relay.go
@@ -21,7 +21,7 @@ func datasourceVcdNsxvDhcpRelay() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/vcd/datasource_vcd_nsxv_dnat.go
+++ b/vcd/datasource_vcd_nsxv_dnat.go
@@ -21,64 +21,64 @@ func datasourceVcdNsxvDnat() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the NAT rule is located",
 			},
-			"rule_id": &schema.Schema{
+			"rule_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NAT rule ID for lookup",
 			},
-			"network_name": &schema.Schema{
+			"network_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Org or external network name",
 			},
-			"network_type": &schema.Schema{
+			"network_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network type. One of 'ext', 'org'",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Possible values 'user', 'internal_high'",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Custom rule tag. Contains rule ID if tag was not set",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if the rule is enabled",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if logging is enabled for the rule",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NAT rule description",
 			},
-			"original_address": &schema.Schema{
+			"original_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Original address or address range. This is the " +
 					"the destination address for DNAT rules.",
 			},
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Protocol. One of 'tcp', 'udp', 'icmp', 'any'",
 			},
-			"icmp_type": &schema.Schema{
+			"icmp_type": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "ICMP type. Only supported when protocol is ICMP. One of `any`, " +
@@ -86,17 +86,17 @@ func datasourceVcdNsxvDnat() *schema.Resource {
 					"`echo-reply`, `parameter-problem`, `redirect`, `router-advertisement`, `router-solicitation`, " +
 					"`source-quench`, `time-exceeded`, `timestamp-request`, `timestamp-reply`. Default `any`",
 			},
-			"original_port": &schema.Schema{
+			"original_port": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Original port. This is the destinationport for DNAT rules",
 			},
-			"translated_address": &schema.Schema{
+			"translated_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Translated address or address range",
 			},
-			"translated_port": &schema.Schema{
+			"translated_port": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Translated port",

--- a/vcd/datasource_vcd_nsxv_firewall.go
+++ b/vcd/datasource_vcd_nsxv_firewall.go
@@ -19,42 +19,42 @@ func datasourceVcdNsxvFirewallRule() *schema.Resource {
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Edge gateway name in which the firewall rule is located",
 			},
-			"rule_id": &schema.Schema{
+			"rule_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Firewall rule ID for lookup",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Firewall rule name",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Read only. Possible values 'user', 'internal_high'",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Optional. Allows to set custom rule tag",
 			},
-			"action": &schema.Schema{
+			"action": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "'accept' or 'deny'. Default 'accept'",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether the rule should be enabled. Default 'true'",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether logging should be enabled for this rule. Default 'false'",

--- a/vcd/datasource_vcd_nsxv_snat.go
+++ b/vcd/datasource_vcd_nsxv_snat.go
@@ -21,59 +21,59 @@ func datasourceVcdNsxvSnat() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the NAT rule is located",
 			},
-			"rule_id": &schema.Schema{
+			"rule_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NAT rule ID for lookup",
 			},
-			"network_name": &schema.Schema{
+			"network_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Org or external network name",
 			},
-			"network_type": &schema.Schema{
+			"network_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network type. One of 'ext', 'org'",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Possible values 'user', 'internal_high'.",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Custom rule tag. Contains rule ID if tag was not set",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if the rule is enabled",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Defines if logging is enabled for the rule",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NAT rule description",
 			},
-			"original_address": &schema.Schema{
+			"original_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Original address or address range. This is the " +
 					"the source address for SNAT rules",
 			},
-			"translated_address": &schema.Schema{
+			"translated_address": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Translated address or address range",

--- a/vcd/datasource_vcd_org_group.go
+++ b/vcd/datasource_vcd_org_group.go
@@ -2,6 +2,7 @@ package vcd
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -68,7 +69,7 @@ func datasourceVcdOrgGroupRead(_ context.Context, d *schema.ResourceData, meta i
 	for _, userRef := range orgGroup.Group.UsersList.UserReference {
 		users = append(users, userRef.Name)
 	}
-	err = d.Set("user_names", convertStringsTotTypeSet(users))
+	err = d.Set("user_names", convertStringsToTypeSet(users))
 	if err != nil {
 		return diag.Errorf("could not set user_names field: %s", err)
 	}

--- a/vcd/datasource_vcd_org_vdc.go
+++ b/vcd/datasource_vcd_org_vdc.go
@@ -44,20 +44,20 @@ func datasourceVcdOrgVdc() *schema.Resource {
 				Optional:    true,
 				Description: "Organization to create the VDC in",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"allocation_model": &schema.Schema{
+			"allocation_model": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool, Flex}",
 			},
-			"compute_capacity": &schema.Schema{
+			"compute_capacity": {
 				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{
@@ -68,27 +68,27 @@ func datasourceVcdOrgVdc() *schema.Resource {
 				},
 				Description: "The compute capacity allocated to this VDC.",
 			},
-			"nic_quota": &schema.Schema{
+			"nic_quota": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.",
 			},
-			"network_quota": &schema.Schema{
+			"network_quota": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.",
 			},
-			"vm_quota": &schema.Schema{
+			"vm_quota": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this VDC is enabled for use by the organization VDCs. Default is true.",
 			},
-			"storage_profile": &schema.Schema{
+			"storage_profile": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
@@ -122,63 +122,63 @@ func datasourceVcdOrgVdc() *schema.Resource {
 				},
 				Description: "Storage profiles supported by this VDC.",
 			},
-			"memory_guaranteed": &schema.Schema{
+			"memory_guaranteed": {
 				Type:     schema.TypeFloat,
 				Computed: true,
 				Description: "Percentage of allocated memory resources guaranteed to vApps deployed in this VDC. " +
 					"For example, if this value is 0.75, then 75% of allocated resources are guaranteed. " +
 					"Required when AllocationModel is AllocationVApp or AllocationPool. When Allocation model is AllocationPool minimum value is 0.2. If the element is empty, vCD sets a value.",
 			},
-			"cpu_guaranteed": &schema.Schema{
+			"cpu_guaranteed": {
 				Type:     schema.TypeFloat,
 				Computed: true,
 				Description: "Percentage of allocated CPU resources guaranteed to vApps deployed in this VDC. " +
 					"For example, if this value is 0.75, then 75% of allocated resources are guaranteed. " +
 					"Required when AllocationModel is AllocationVApp or AllocationPool. If the element is empty, vCD sets a value",
 			},
-			"cpu_speed": &schema.Schema{
+			"cpu_speed": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Specifies the clock frequency, in Megahertz, for any virtual CPU that is allocated to a VM. A VM with 2 vCPUs will consume twice as much of this value. Ignored for ReservationPool. Required when AllocationModel is AllocationVApp or AllocationPool, and may not be less than 256 MHz. Defaults to 1000 MHz if the element is empty or missing.",
 			},
-			"enable_thin_provisioning": &schema.Schema{
+			"enable_thin_provisioning": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Boolean to request thin provisioning. Request will be honored only if the underlying datastore supports it. Thin provisioning saves storage space by committing it on demand. This allows over-allocation of storage.",
 			},
-			"network_pool_name": &schema.Schema{
+			"network_pool_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The name of a network pool in the Provider VDC. Required if this VDC will contain routed or isolated networks.",
 			},
-			"provider_vdc_name": &schema.Schema{
+			"provider_vdc_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "A reference to the Provider VDC from which this organization VDC is provisioned.",
 			},
-			"enable_fast_provisioning": &schema.Schema{
+			"enable_fast_provisioning": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Request for fast provisioning. Request will be honored only if the underlying datas tore supports it. Fast provisioning can reduce the time it takes to create virtual machines by using vSphere linked clones. If you disable fast provisioning, all provisioning operations will result in full clones.",
 			},
 			//  Always null in the response to a GET request. On update, set to false to disallow the update if the AllocationModel is AllocationPool or ReservationPool
 			//  and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Defaults to true if empty or missing.
-			"allow_over_commit": &schema.Schema{
+			"allow_over_commit": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Set to false to disallow creation of the VDC if the AllocationModel is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Default is true.",
 			},
-			"enable_vm_discovery": &schema.Schema{
+			"enable_vm_discovery": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this VDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
 			},
-			"elasticity": &schema.Schema{
+			"elasticity": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if the Flex VDC is elastic.",
 			},
-			"include_vm_memory_overhead": &schema.Schema{
+			"include_vm_memory_overhead": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if the Flex VDC includes memory overhead into its accounting for admission control.",
@@ -196,7 +196,7 @@ func datasourceVcdOrgVdc() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"default_vm_sizing_policy_id": &schema.Schema{
+			"default_vm_sizing_policy_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "ID of default VM sizing policy ID",

--- a/vcd/datasource_vcd_org_vdc_test.go
+++ b/vcd/datasource_vcd_org_vdc_test.go
@@ -80,7 +80,7 @@ func validateResourceAndDataSource(t *testing.T, configText string, datasourceVd
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVdcExists("vcd_org_vdc."+vdcName),
@@ -131,7 +131,7 @@ func validateDataSource(t *testing.T, configText string, datasourceVdc string) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data."+datasourceVdc, "name", testConfig.VCD.Vdc),

--- a/vcd/datasource_vcd_portgroup.go
+++ b/vcd/datasource_vcd_portgroup.go
@@ -13,12 +13,12 @@ func datasourceVcdPortgroup() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourcePortgroupRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NSX-T Tier-0 router.",
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Portgroup type. One of 'NETWORK', 'DV_PORTGROUP'",

--- a/vcd/datasource_vcd_resource_list.go
+++ b/vcd/datasource_vcd_resource_list.go
@@ -47,17 +47,17 @@ func datasourceVcdResourceList() *schema.Resource {
 				Optional:    true,
 				Description: "The name of the parent to the resources being retrieved",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique name of the Info",
 			},
-			"resource_type": &schema.Schema{
+			"resource_type": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Which resource we should list",
 			},
-			"list": &schema.Schema{
+			"list": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Holds the list of requested resources",
@@ -65,7 +65,7 @@ func datasourceVcdResourceList() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"list_mode": &schema.Schema{
+			"list_mode": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "name",
@@ -79,7 +79,7 @@ func datasourceVcdResourceList() *schema.Resource {
 					"hierarchy", // The list will contain parent names + resource name for each item
 				}, true),
 			},
-			"name_id_separator": &schema.Schema{
+			"name_id_separator": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "  ",

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -130,7 +130,7 @@ func runResourceInfoTest(def listDef, t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vcd_resource_list."+def.name, "name", def.name),

--- a/vcd/datasource_vcd_resource_schema.go
+++ b/vcd/datasource_vcd_resource_schema.go
@@ -15,37 +15,37 @@ func datasourceVcdResourceSchema() *schema.Resource {
 		Description: "Attributes of the resource",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"name": &schema.Schema{
+				"name": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "attribute name",
 				},
-				"type": &schema.Schema{
+				"type": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "attribute type",
 				},
-				"description": &schema.Schema{
+				"description": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "attribute description",
 				},
-				"required": &schema.Schema{
+				"required": {
 					Type:        schema.TypeBool,
 					Computed:    true,
 					Description: "Is the attribute required",
 				},
-				"computed": &schema.Schema{
+				"computed": {
 					Type:        schema.TypeBool,
 					Computed:    true,
 					Description: "Is the attribute computed",
 				},
-				"optional": &schema.Schema{
+				"optional": {
 					Type:        schema.TypeBool,
 					Computed:    true,
 					Description: "Is the attribute optional",
 				},
-				"sensitive": &schema.Schema{
+				"sensitive": {
 					Type:        schema.TypeBool,
 					Computed:    true,
 					Description: "Is the attribute sensitive",
@@ -56,28 +56,28 @@ func datasourceVcdResourceSchema() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVcdResourceSchemaRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique name of the structure",
 			},
-			"resource_type": &schema.Schema{
+			"resource_type": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Which resource we should list",
 			},
 			"attributes": &Attribute,
-			"block_attributes": &schema.Schema{
+			"block_attributes": {
 				Computed: true,
 				Type:     schema.TypeSet,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Name of the Block",
 						},
-						"nesting_mode": &schema.Schema{
+						"nesting_mode": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "How the block is nested",

--- a/vcd/datasource_vcd_resource_schema_test.go
+++ b/vcd/datasource_vcd_resource_schema_test.go
@@ -38,7 +38,7 @@ func runResourceSchemaTest(name string, t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(

--- a/vcd/datasource_vcd_right.go
+++ b/vcd/datasource_vcd_right.go
@@ -11,32 +11,32 @@ func datasourceVcdRight() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceRightRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of Right.",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Right description",
 			},
-			"category_id": &schema.Schema{
+			"category_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "ID of the category for this right",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"right_type": &schema.Schema{
+			"right_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Type of the right",
 			},
-			"implied_rights": &schema.Schema{
+			"implied_rights": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of rights that are implied with this one",

--- a/vcd/datasource_vcd_rights_bundle.go
+++ b/vcd/datasource_vcd_rights_bundle.go
@@ -11,38 +11,38 @@ func datasourceVcdRightsBundle() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceRightsBundleRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of rights bundle.",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Rights bundle description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this rights bundle is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of rights assigned to this rights bundle",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"publish_to_all_tenants": &schema.Schema{
+			"publish_to_all_tenants": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "When true, publishes the global role to all tenants",
 			},
-			"tenants": &schema.Schema{
+			"tenants": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of tenants to which this rights bundle is published",

--- a/vcd/datasource_vcd_rights_container_test.go
+++ b/vcd/datasource_vcd_rights_container_test.go
@@ -187,7 +187,7 @@ func TestAccVcdRightsContainers(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists(datasourceRoleDef),

--- a/vcd/datasource_vcd_role.go
+++ b/vcd/datasource_vcd_role.go
@@ -11,7 +11,7 @@ func datasourceVcdRole() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceRoleRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of Role.",
@@ -22,22 +22,22 @@ func datasourceVcdRole() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Role description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this role is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "list of rights assigned to this role",

--- a/vcd/datasource_vcd_vapp.go
+++ b/vcd/datasource_vcd_vapp.go
@@ -53,18 +53,18 @@ func datasourceVcdVApp() *schema.Resource {
 				Computed:    true,
 				Description: "Shows the status of the vApp",
 			},
-			"lease": &schema.Schema{
+			"lease": {
 				Type:        schema.TypeList,
 				Computed:    true,
 				Description: "Defines lease parameters for this vApp",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"runtime_lease_in_sec": &schema.Schema{
+						"runtime_lease_in_sec": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires",
 						},
-						"storage_lease_in_sec": &schema.Schema{
+						"storage_lease_in_sec": {
 							Type:        schema.TypeInt,
 							Computed:    true,
 							Description: "How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires",

--- a/vcd/datasource_vcd_vapp_network.go
+++ b/vcd/datasource_vcd_vapp_network.go
@@ -8,12 +8,12 @@ func datasourceVcdVappNetwork() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceVappNetworkRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "vApp network name",
 			},
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "vApp to use",
@@ -29,41 +29,41 @@ func datasourceVcdVappNetwork() *schema.Resource {
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Optional description for the network",
 			},
-			"netmask": &schema.Schema{
+			"netmask": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Netmask address for a subnet",
 			},
-			"gateway": &schema.Schema{
+			"gateway": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Gateway of the network",
 			},
 
-			"dns1": &schema.Schema{
+			"dns1": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Primary DNS server",
 			},
 
-			"dns2": &schema.Schema{
+			"dns2": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Secondary DNS server",
 			},
 
-			"dns_suffix": &schema.Schema{
+			"dns_suffix": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "DNS suffix",
 			},
 
-			"guest_vlan_allowed": &schema.Schema{
+			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if Network allows guest VLAN tagging",
@@ -78,33 +78,33 @@ func datasourceVcdVappNetwork() *schema.Resource {
 				Computed:    true,
 				Description: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments.",
 			},
-			"dhcp_pool": &schema.Schema{
+			"dhcp_pool": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "A range of IPs to issue to virtual machines that don't have a static IP",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_address": &schema.Schema{
+						"start_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 
-						"end_address": &schema.Schema{
+						"end_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 
-						"default_lease_time": &schema.Schema{
+						"default_lease_time": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
 
-						"max_lease_time": &schema.Schema{
+						"max_lease_time": {
 							Type:     schema.TypeInt,
 							Computed: true,
 						},
 
-						"enabled": &schema.Schema{
+						"enabled": {
 							Type:     schema.TypeBool,
 							Computed: true,
 						},
@@ -112,18 +112,18 @@ func datasourceVcdVappNetwork() *schema.Resource {
 				},
 				Set: resourceVcdDhcpPoolHash,
 			},
-			"static_ip_pool": &schema.Schema{
+			"static_ip_pool": {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "A range of IPs permitted to be used as static IPs for virtual machines",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_address": &schema.Schema{
+						"start_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
 
-						"end_address": &schema.Schema{
+						"end_address": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/vcd/datasource_vcd_vapp_network_test.go
+++ b/vcd/datasource_vcd_vapp_network_test.go
@@ -66,7 +66,7 @@ func TestAccVcdVappNetworkDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("netmask", netmask),

--- a/vcd/datasource_vcd_vapp_org_network.go
+++ b/vcd/datasource_vcd_vapp_org_network.go
@@ -8,33 +8,33 @@ func datasourceVcdVappOrgNetwork() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceVappOrgNetworkRead,
 		Schema: map[string]*schema.Schema{
-			"org": &schema.Schema{
+			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "vApp name",
 			},
-			"org_network_name": &schema.Schema{
+			"org_network_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Organization network name to which vApp network is connected to",
 			},
-			"is_fenced": &schema.Schema{
+			"is_fenced": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Fencing allows identical virtual machines in different vApp networks connect to organization VDC networks that are accessed in this vApp",
 			},
-			"retain_ip_mac_enabled": &schema.Schema{
+			"retain_ip_mac_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments.",

--- a/vcd/datasource_vcd_vapp_org_network_test.go
+++ b/vcd/datasource_vcd_vapp_org_network_test.go
@@ -40,7 +40,7 @@ func TestAccVcdVappOrgNetworkDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckVappOrgNetworkNonStringOutputs(retainIpMacEnabled),

--- a/vcd/datasource_vcd_vapp_test.go
+++ b/vcd/datasource_vcd_vapp_test.go
@@ -76,7 +76,7 @@ func TestAccVcdVappDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 

--- a/vcd/datasource_vcd_vapp_vm.go
+++ b/vcd/datasource_vcd_vapp_vm.go
@@ -12,19 +12,19 @@ import (
 
 func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"vapp_name": &schema.Schema{
+		"vapp_name": {
 			Type:        schema.TypeString,
 			Required:    vmType == vappVmType,
 			Optional:    vmType == standaloneVmType,
 			Computed:    vmType == standaloneVmType,
 			Description: "The vApp this VM belongs to - Required, unless it is a standalone VM",
 		},
-		"vm_type": &schema.Schema{
+		"vm_type": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: fmt.Sprintf("Type of VM: either '%s' or '%s'", vappVmType, standaloneVmType),
 		},
-		"name": &schema.Schema{
+		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "A name for the VM, unique within the vApp",
@@ -40,68 +40,68 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 			Optional:    true,
 			Description: "The name of VDC to use, optional if defined at provider level",
 		},
-		"computer_name": &schema.Schema{
+		"computer_name": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Computer name assigned to this virtual machine",
 		},
-		"description": &schema.Schema{
+		"description": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "The VM description",
 			// Currently, this field has the description of the OVA used to create the VM
 		},
-		"memory": &schema.Schema{
+		"memory": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The amount of RAM (in MB) to allocate to the VM",
 		},
-		"memory_reservation": &schema.Schema{
+		"memory_reservation": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The amount of RAM (in MB) reservation on the underlying virtualization infrastructure",
 		},
-		"memory_priority": &schema.Schema{
+		"memory_priority": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload",
 		},
-		"memory_shares": &schema.Schema{
+		"memory_shares": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "Custom priority for the resource",
 		},
-		"memory_limit": &schema.Schema{
+		"memory_limit": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The limit for how much of memory can be consumed on the underlying virtualization infrastructure. This is only valid when the resource allocation is not unlimited",
 		},
-		"cpus": &schema.Schema{
+		"cpus": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The number of virtual CPUs to allocate to the VM",
 		},
-		"cpu_cores": &schema.Schema{
+		"cpu_cores": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The number of cores per socket",
 		},
-		"cpu_reservation": &schema.Schema{
+		"cpu_reservation": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The amount of MHz reservation on the underlying virtualization infrastructure",
 		},
-		"cpu_priority": &schema.Schema{
+		"cpu_priority": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload",
 		},
-		"cpu_shares": &schema.Schema{
+		"cpu_shares": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "Custom priority for the resource",
 		},
-		"cpu_limit": &schema.Schema{
+		"cpu_limit": {
 			Type:        schema.TypeInt,
 			Computed:    true,
 			Description: "The limit for how much of CPU can be consumed on the underlying virtualization infrastructure. This is only valid when the resource allocation is not unlimited",
@@ -111,22 +111,22 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 			Computed:    true,
 			Description: "Key value map of metadata to assign to this VM",
 		},
-		"href": &schema.Schema{
+		"href": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "VM Hyper Reference",
 		},
-		"storage_profile": &schema.Schema{
+		"storage_profile": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Storage profile used with the VM",
 		},
-		"os_type": &schema.Schema{
+		"os_type": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Operating System type.",
 		},
-		"hardware_version": &schema.Schema{
+		"hardware_version": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "Virtual Hardware Version.",
@@ -254,14 +254,14 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 					Computed:    true,
 					Description: "Specifies the IOPS for the disk. Default is 0.",
 				},
-				"storage_profile": &schema.Schema{
+				"storage_profile": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "Storage profile to override the VM default one",
 				},
 			}},
 		},
-		"expose_hardware_virtualization": &schema.Schema{
+		"expose_hardware_virtualization": {
 			Type:        schema.TypeBool,
 			Computed:    true,
 			Description: "Expose hardware-assisted CPU virtualization to guest OS.",
@@ -272,7 +272,7 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 			Description: "Key/value settings for guest properties",
 		},
 
-		"customization": &schema.Schema{
+		"customization": {
 			Computed:    true,
 			Type:        schema.TypeList,
 			Description: "Guest customization block",
@@ -350,7 +350,7 @@ func vcdVmDS(vmType typeOfVm) map[string]*schema.Schema {
 						Computed:    true,
 						Description: "Account organizational unit for domain name join",
 					},
-					"initscript": &schema.Schema{
+					"initscript": {
 						Type:        schema.TypeString,
 						Computed:    true,
 						Description: "Script to run on initial boot or with customization.force=true set",

--- a/vcd/datasource_vcd_vapp_vm_test.go
+++ b/vcd/datasource_vcd_vapp_vm_test.go
@@ -34,7 +34,7 @@ func TestAccVcdVappVmDS(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "web1"),

--- a/vcd/datasource_vcd_vm_affinity_rule.go
+++ b/vcd/datasource_vcd_vm_affinity_rule.go
@@ -21,29 +21,29 @@ func datasourceVcdVmAffinityRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: []string{"name", "rule_id"},
 				Description:  "VM affinity rule name. Used to retrieve a rule only when the name is unique",
 			},
-			"rule_id": &schema.Schema{
+			"rule_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "VM affinity rule ID. It's the preferred way of identifying a rule",
 			},
-			"polarity": &schema.Schema{
+			"polarity": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "One of 'Affinity', 'Anti-Affinity'",
 			},
-			"required": &schema.Schema{
+			"required": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Description: "True if this affinity rule is required. When a rule is mandatory, " +
 					"a host failover will not power on the VM if doing so would violate the rule",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this affinity rule is enabled",

--- a/vcd/datasource_vcd_vm_sizing_policy.go
+++ b/vcd/datasource_vcd_vm_sizing_policy.go
@@ -16,15 +16,15 @@ func datasourceVcdVmSizingPolicy() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"cpu": &schema.Schema{
+			"cpu": {
 				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{
@@ -62,7 +62,7 @@ func datasourceVcdVmSizingPolicy() *schema.Resource {
 					},
 				},
 			},
-			"memory": &schema.Schema{
+			"memory": {
 				Computed: true,
 				Type:     schema.TypeList,
 				Elem: &schema.Resource{

--- a/vcd/datasource_vcenter.go
+++ b/vcd/datasource_vcenter.go
@@ -14,33 +14,33 @@ func datasourceVcdVcenter() *schema.Resource {
 	return &schema.Resource{
 		Read: datasourceVcenterRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of vCenter.",
 			},
-			"vcenter_version": &schema.Schema{
+			"vcenter_version": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "vCenter version",
 			},
-			"vcenter_host": &schema.Schema{
+			"vcenter_host": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "vCenter hostname",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "vCenter status",
 			},
-			"is_enabled": &schema.Schema{
+			"is_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "vCenter version",
 			},
 			// In UI this field is called `connection`, but it is a reserved field in Terrraform
-			"connection_status": &schema.Schema{
+			"connection_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "vCenter connection state",

--- a/vcd/datasource_vcenter_test.go
+++ b/vcd/datasource_vcenter_test.go
@@ -30,7 +30,7 @@ func TestAccVcdVcenter(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("data.vcd_vcenter.vc", "id", regexp.MustCompile("^urn:vcloud:vimserver:.*")),

--- a/vcd/filter.go
+++ b/vcd/filter.go
@@ -59,23 +59,23 @@ var (
 		Description: "metadata filter",
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"key": &schema.Schema{
+				"key": {
 					Type:        schema.TypeString,
 					Required:    true,
 					Description: "Metadata key (field name)",
 				},
-				"is_system": &schema.Schema{
+				"is_system": {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "True if is a metadata@SYSTEM key",
 				},
-				"value": &schema.Schema{
+				"value": {
 					Type:         schema.TypeString,
 					Required:     true,
 					Description:  `Metadata value (can be a regular expression if "use_api_search" is false)`,
 					ValidateFunc: validation.StringIsValidRegExp,
 				},
-				"type": &schema.Schema{
+				"type": {
 					Type:         schema.TypeString,
 					Optional:     true,
 					Default:      "STRING",
@@ -86,7 +86,7 @@ var (
 				// The default behavior is to fetch all items, including the metadata info, and filter it
 				// via regular expressions. The search by API is faster, although more strict: field types need
 				// to be provided, searches only for exact matches.
-				"use_api_search": &schema.Schema{
+				"use_api_search": {
 					Type:        schema.TypeBool,
 					Optional:    true,
 					Description: "If true, will search the vCD using native metadata query (without regular expressions)",

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -63,7 +63,7 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVdcExists("vcd_org_vdc."+params["VdcName"].(string)),
@@ -119,7 +119,7 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 						resourceDef, "include_vm_memory_overhead", regexp.MustCompile(`^`+params["MemoryOverheadValueForAssert"].(string)+`$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateText,
 				Check: resource.ComposeTestCheckFunc(
 					testVcdVdcUpdated("vcd_org_vdc."+params["VdcName"].(string)),
@@ -195,7 +195,7 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 				),
 			},
 			// Test removal of second storage profile
-			resource.TestStep{
+			{
 				Config: secondUpdateText,
 				// This test runs only if we have a second storage profile
 				Check: testConditionalCheck(secondStorageProfile != "", resource.ComposeTestCheckFunc(
@@ -210,7 +210,7 @@ func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 					}),
 				)),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_org_vdc." + params["VdcName"].(string),
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -168,103 +168,103 @@ var globalResourceMap = map[string]*schema.Resource{
 func Provider() *schema.Provider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"user": &schema.Schema{
+			"user": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_USER", nil),
 				Description: "The user name for VCD API operations.",
 			},
 
-			"password": &schema.Schema{
+			"password": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_PASSWORD", nil),
 				Description: "The user password for VCD API operations.",
 			},
-			"auth_type": &schema.Schema{
+			"auth_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("VCD_AUTH_TYPE", "integrated"),
 				Description:  "'integrated', 'saml_adfs', 'token', and 'api_token' are the only ones supported now. 'integrated' is default.",
 				ValidateFunc: validation.StringInSlice([]string{"integrated", "saml_adfs", "token", "api_token"}, false),
 			},
-			"saml_adfs_rpt_id": &schema.Schema{
+			"saml_adfs_rpt_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_SAML_ADFS_RPT_ID", nil),
 				Description: "Allows to specify custom Relaying Party Trust Identifier for auth_type=saml_adfs",
 			},
 
-			"token": &schema.Schema{
+			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_TOKEN", nil),
 				Description: "The token used instead of username/password for VCD API operations.",
 			},
 
-			"api_token": &schema.Schema{
+			"api_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_API_TOKEN", nil),
 				Description: "The API token used instead of username/password for VCD API operations. (Requires VCD 10.3.1+)",
 			},
 
-			"sysorg": &schema.Schema{
+			"sysorg": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_SYS_ORG", nil),
 				Description: "The VCD Org for user authentication",
 			},
 
-			"org": &schema.Schema{
+			"org": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_ORG", nil),
 				Description: "The VCD Org for API operations",
 			},
 
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_VDC", nil),
 				Description: "The VDC for API operations",
 			},
 
-			"url": &schema.Schema{
+			"url": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_URL", nil),
 				Description: "The VCD url for VCD API operations.",
 			},
 
-			"max_retry_timeout": &schema.Schema{
+			"max_retry_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_MAX_RETRY_TIMEOUT", 60),
 				Description: "Max num seconds to wait for successful response when operating on resources within vCloud (defaults to 60)",
 			},
 
-			"allow_unverified_ssl": &schema.Schema{
+			"allow_unverified_ssl": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_ALLOW_UNVERIFIED_SSL", false),
 				Description: "If set, VCDClient will permit unverifiable SSL certificates.",
 			},
 
-			"logging": &schema.Schema{
+			"logging": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_API_LOGGING", false),
 				Description: "If set, it will enable logging of API requests and responses",
 			},
 
-			"logging_file": &schema.Schema{
+			"logging_file": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_API_LOGGING_FILE", "go-vcloud-director.log"),
 				Description: "Defines the full name of the logging file for API calls (requires 'logging')",
 			},
-			"import_separator": &schema.Schema{
+			"import_separator": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VCD_IMPORT_SEPARATOR", "."),

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -31,47 +31,47 @@ func resourceVcdCatalogItem() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"catalog": &schema.Schema{
+			"catalog": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "catalog name where upload the OVA file",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "catalog item name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"created": &schema.Schema{
+			"created": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Time stamp of when the item was created",
 			},
-			"ova_path": &schema.Schema{
+			"ova_path": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{"ova_path", "ovf_url"},
 				Description:  "Absolute or relative path to OVA",
 			},
-			"ovf_url": &schema.Schema{
+			"ovf_url": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ExactlyOneOf: []string{"ova_path", "ovf_url"},
 				Description:  "URL of OVF file",
 			},
-			"upload_piece_size": &schema.Schema{
+			"upload_piece_size": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     1,
 				Description: "size of upload file piece size in mega bytes",
 			},
-			"show_upload_progress": &schema.Schema{
+			"show_upload_progress": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "shows upload progress in stdout",

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -76,7 +76,7 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckCatalogItemDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogItemExists("vcd_catalog_item."+TestAccVcdCatalogItem),
@@ -90,7 +90,7 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 						resourceCatalogItem, "metadata.catalogItem_metadata2", "catalogItem Metadata2"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateConfigText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogItemExists("vcd_catalog_item."+TestAccVcdCatalogItem),
@@ -106,7 +106,7 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.catalogItem_metadata3", "catalogItem Metadata3"),
 				),
 			},
-			resource.TestStep{
+			{
 				SkipFunc: func() (bool, error) { return skipOnVcd1020, nil },
 				Config:   fromUrlConfigText,
 				Check: resource.ComposeTestCheckFunc(
@@ -123,7 +123,7 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata3", "catalogItem Metadata3"),
 				),
 			},
-			resource.TestStep{
+			{
 				SkipFunc: func() (bool, error) { return skipOnVcd1020, nil },
 				Config:   fromUrlConfigTextUpdate,
 				Check: resource.ComposeTestCheckFunc(

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -32,37 +32,37 @@ func resourceVcdCatalogMedia() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"catalog": &schema.Schema{
+			"catalog": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "catalog name where upload the Media file",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "media name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"media_path": &schema.Schema{
+			"media_path": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "absolute or relative path to Media file",
 			},
-			"upload_piece_size": &schema.Schema{
+			"upload_piece_size": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     1,
 				Description: "size of upload file piece size in mega bytes",
 			},
-			"show_upload_progress": &schema.Schema{
+			"show_upload_progress": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
@@ -75,37 +75,37 @@ func resourceVcdCatalogMedia() *schema.Resource {
 				// For now underlying go-vcloud-director repo only supports
 				// a value of type String in this map.
 			},
-			"is_iso": &schema.Schema{
+			"is_iso": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this media file is ISO",
 			},
-			"owner_name": &schema.Schema{
+			"owner_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Owner name",
 			},
-			"is_published": &schema.Schema{
+			"is_published": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "True if this media file is in a published catalog",
 			},
-			"creation_date": &schema.Schema{
+			"creation_date": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Creation date",
 			},
-			"size": &schema.Schema{
+			"size": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Media storage in Bytes",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Media status",
 			},
-			"storage_profile_name": &schema.Schema{
+			"storage_profile_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Storage profile name",

--- a/vcd/resource_vcd_catalog_media_test.go
+++ b/vcd/resource_vcd_catalog_media_test.go
@@ -43,7 +43,7 @@ func TestAccVcdCatalogMediaBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckCatalogMediaDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogMediaExists("vcd_catalog_media."+TestAccVcdCatalogMedia),
@@ -62,7 +62,7 @@ func TestAccVcdCatalogMediaBasic(t *testing.T) {
 					testCheckMediaNonStringOutputs(),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateConfigText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogMediaExists("vcd_catalog_media."+TestAccVcdCatalogMedia),
@@ -78,7 +78,7 @@ func TestAccVcdCatalogMediaBasic(t *testing.T) {
 						"vcd_catalog_media."+TestAccVcdCatalogMedia, "metadata.mediaItem_metadata3", "mediaItem Metadata3"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_catalog_media." + TestAccVcdCatalogMedia,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -66,7 +66,7 @@ func TestAccVcdCatalog(t *testing.T) {
 		CheckDestroy:      testAccCheckCatalogDestroy,
 		Steps: []resource.TestStep{
 			// Provision catalog without storage profile and a vApp template and media
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					cachedId.cacheTestResourceFieldValue(resourceAddress, "id"),
@@ -88,7 +88,7 @@ func TestAccVcdCatalog(t *testing.T) {
 				),
 			},
 			// Set storage profile for existing catalog
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					cachedId.testCheckCachedResourceFieldValue(resourceAddress, "id"),
@@ -110,7 +110,7 @@ func TestAccVcdCatalog(t *testing.T) {
 				),
 			},
 			// Remove storage profile just like it was provisioned in step 0
-			resource.TestStep{
+			{
 
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
@@ -121,7 +121,7 @@ func TestAccVcdCatalog(t *testing.T) {
 					testAccCheckVcdCatalogExists(resourceAddress),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceAddress,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -164,7 +164,7 @@ func TestAccVcdCatalogWithStorageProfile(t *testing.T) {
 		CheckDestroy:      testAccCheckCatalogDestroy,
 		Steps: []resource.TestStep{
 			// Provision with storage profile
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogExists(resourceAddress),
@@ -277,7 +277,7 @@ func TestAccVcdCatalogPublishedToExternalOrg(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckCatalogDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogExists(resourceAddress),
@@ -292,7 +292,7 @@ func TestAccVcdCatalogPublishedToExternalOrg(t *testing.T) {
 					//resource.TestCheckResourceAttr(resourceAddress, "password", params[]),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpd1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogExists(resourceAddress),
@@ -307,7 +307,7 @@ func TestAccVcdCatalogPublishedToExternalOrg(t *testing.T) {
 					//resource.TestCheckResourceAttr(resourceAddress, "password", params[]),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpd2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdCatalogExists(resourceAddress),
@@ -539,7 +539,7 @@ func TestAccVcdCatalogSharedAccess(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					// There is no need to check for much resources - the main point is to have the VMs created
@@ -620,7 +620,7 @@ func spawnTestOrgVdcSharedCatalog(client *VCDClient, name string) (govcd.AdminCa
 		Xmlns:           types.XMLNamespaceVCloud,
 		AllocationModel: "Flex",
 		ComputeCapacity: []*types.ComputeCapacity{
-			&types.ComputeCapacity{
+			{
 				CPU: &types.CapacityWithUsage{
 					Units:     "MHz",
 					Allocated: 1024,
@@ -633,7 +633,7 @@ func spawnTestOrgVdcSharedCatalog(client *VCDClient, name string) (govcd.AdminCa
 				},
 			},
 		},
-		VdcStorageProfile: []*types.VdcStorageProfileConfiguration{&types.VdcStorageProfileConfiguration{
+		VdcStorageProfile: []*types.VdcStorageProfileConfiguration{{
 			Enabled: takeBoolPointer(true),
 			Units:   "MB",
 			Limit:   1024,
@@ -674,7 +674,7 @@ func spawnTestOrgVdcSharedCatalog(client *VCDClient, name string) (govcd.AdminCa
 		IsSharedToEveryone:  false,
 		EveryoneAccessLevel: &readOnly,
 		AccessSettings: &types.AccessSettingList{
-			AccessSetting: []*types.AccessSetting{&types.AccessSetting{
+			AccessSetting: []*types.AccessSetting{{
 				Subject: &types.LocalSubject{
 					HREF: existingOrg.AdminOrg.HREF,
 					Name: existingOrg.AdminOrg.Name,

--- a/vcd/resource_vcd_certificate_library_test.go
+++ b/vcd/resource_vcd_certificate_library_test.go
@@ -71,7 +71,7 @@ func TestAccVcdLibraryCertificateResource(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressOrgCert, "alias", params["Alias"].(string)),
@@ -92,7 +92,7 @@ func TestAccVcdLibraryCertificateResource(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddressSysPrivateCert, "certificate", regexp.MustCompile(`^\S+`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressOrgCert, "alias", params["AliasUpdate"].(string)),
@@ -105,7 +105,7 @@ func TestAccVcdLibraryCertificateResource(t *testing.T) {
 					resource.TestMatchResourceAttr(resourceAddressSysPrivateCert, "certificate", regexp.MustCompile(`^\S+`)),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceAddressOrgCert,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_edgegateway.go
+++ b/vcd/resource_vcd_edgegateway.go
@@ -116,43 +116,43 @@ func resourceVcdEdgeGateway() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"org": &schema.Schema{
+			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"configuration": &schema.Schema{
+			"configuration": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: `Configuration of the vShield edge VM for this gateway. One of: compact, full ("Large"), full4 ("Quad Large"), x-large`,
 			},
-			"ha_enabled": &schema.Schema{
+			"ha_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				ForceNew:    true,
 				Description: "Enable high availability on this edge gateway",
 			},
-			"default_external_network_ip": &schema.Schema{
+			"default_external_network_ip": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "IP address of edge gateway interface which is used as default.",
@@ -165,32 +165,32 @@ func resourceVcdEdgeGateway() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"distributed_routing": &schema.Schema{
+			"distributed_routing": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				ForceNew:    true,
 				Description: "Enable distributed routing",
 			},
-			"lb_enabled": &schema.Schema{
+			"lb_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancing. (Disabled by default)",
 			},
-			"lb_acceleration_enabled": &schema.Schema{
+			"lb_acceleration_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancer acceleration. (Disabled by default)",
 			},
-			"lb_logging_enabled": &schema.Schema{
+			"lb_logging_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancer logging. (Disabled by default)",
 			},
-			"lb_loglevel": &schema.Schema{
+			"lb_loglevel": {
 				Type:         schema.TypeString,
 				Default:      "info",
 				Optional:     true,
@@ -198,33 +198,33 @@ func resourceVcdEdgeGateway() *schema.Resource {
 				Description: "Log level. One of 'emergency', 'alert', 'critical', 'error', " +
 					"'warning', 'notice', 'info', 'debug'. ('info' by default)",
 			},
-			"fw_enabled": &schema.Schema{
+			"fw_enabled": {
 				Type:        schema.TypeBool,
 				Default:     true,
 				Optional:    true,
 				Description: "Enable firewall. Default 'true'",
 			},
-			"fw_default_rule_logging_enabled": &schema.Schema{
+			"fw_default_rule_logging_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable logging for default rule. Default 'false'",
 			},
-			"fw_default_rule_action": &schema.Schema{
+			"fw_default_rule_action": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "deny",
 				Description:  "'accept' or 'deny'. Default 'deny'",
 				ValidateFunc: validation.StringInSlice([]string{"accept", "deny"}, false),
 			},
-			"fips_mode_enabled": &schema.Schema{
+			"fips_mode_enabled": {
 				Type:        schema.TypeBool,
 				ForceNew:    true,
 				Optional:    true,
 				Default:     false,
 				Description: "Enable FIPS mode. FIPS mode turns on the cipher suites that comply with FIPS. (False by default)",
 			},
-			"use_default_route_for_dns_relay": &schema.Schema{
+			"use_default_route_for_dns_relay": {
 				Type:        schema.TypeBool,
 				ForceNew:    true,
 				Optional:    true,

--- a/vcd/resource_vcd_edgegateway_settings.go
+++ b/vcd/resource_vcd_edgegateway_settings.go
@@ -21,53 +21,53 @@ func resourceVcdEdgeGatewaySettings() *schema.Resource {
 			State: resourceVcdEdgeGatewaySettingsImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"org": &schema.Schema{
+			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_name": &schema.Schema{
+			"edge_gateway_name": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				Description:  "Name of the edge gateway. Required when 'edge_gateway_id' is not set",
 				ExactlyOneOf: []string{"edge_gateway_id", "edge_gateway_name"},
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				Description:  "ID of the edge gateway. Required when 'edge_gateway_name' is not set",
 				ExactlyOneOf: []string{"edge_gateway_id", "edge_gateway_name"},
 			},
-			"lb_enabled": &schema.Schema{
+			"lb_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancing. (Disabled by default)",
 			},
-			"lb_acceleration_enabled": &schema.Schema{
+			"lb_acceleration_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancer acceleration. (Disabled by default)",
 			},
-			"lb_logging_enabled": &schema.Schema{
+			"lb_logging_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable load balancer logging. (Disabled by default)",
 				// Due to a VCD bug, this field can only be changed by a system administrator
 			},
-			"lb_loglevel": &schema.Schema{
+			"lb_loglevel": {
 				Type:         schema.TypeString,
 				Default:      "info",
 				Optional:     true,
@@ -76,19 +76,19 @@ func resourceVcdEdgeGatewaySettings() *schema.Resource {
 					"'warning', 'notice', 'info', 'debug'. ('info' by default)",
 				// Due to a VCD bug, this field can only be changed by a system administrator
 			},
-			"fw_enabled": &schema.Schema{
+			"fw_enabled": {
 				Type:        schema.TypeBool,
 				Default:     true,
 				Optional:    true,
 				Description: "Enable firewall. Default 'true'",
 			},
-			"fw_default_rule_logging_enabled": &schema.Schema{
+			"fw_default_rule_logging_enabled": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
 				Description: "Enable logging for default rule. Default 'false'",
 			},
-			"fw_default_rule_action": &schema.Schema{
+			"fw_default_rule_action": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "deny",

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -175,7 +175,7 @@ func TestAccVcdEdgeGatewaySettingsBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		//CheckDestroy: func(s *terraform.State) error {return nil},
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					// Check that the resource has the expected values
@@ -197,7 +197,7 @@ func TestAccVcdEdgeGatewaySettingsBasic(t *testing.T) {
 					checkEdgeGatewaySettingsCorrespondence("fw_default_rule_action", "accept"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "vcd_edgegateway_settings." + testName,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -59,13 +59,13 @@ func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdEdgeGatewayDestroy(edgeGatewayNameBasic),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_edgegateway."+edgeGatewayNameBasic, "default_external_network_ip", ipV4Regex),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "vcd_edgegateway." + edgeGatewayNameBasic,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -114,13 +114,13 @@ func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdEdgeGatewayDestroy(edgeGatewayNameBasic),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_edgegateway."+edgeGatewayNameBasic, "default_external_network_ip", ipV4Regex),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "vcd_edgegateway." + edgeGatewayNameBasic,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -204,7 +204,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdEdgeGatewayDestroy("edge-with-complex-networks"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "name", "edge-with-complex-networks"),
@@ -282,7 +282,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					resource.TestCheckResourceAttrPair("vcd_edgegateway.egw", "use_default_route_for_dns_relay", "data.vcd_edgegateway.egw", "use_default_route_for_dns_relay"),
 				),
 			},
-			resource.TestStep{
+			{
 				Taint:  []string{"vcd_edgegateway.egw"},
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -316,7 +316,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "lb_loglevel", "info"),
 				),
 			},
-			resource.TestStep{ // step2 - import
+			{ // step2 - import
 				ResourceName:            "vcd_edgegateway.egw",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -417,7 +417,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdEdgeGatewayDestroy("edge-with-complex-networks"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw", "name", "edge-with-rate-limits"),
@@ -429,7 +429,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Taint:  []string{"vcd_edgegateway.egw"},
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -442,7 +442,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{ // step2 - import
+			{ // step2 - import
 				ResourceName:            "vcd_edgegateway.egw",
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -533,7 +533,7 @@ func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
 			testAccCheckVcdEdgeGatewayDestroy("parallel-1"),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_edgegateway.egw.0", "name", "parallel-0"),

--- a/vcd/resource_vcd_edgegateway_vpn.go
+++ b/vcd/resource_vcd_edgegateway_vpn.go
@@ -13,17 +13,17 @@ import (
 
 var edgeVpnLocalSubnetResource = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"local_subnet_name": &schema.Schema{
+		"local_subnet_name": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
 
-		"local_subnet_gateway": &schema.Schema{
+		"local_subnet_gateway": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
 
-		"local_subnet_mask": &schema.Schema{
+		"local_subnet_mask": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
@@ -32,17 +32,17 @@ var edgeVpnLocalSubnetResource = &schema.Resource{
 
 var edgeVpnPeerSubnetResource = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"peer_subnet_name": &schema.Schema{
+		"peer_subnet_name": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
 
-		"peer_subnet_gateway": &schema.Schema{
+		"peer_subnet_gateway": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
 
-		"peer_subnet_mask": &schema.Schema{
+		"peer_subnet_mask": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
@@ -57,13 +57,13 @@ func resourceVcdEdgeGatewayVpn() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -81,63 +81,63 @@ func resourceVcdEdgeGatewayVpn() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"encryption_protocol": &schema.Schema{
+			"encryption_protocol": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"local_ip_address": &schema.Schema{
+			"local_ip_address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"local_id": &schema.Schema{
+			"local_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"mtu": &schema.Schema{
+			"mtu": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"peer_ip_address": &schema.Schema{
+			"peer_ip_address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"peer_id": &schema.Schema{
+			"peer_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"shared_secret": &schema.Schema{
+			"shared_secret": {
 				Type:      schema.TypeString,
 				Required:  true,
 				ForceNew:  true,
 				Sensitive: true,
 			},
 
-			"local_subnets": &schema.Schema{
+			"local_subnets": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
 				Elem:     edgeVpnLocalSubnetResource,
 			},
 
-			"peer_subnets": &schema.Schema{
+			"peer_subnets": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,

--- a/vcd/resource_vcd_edgegateway_vpn_test.go
+++ b/vcd/resource_vcd_edgegateway_vpn_test.go
@@ -47,7 +47,7 @@ func TestAccVcdVpn_Basic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVpnDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(

--- a/vcd/resource_vcd_external_network.go
+++ b/vcd/resource_vcd_external_network.go
@@ -22,72 +22,72 @@ func resourceVcdExternalNetwork() *schema.Resource {
 			State: resourceVcdExternalNetworkImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"ip_scope": &schema.Schema{
+			"ip_scope": {
 				Type:        schema.TypeList,
 				Required:    true,
 				ForceNew:    true,
 				Description: "A list of IP scopes for the network",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"gateway": &schema.Schema{
+						"gateway": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
 							Description:  "Gateway of the network",
 							ValidateFunc: validation.IsIPAddress,
 						},
-						"netmask": &schema.Schema{
+						"netmask": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
 							Description:  "Network mask",
 							ValidateFunc: validation.IsIPAddress,
 						},
-						"dns1": &schema.Schema{
+						"dns1": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
 							Description:  "Primary DNS server",
 							ValidateFunc: validation.IsIPAddress,
 						},
-						"dns2": &schema.Schema{
+						"dns2": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ForceNew:     true,
 							Description:  "Secondary DNS server",
 							ValidateFunc: validation.IsIPAddress,
 						},
-						"dns_suffix": &schema.Schema{
+						"dns_suffix": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							ForceNew:    true,
 							Description: "DNS suffix",
 						},
-						"static_ip_pool": &schema.Schema{
+						"static_ip_pool": {
 							Type:        schema.TypeList,
 							Optional:    true,
 							ForceNew:    true,
 							Description: "IP ranges used for static pool allocation in the network",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"start_address": &schema.Schema{
+									"start_address": {
 										Type:         schema.TypeString,
 										Required:     true,
 										ForceNew:     true,
 										Description:  "Start address of the IP range",
 										ValidateFunc: validation.IsIPAddress,
 									},
-									"end_address": &schema.Schema{
+									"end_address": {
 										Type:         schema.TypeString,
 										Required:     true,
 										ForceNew:     true,
@@ -100,26 +100,26 @@ func resourceVcdExternalNetwork() *schema.Resource {
 					},
 				},
 			},
-			"vsphere_network": &schema.Schema{
+			"vsphere_network": {
 				Type:        schema.TypeList,
 				Required:    true,
 				ForceNew:    true,
 				Description: "A list of port groups that back this network. Each referenced DV_PORTGROUP or NETWORK must exist on a vCenter server registered with the system.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"vcenter": &schema.Schema{
+						"vcenter": {
 							Type:        schema.TypeString,
 							Required:    true,
 							ForceNew:    true,
 							Description: "The vCenter server name",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							ForceNew:    true,
 							Description: "The name of the port group",
 						},
-						"type": &schema.Schema{
+						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ForceNew:     true,
@@ -129,7 +129,7 @@ func resourceVcdExternalNetwork() *schema.Resource {
 					},
 				},
 			},
-			"retain_net_info_across_deployments": &schema.Schema{
+			"retain_net_info_across_deployments": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
@@ -411,7 +411,7 @@ func getExternalNetworkResource(vcdClient *govcd.VCDClient, extNetIdentifier str
 	}
 
 	extNetRes["vsphere_network"] = []StringMap{
-		StringMap{
+		{
 			"name":    portGroupName,
 			"vcenter": virtualCenters[0].Name,
 			"type":    externalNetwork.ExternalNetwork.VimPortGroupRef.VimObjectType,

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -58,7 +58,7 @@ func TestAccVcdExternalNetworkBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckExternalNetworkDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdExternalNetworkExists("vcd_external_network."+TestAccVcdExternalNetwork, &externalNetwork),
@@ -88,7 +88,7 @@ func TestAccVcdExternalNetworkBasic(t *testing.T) {
 						resourceName, "retain_net_info_across_deployments", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -86,7 +86,7 @@ func testAccVcdExternalNetworkV2Nsxt(t *testing.T, nsxtTier0Router string) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -128,13 +128,13 @@ func testAccVcdExternalNetworkV2Nsxt(t *testing.T, nsxtTier0Router string) {
 					testCheckOutputNonEmpty("nsxt-tier0-router"), // Match any non empty string
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdTopHierarchy(t.Name()),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -298,7 +298,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -323,7 +323,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 					testCheckOutputNonEmpty("portgroup-id"), // Match any non empty string
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -362,7 +362,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 					testCheckOutputNonEmpty("portgroup-id"), // Match any non empty string because IDs may differ
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -513,7 +513,7 @@ func TestAccVcdExternalNetworkV2NsxtSegmentUnsupported(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      configText,
 				ExpectError: regexp.MustCompile(`NSX-T Segment backed External Network is only supported in VCD 10.3.0+`),
 			},
@@ -573,7 +573,7 @@ func TestAccVcdExternalNetworkV2NsxtSegment(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -613,13 +613,13 @@ func TestAccVcdExternalNetworkV2NsxtSegment(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "nsxt_network.#", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdTopHierarchy(t.Name()),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -762,7 +762,7 @@ func TestAccVcdExternalNetworkV2NsxtConfigError(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      configText,
 				ExpectError: regexp.MustCompile(`Invalid combination of arguments`),
 			},
@@ -889,7 +889,7 @@ func TestAccVcdExternalNetworkV2NsxtSegmentIntegration(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckExternalNetworkDestroyV2(t.Name()),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
@@ -931,7 +931,7 @@ func TestAccVcdExternalNetworkV2NsxtSegmentIntegration(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "nsxt_network.0.nsxt_segment_name"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_external_network_v2.ext-net-nsxt", "vcd_external_network_v2.ext-net-nsxt", nil),

--- a/vcd/resource_vcd_global_role.go
+++ b/vcd/resource_vcd_global_role.go
@@ -21,38 +21,38 @@ func resourceVcdGlobalRole() *schema.Resource {
 			StateContext: resourceVcdGlobalRoleImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of global role.",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Global role description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this global role is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "list of rights assigned to this global role",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"publish_to_all_tenants": &schema.Schema{
+			"publish_to_all_tenants": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "When true, publishes the global role to all tenants",
 			},
-			"tenants": &schema.Schema{
+			"tenants": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,

--- a/vcd/resource_vcd_global_role_test.go
+++ b/vcd/resource_vcd_global_role_test.go
@@ -50,7 +50,7 @@ func TestAccVcdGlobalRole(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckGlobalRoleDestroy(resourceDef),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalRoleExists(resourceDef),
@@ -61,7 +61,7 @@ func TestAccVcdGlobalRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "tenants.#", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlobalRoleExists(resourceDef),
@@ -71,7 +71,7 @@ func TestAccVcdGlobalRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "rights.#", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceDef,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -516,7 +517,7 @@ func setMainData(d *schema.ResourceData, disk *govcd.Disk, diskRecord *types.Dis
 	for _, vmHref := range vmsHrefs {
 		attachedVmIds = append(attachedVmIds, extractUuid(vmHref))
 	}
-	attachedVmSet := convertStringsTotTypeSet(attachedVmIds)
+	attachedVmSet := convertStringsToTypeSet(attachedVmIds)
 	err = d.Set("attached_vm_ids", attachedVmSet)
 	if err != nil {
 		return fmt.Errorf("[Independent disk read] error setting the list of attached VM IDs: %s ", err)

--- a/vcd/resource_vcd_inserted_media.go
+++ b/vcd/resource_vcd_inserted_media.go
@@ -30,31 +30,31 @@ func resourceVcdInsertedMedia() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"catalog": &schema.Schema{
+			"catalog": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "catalog name where to find media file",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "media name to use",
 			},
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp to use",
 			},
-			"vm_name": &schema.Schema{
+			"vm_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "VM in vApp in which media will be inserted or ejected",
 			},
-			"eject_force": &schema.Schema{
+			"eject_force": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -52,7 +52,7 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccResourcesDestroyed,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMediaInserted("vcd_inserted_media."+TestAccVcdMediaInsert),

--- a/vcd/resource_vcd_ipset.go
+++ b/vcd/resource_vcd_ipset.go
@@ -34,17 +34,17 @@ func resourceVcdIpSet() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "IP set name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "IP set description",
 			},
-			"is_inheritance_allowed": &schema.Schema{
+			"is_inheritance_allowed": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,

--- a/vcd/resource_vcd_ipset_test.go
+++ b/vcd/resource_vcd_ipset_test.go
@@ -45,7 +45,7 @@ func TestAccVcdIpSet(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdIpSetDestroy("vcd_nsxv_ip_set.test-ipset", params["IpSetName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
@@ -60,7 +60,7 @@ func TestAccVcdIpSet(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
@@ -75,13 +75,13 @@ func TestAccVcdIpSet(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxv_ip_set.test-ipset",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdOrgVdcObject(testConfig, "TestAccVcdIpSet-changed"),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_ip_set.test-ipset", "id", regexp.MustCompile(`.*ipset-\d*$`)),
@@ -95,7 +95,7 @@ func TestAccVcdIpSet(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxv_ip_set.test-ipset", "data.vcd_nsxv_ip_set.test-ipset", []string{}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Taint:  []string{"vcd_nsxv_ip_set.test-ipset"}, // Force provisioning from scratch instead of update
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/vcd/resource_vcd_lb_app_profile.go
+++ b/vcd/resource_vcd_lb_app_profile.go
@@ -32,44 +32,44 @@ func resourceVcdLBAppProfile() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Application Profile is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique LB Application Profile name",
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validateCase("lower"),
 				Description: "Protocol type used to send requests to the server. One of 'tcp', " +
 					"'udp', 'http' org 'https'",
 			},
-			"enable_ssl_passthrough": &schema.Schema{
+			"enable_ssl_passthrough": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Description: "Enable SSL authentication to be passed through to the virtual " +
 					"server. Otherwise SSL authentication takes place at the destination address.",
 			},
-			"http_redirect_url": &schema.Schema{
+			"http_redirect_url": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: "The URL to which traffic that arrives at the destination address " +
 					"should be redirected. Only applies for types 'http' and 'https'",
 			},
-			"persistence_mechanism": &schema.Schema{
+			"persistence_mechanism": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateCase("lower"),
 				Description: "Persistence mechanism for the profile. One of 'cookie', " +
 					"'ssl-sessionid', 'sourceip'",
 			},
-			"cookie_name": &schema.Schema{
+			"cookie_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: "Used to uniquely identify the session the first time a client " +
@@ -77,19 +77,19 @@ func resourceVcdLBAppProfile() *schema.Resource {
 					"subsequent requests in the session, so that they all go to the same virtual " +
 					"server. Only applies for persistence_mechanism 'cookie'",
 			},
-			"cookie_mode": &schema.Schema{
+			"cookie_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateCase("lower"),
 				Description: "The mode by which the cookie should be inserted. One of 'insert', " +
 					"'prefix', or 'appsession'",
 			},
-			"expiration": &schema.Schema{
+			"expiration": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Length of time in seconds that persistence stays in effect",
 			},
-			"insert_x_forwarded_http_header": &schema.Schema{
+			"insert_x_forwarded_http_header": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -100,7 +100,7 @@ func resourceVcdLBAppProfile() *schema.Resource {
 			// TODO https://github.com/vmware/terraform-provider-vcd/issues/258
 			// This will not give much use without SSL certs being available. The only method to
 			// make use of it is by manually attaching certificates.
-			"enable_pool_side_ssl": &schema.Schema{
+			"enable_pool_side_ssl": {
 				Type:     schema.TypeBool,
 				Default:  false,
 				Optional: true,

--- a/vcd/resource_vcd_lb_app_profile_test.go
+++ b/vcd/resource_vcd_lb_app_profile_test.go
@@ -63,7 +63,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdLBAppProfileDestroy(params["AppProfileName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // TCP
+			{ // TCP
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_profile.test", "id", regexp.MustCompile(`^applicationProfile-\d*$`)),
@@ -82,7 +82,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_lb_app_profile.test", "enable_pool_side_ssl", "false"),
 				),
 			},
-			resource.TestStep{ // UDP
+			{ // UDP
 				Config: configTextStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_profile.test", "id", regexp.MustCompile(`^applicationProfile-\d*$`)),
@@ -101,7 +101,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_lb_app_profile.test", "enable_pool_side_ssl", "true"),
 				),
 			},
-			resource.TestStep{ // HTTP - Cookie
+			{ // HTTP - Cookie
 				Config: configTextStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_profile.test", "id", regexp.MustCompile(`^applicationProfile-\d*$`)),
@@ -129,7 +129,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{ // HTTP - Source IP
+			{ // HTTP - Source IP
 				Config: configTextStep3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_profile.test", "id", regexp.MustCompile(`^applicationProfile-\d*$`)),
@@ -155,7 +155,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{ // HTTPS
+			{ // HTTPS
 				Config: configTextStep4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_profile.test", "id", regexp.MustCompile(`^applicationProfile-\d*$`)),
@@ -179,7 +179,7 @@ func TestAccVcdLBAppProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_lb_app_profile.test", "expiration", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_lb_app_profile.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_lb_app_rule.go
+++ b/vcd/resource_vcd_lb_app_rule.go
@@ -32,13 +32,13 @@ func resourceVcdLBAppRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Application Rule is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique LB Application Rule name",

--- a/vcd/resource_vcd_lb_app_rule_test.go
+++ b/vcd/resource_vcd_lb_app_rule_test.go
@@ -70,7 +70,7 @@ acl other_page2 url_beg / other2 redirect location https://www.other2.com/ ifoth
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdLBAppRuleDestroy(params["AppRuleName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // Single Line Script
+			{ // Single Line Script
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_rule.test", "id", regexp.MustCompile(`^applicationRule-\d*$`)),
@@ -84,7 +84,7 @@ acl other_page2 url_beg / other2 redirect location https://www.other2.com/ ifoth
 				),
 			},
 
-			resource.TestStep{ // Multi Line Script
+			{ // Multi Line Script
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_app_rule.test", "id", regexp.MustCompile(`^applicationRule-\d*$`)),
@@ -98,14 +98,14 @@ acl other_page2 url_beg / other2 redirect location https://www.other2.com/ ifoth
 				),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_lb_app_rule.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdEdgeGatewayObject(testConfig, testConfig.Networking.EdgeGateway, params["AppRuleName"].(string)),
 			},
 
-			resource.TestStep{ // Multi Line Script with invalid rule
+			{ // Multi Line Script with invalid rule
 				Config:      configText3,
 				ExpectError: regexp.MustCompile(`.*vShield Edge .* Not found pool name .* in rules.*`),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/vcd/resource_vcd_lb_server_pool.go
+++ b/vcd/resource_vcd_lb_server_pool.go
@@ -32,23 +32,23 @@ func resourceVcdLBServerPool() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Server Pool is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique LB Server Pool name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Server pool description",
 			},
-			"algorithm": &schema.Schema{
+			"algorithm": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Balancing method for the service. One of 'ip-hash', 'round-robin', 'uri', 'leastconn', 'url', or 'httpheader'",
@@ -59,12 +59,12 @@ func resourceVcdLBServerPool() *schema.Resource {
 				Optional:    true,
 				Description: "Additional options for load balancing algorithm for httpheader or url algorithms",
 			},
-			"monitor_id": &schema.Schema{
+			"monitor_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Load Balancer Service Monitor ID",
 			},
-			"enable_transparency": &schema.Schema{
+			"enable_transparency": {
 				Type:        schema.TypeBool,
 				Default:     false,
 				Optional:    true,
@@ -82,7 +82,7 @@ func resourceVcdLBServerPool() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: "Pool member id (formatted as member-xx, where xx is a number)",
 						},
-						"condition": &schema.Schema{
+						"condition": {
 							Type:         schema.TypeString,
 							ForceNew:     false,
 							Required:     true,

--- a/vcd/resource_vcd_lb_server_pool_test.go
+++ b/vcd/resource_vcd_lb_server_pool_test.go
@@ -50,7 +50,7 @@ func TestAccVcdLbServerPool(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdLbServerPoolDestroy(params["ServerPoolName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_lb_server_pool.server-pool", "name", t.Name()),
@@ -104,7 +104,7 @@ func TestAccVcdLbServerPool(t *testing.T) {
 				),
 			},
 			// configTextStep1 attaches monitor_id, changes some member settings
-			resource.TestStep{
+			{
 				Config: configTextStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_server_pool.server-pool", "id", regexp.MustCompile(`^pool-\d*$`)),
@@ -209,7 +209,7 @@ func TestAccVcdLbServerPool(t *testing.T) {
 				),
 			},
 			// Check that import works
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_lb_server_pool.server-pool",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_lb_service_monitor.go
+++ b/vcd/resource_vcd_lb_service_monitor.go
@@ -32,63 +32,63 @@ func resourceVcdLbServiceMonitor() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Service Monitor is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique LB Service Monitor name",
 			},
-			"interval": &schema.Schema{
+			"interval": {
 				Type:        schema.TypeInt,
 				Default:     10,
 				Optional:    true,
 				Description: "Interval in seconds at which a server is to be monitored (defaults to 10)",
 			},
-			"timeout": &schema.Schema{
+			"timeout": {
 				Type:        schema.TypeInt,
 				Default:     15,
 				Optional:    true,
 				Description: "Maximum time in seconds within which a response from the server must be received  (defaults to 15)",
 			},
-			"max_retries": &schema.Schema{
+			"max_retries": {
 				Type:        schema.TypeInt,
 				Default:     3,
 				Optional:    true,
 				Description: "Number of times the specified monitoring Method must fail sequentially before the server is declared down  (defaults to 3)",
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Way in which you want to send the health check request to the server. One of http, https, tcp, icmp, or udp",
 				ValidateFunc: validateCase("lower"),
 			},
-			"expected": &schema.Schema{
+			"expected": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "String that the monitor expects to match in the status line of the http or https response (for example, HTTP/1.1)",
 			},
-			"method": &schema.Schema{
+			"method": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  "Method to be used to detect server status. One of OPTIONS, GET, HEAD, POST, PUT, DELETE, TRACE, or CONNECT",
 				ValidateFunc: validateCase("upper"),
 			},
-			"url": &schema.Schema{
+			"url": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "URL to be used in the server status request",
 			},
-			"send": &schema.Schema{
+			"send": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Data to be sent",
 			},
-			"receive": &schema.Schema{
+			"receive": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "String to be matched in the response content",

--- a/vcd/resource_vcd_lb_service_monitor_test.go
+++ b/vcd/resource_vcd_lb_service_monitor_test.go
@@ -54,7 +54,7 @@ func TestAccVcdLbServiceMonitor(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdLbServiceMonitorDestroy(params["ServiceMonitorName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_lb_service_monitor.lb-service-monitor", "name", t.Name()),
@@ -78,7 +78,7 @@ func TestAccVcdLbServiceMonitor(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_lb_service_monitor.ds-lb-service-monitor", "name", t.Name()),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_lb_service_monitor.lb-service-monitor", "name", t.Name()+"-step1"),
@@ -87,7 +87,7 @@ func TestAccVcdLbServiceMonitor(t *testing.T) {
 				),
 			},
 			// Check that import works
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_lb_service_monitor.lb-service-monitor",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_lb_virtual_server.go
+++ b/vcd/resource_vcd_lb_virtual_server.go
@@ -33,23 +33,23 @@ func resourceVcdLBVirtualServer() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which the LB Virtual Server is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Unique Virtual Server name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Virtual Server description",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Default:     true,
 				Optional:    true,
@@ -61,43 +61,43 @@ func resourceVcdLBVirtualServer() *schema.Resource {
 				Description:  "IP address that the load balancer listens on",
 				ValidateFunc: validation.IsIPAddress,
 			},
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Protocol that the virtual server accepts",
 				ValidateFunc: validateCase("lower"),
 			},
-			"port": &schema.Schema{
+			"port": {
 				Type:        schema.TypeInt,
 				Required:    true,
 				Description: "Port number that the load balancer listens on",
 			},
-			"enable_acceleration": &schema.Schema{
+			"enable_acceleration": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Enable virtual server acceleration",
 			},
-			"connection_limit": &schema.Schema{
+			"connection_limit": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum concurrent connections that the virtual server can process",
 			},
-			"connection_rate_limit": &schema.Schema{
+			"connection_rate_limit": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum incoming new connection requests per second",
 			},
-			"app_profile_id": &schema.Schema{
+			"app_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Application profile ID to be associated with the virtual server",
 			},
-			"server_pool_id": &schema.Schema{
+			"server_pool_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The server pool that the load balancer will use",
 			},
-			"app_rule_ids": &schema.Schema{
+			"app_rule_ids": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "List of attached application rule IDs",

--- a/vcd/resource_vcd_lb_virtual_server_test.go
+++ b/vcd/resource_vcd_lb_virtual_server_test.go
@@ -45,7 +45,7 @@ func TestAccVcdLbVirtualServer(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdLbVirtualServerDestroy(params["VirtualServerName"].(string)),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // step 0
+			{ // step 0
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_virtual_server.http", "id", regexp.MustCompile(`^virtualServer-\d*$`)),
@@ -78,13 +78,13 @@ func TestAccVcdLbVirtualServer(t *testing.T) {
 			},
 
 			// Check that import works
-			resource.TestStep{ // step 1
+			{ // step 1
 				ResourceName:      "vcd_lb_virtual_server.http",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdEdgeGatewayObject(testConfig, testConfig.Networking.EdgeGateway, t.Name()),
 			},
-			resource.TestStep{ // step 2
+			{ // step 2
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_lb_virtual_server.http", "id", regexp.MustCompile(`^virtualServer-\d*$`)),

--- a/vcd/resource_vcd_network_isolated_v2_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_test.go
@@ -32,7 +32,7 @@ func TestAccVcdNetworkIsolatedV2Nsxv(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.VCD.Vdc, t.Name()),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_network_isolated_v2.net1", "id"),
@@ -49,7 +49,7 @@ func TestAccVcdNetworkIsolatedV2Nsxv(t *testing.T) {
 				),
 			},
 			// Check that import works
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_network_isolated_v2.net1",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_alb_cloud.go
+++ b/vcd/resource_vcd_nsxt_alb_cloud.go
@@ -24,47 +24,47 @@ func resourceVcdAlbCloud() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Cloud name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Cloud description",
 			},
-			"controller_id": &schema.Schema{
+			"controller_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Controller ID",
 			},
-			"importable_cloud_id": &schema.Schema{
+			"importable_cloud_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Importable Cloud ID",
 			},
-			"network_pool_id": &schema.Schema{
+			"network_pool_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Network pool ID for NSX-T ALB Importable Cloud",
 			},
-			"network_pool_name": &schema.Schema{
+			"network_pool_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Network pool name of NSX-T ALB Cloud",
 			},
-			"health_status": &schema.Schema{
+			"health_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Cloud health status",
 			},
-			"health_message": &schema.Schema{
+			"health_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Cloud detailed health message",

--- a/vcd/resource_vcd_nsxt_alb_cloud_test.go
+++ b/vcd/resource_vcd_nsxt_alb_cloud_test.go
@@ -54,7 +54,7 @@ func TestAccVcdNsxtAlbCloud(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdAlbCloudDestroy("vcd_nsxt_alb_cloud.first"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_cloud.first", "id", regexp.MustCompile(`\d*`)),
@@ -68,7 +68,7 @@ func TestAccVcdNsxtAlbCloud(t *testing.T) {
 					//resource.TestCheckResourceAttrSet("vcd_nsxt_alb_cloud.first", "health_message"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_cloud.first", "id", regexp.MustCompile(`\d*`)),
@@ -82,13 +82,13 @@ func TestAccVcdNsxtAlbCloud(t *testing.T) {
 					//resource.TestCheckResourceAttrSet("vcd_nsxt_alb_cloud.first", "health_message"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_cloud.first",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateId:     "nsxt-cloud-renamed",
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					// health_status and health_message might have different values purely because of time difference

--- a/vcd/resource_vcd_nsxt_alb_controller.go
+++ b/vcd/resource_vcd_nsxt_alb_controller.go
@@ -25,39 +25,39 @@ func resourceVcdAlbController() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Controller name",
 			},
-			"url": &schema.Schema{
+			"url": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Controller URL",
 			},
-			"username": &schema.Schema{
+			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Controller Username",
 			},
-			"password": &schema.Schema{
+			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
 				Description: "NSX-T ALB Controller Password",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "NSX-T ALB Controller description",
 			},
-			"license_type": &schema.Schema{
+			"license_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"BASIC", "ENTERPRISE"}, false),
 				Description:  "NSX-T ALB License type. One of 'BASIC', 'ENTERPRISE'",
 			},
-			"version": &schema.Schema{
+			"version": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Controller version",

--- a/vcd/resource_vcd_nsxt_alb_controller_test.go
+++ b/vcd/resource_vcd_nsxt_alb_controller_test.go
@@ -52,7 +52,7 @@ func TestAccVcdNsxtAlbController(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdAlbControllerDestroy("vcd_nsxt_alb_controller.first"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_controller.first", "id", regexp.MustCompile(`\d*`)),
@@ -63,7 +63,7 @@ func TestAccVcdNsxtAlbController(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_controller.first", "license_type", "ENTERPRISE"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_controller.first", "id", regexp.MustCompile(`\d*`)),
@@ -74,14 +74,14 @@ func TestAccVcdNsxtAlbController(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_controller.first", "license_type", "BASIC"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            "vcd_nsxt_alb_controller.first",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateId:           t.Name() + "-renamed",
 				ImportStateVerifyIgnore: []string{"password"},
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_controller.first", "id", regexp.MustCompile(`\d*`)),

--- a/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group.go
+++ b/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group.go
@@ -36,36 +36,36 @@ func resourceVcdAlbEdgeGatewayServiceEngineGroup() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge Gateway ID in which ALB Service Engine Group should be located",
 			},
-			"service_engine_group_id": &schema.Schema{
+			"service_engine_group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Service Engine Group ID to attach to this NSX-T Edge Gateway",
 			},
-			"service_engine_group_name": &schema.Schema{
+			"service_engine_group_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Service Engine Group Name which is attached to NSX-T Edge Gateway",
 			},
-			"max_virtual_services": &schema.Schema{
+			"max_virtual_services": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
 				Description: "Maximum number of virtual services to be used in this Service Engine Group",
 			},
-			"reserved_virtual_services": &schema.Schema{
+			"reserved_virtual_services": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
 				Description: "Number of reserved virtual services for this Service Engine Group",
 			},
-			"deployed_virtual_services": &schema.Schema{
+			"deployed_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of deployed virtual services for this Service Engine Group",

--- a/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group_test.go
@@ -58,7 +58,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupDedicated(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "id", regexp.MustCompile(`\d*`)),
@@ -66,7 +66,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupDedicated(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "reserved_virtual_services", regexp.MustCompile(`\d*`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "id", regexp.MustCompile(`\d*`)),
@@ -74,7 +74,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupDedicated(t *testing.T) {
 					resourceFieldsEqual("data.vcd_nsxt_alb_edgegateway_service_engine_group.test", "vcd_nsxt_alb_edgegateway_service_engine_group.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_edgegateway_service_engine_group.test",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -159,7 +159,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupShared(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "id", regexp.MustCompile(`\d*`)),
@@ -168,7 +168,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupShared(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "deployed_virtual_services", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "id", regexp.MustCompile(`\d*`)),
@@ -176,7 +176,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupShared(t *testing.T) {
 					resourceFieldsEqual("data.vcd_nsxt_alb_edgegateway_service_engine_group.test", "vcd_nsxt_alb_edgegateway_service_engine_group.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "id", regexp.MustCompile(`\d*`)),
@@ -185,7 +185,7 @@ func TestAccVcdNsxtEdgeGatewayServiceEngineGroupShared(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_edgegateway_service_engine_group.test", "deployed_virtual_services", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_edgegateway_service_engine_group.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_alb_pool.go
+++ b/vcd/resource_vcd_nsxt_alb_pool.go
@@ -461,8 +461,8 @@ func setNsxtAlbPoolData(d *schema.ResourceData, albPool *types.NsxtAlbPool) erro
 
 	associatedVirtualServiceIds := extractIdsFromOpenApiReferences(albPool.VirtualServiceRefs)
 	associatedVirtualServiceNames := extractNamesFromOpenApiReferences(albPool.VirtualServiceRefs)
-	associatedVirtualServiceIdsSet := convertStringsTotTypeSet(associatedVirtualServiceIds)
-	associatedVirtualServiceNameSet := convertStringsTotTypeSet(associatedVirtualServiceNames)
+	associatedVirtualServiceIdsSet := convertStringsToTypeSet(associatedVirtualServiceIds)
+	associatedVirtualServiceNameSet := convertStringsToTypeSet(associatedVirtualServiceNames)
 	err = d.Set("associated_virtual_service_ids", associatedVirtualServiceIdsSet)
 	if err != nil {
 		return fmt.Errorf("error setting 'associated_virtual_service_ids': %s", err)
@@ -553,7 +553,7 @@ func setNsxtAlbPoolMemberData(d *schema.ResourceData, members []types.NsxtAlbPoo
 			memberMap["ratio"] = *member.Ratio
 		}
 
-		memberMap["marked_down_by"] = convertStringsTotTypeSet(member.MarkedDownBy)
+		memberMap["marked_down_by"] = convertStringsToTypeSet(member.MarkedDownBy)
 		memberMap["health_status"] = member.HealthStatus
 		memberMap["detailed_health_message"] = member.DetailedHealthMessage
 
@@ -610,7 +610,7 @@ func setNsxtAlbPoolPersistenceProfileData(d *schema.ResourceData, persistencePro
 func setCertificateData(d *schema.ResourceData, albPool *types.NsxtAlbPool) error {
 	if albPool.CaCertificateRefs != nil {
 		certIds := extractIdsFromOpenApiReferences(albPool.CaCertificateRefs)
-		certIdSet := convertStringsTotTypeSet(certIds)
+		certIdSet := convertStringsToTypeSet(certIds)
 		err := d.Set("ca_certificate_ids", certIdSet)
 		if err != nil {
 			return fmt.Errorf("error setting 'ca_certificate_ids': %s", err)
@@ -626,7 +626,7 @@ func setCertificateData(d *schema.ResourceData, albPool *types.NsxtAlbPool) erro
 	}
 
 	if albPool.DomainNames != nil {
-		domainNameSet := convertStringsTotTypeSet(albPool.DomainNames)
+		domainNameSet := convertStringsToTypeSet(albPool.DomainNames)
 		err := d.Set("domain_names", domainNameSet)
 		if err != nil {
 			return fmt.Errorf("error setting 'domain_names': %s", err)

--- a/vcd/resource_vcd_nsxt_alb_pool.go
+++ b/vcd/resource_vcd_nsxt_alb_pool.go
@@ -42,29 +42,29 @@ func resourceVcdAlbPool() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID in which ALB Pool should be created",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of ALB Pool",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Boolean value if ALB Pool is enabled or not (default true)",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Description of ALB Pool",
 			},
-			"algorithm": &schema.Schema{
+			"algorithm": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: "Algorithm for choosing pool members (default LEAST_CONNECTIONS). Other `ROUND_ROBIN`," +
@@ -73,7 +73,7 @@ func resourceVcdAlbPool() *schema.Resource {
 				// Default is LEAST_CONNECTIONS even if no value is sent
 				Default: "LEAST_CONNECTIONS",
 			},
-			"default_port": &schema.Schema{
+			"default_port": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Default Port defines destination server port used by the traffic sent to the member (default 80)",
@@ -81,7 +81,7 @@ func resourceVcdAlbPool() *schema.Resource {
 				Default: 80,
 			},
 			//
-			"graceful_timeout_period": &schema.Schema{
+			"graceful_timeout_period": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum time in minutes to gracefully disable pool member (default 1)",
@@ -113,7 +113,7 @@ func resourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"cn_check_enabled": &schema.Schema{
+			"cn_check_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -127,7 +127,7 @@ func resourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"passive_monitoring_enabled": &schema.Schema{
+			"passive_monitoring_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
@@ -150,22 +150,22 @@ func resourceVcdAlbPool() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"member_count": &schema.Schema{
+			"member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of members in the pool",
 			},
-			"up_member_count": &schema.Schema{
+			"up_member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of members in the pool serving the traffic",
 			},
-			"enabled_member_count": &schema.Schema{
+			"enabled_member_count": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Number of enabled members in the pool",
 			},
-			"health_message": &schema.Schema{
+			"health_message": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Health message",
@@ -176,7 +176,7 @@ func resourceVcdAlbPool() *schema.Resource {
 
 var nsxtAlbPoolMember = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"enabled": &schema.Schema{
+		"enabled": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
@@ -224,16 +224,16 @@ var nsxtAlbPoolMember = &schema.Resource{
 
 var nsxtAlbPoolHealthMonitor = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"type": &schema.Schema{
+		"type": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Type of health monitor. One of `HTTP`, `HTTPS`, `TCP`, `UDP`, `PING`",
 		},
-		"name": &schema.Schema{
+		"name": {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"system_defined": &schema.Schema{
+		"system_defined": {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
@@ -242,17 +242,17 @@ var nsxtAlbPoolHealthMonitor = &schema.Resource{
 
 var nsxtAlbPoolPersistenceProfile = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"name": &schema.Schema{
+		"name": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: "System generated name of persistence profile",
 		},
-		"type": &schema.Schema{
+		"type": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Type of persistence strategy. One of `CLIENT_IP`, `HTTP_COOKIE`, `CUSTOM_HTTP_HEADER`, `APP_COOKIE`, `TLS`",
 		},
-		"value": &schema.Schema{
+		"value": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Value of attribute based on persistence type",

--- a/vcd/resource_vcd_nsxt_alb_pool_test.go
+++ b/vcd/resource_vcd_nsxt_alb_pool_test.go
@@ -124,7 +124,7 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1, // Setup prerequisites - configure NSX-T ALB in Provider
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -147,13 +147,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -184,13 +184,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -269,13 +269,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText6, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText7,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -312,13 +312,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText8, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText9,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -342,13 +342,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText10, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText11,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -370,13 +370,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText12, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText13,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -400,13 +400,13 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("vcd_nsxt_alb_pool.test", "domain_names.*", "domain2"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_pool.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, params["PoolName"].(string)),
 			},
-			resource.TestStep{
+			{
 				Config: configText15, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_pool.test", "vcd_nsxt_alb_pool.test", nil),
@@ -797,7 +797,7 @@ func TestAccVcdNsxtAlbPoolOrgUser(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				PreConfig: configurePrerequisites, // Use temporary System session and setup all prerequisites using SDK
 				Config:    configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -820,7 +820,7 @@ func TestAccVcdNsxtAlbPoolOrgUser(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "cn_check_enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),
@@ -891,14 +891,14 @@ func TestAccVcdNsxtAlbPoolOrgUser(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_pool.test", "persistence_profile.0.value", ""),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_pool.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, params["PoolName"].(string)),
 			},
 			//
-			resource.TestStep{
+			{
 				Config: configText4, // Test data source
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_pool.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerPool:`)),

--- a/vcd/resource_vcd_nsxt_alb_service_engine_group.go
+++ b/vcd/resource_vcd_nsxt_alb_service_engine_group.go
@@ -25,23 +25,23 @@ func resourceVcdAlbServiceEngineGroup() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "NSX-T ALB Service Engine Group name",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "NSX-T ALB Service Engine Group description",
 			},
-			"alb_cloud_id": &schema.Schema{
+			"alb_cloud_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB backing Cloud ID",
 			},
-			"reservation_model": &schema.Schema{
+			"reservation_model": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "NSX-T ALB Service Engine Group reservation model. One of 'DEDICATED', 'SHARED'",
@@ -50,38 +50,38 @@ func resourceVcdAlbServiceEngineGroup() *schema.Resource {
 			// Ideally this should be a reference by ID and a data source for lookup. However, the Importable Service
 			// Engine Group API endpoint does not return entities once they are consumed, and it is impossible to make
 			// a data source.
-			"importable_service_engine_group_name": &schema.Schema{
+			"importable_service_engine_group_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "NSX-T ALB Importable Service Engine Group Name",
 			},
-			"max_virtual_services": &schema.Schema{
+			"max_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group maximum virtual services",
 			},
-			"reserved_virtual_services": &schema.Schema{
+			"reserved_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group reserved virtual services",
 			},
-			"deployed_virtual_services": &schema.Schema{
+			"deployed_virtual_services": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group deployed virtual services",
 			},
-			"ha_mode": &schema.Schema{
+			"ha_mode": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "NSX-T ALB Service Engine Group HA mode",
 			},
-			"overallocated": &schema.Schema{
+			"overallocated": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Boolean value that shows if virtual services are overallocated",
 			},
-			"sync_on_refresh": &schema.Schema{
+			"sync_on_refresh": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
@@ -61,7 +61,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdAlbServiceEngineGroupDestroy("vcd_nsxt_alb_cloud.first"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_service_engine_group.first", "id", regexp.MustCompile(`\d*`)),
@@ -78,7 +78,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_service_engine_group.first", "sync_on_refresh", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_service_engine_group.first",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -88,7 +88,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 				// this field remains empty.
 				ImportStateVerifyIgnore: []string{"importable_service_engine_group_name"},
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_service_engine_group.first", "id", regexp.MustCompile(`\d*`)),
@@ -105,7 +105,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_service_engine_group.first", "sync_on_refresh", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_service_engine_group.first", "id", regexp.MustCompile(`\d*`)),
@@ -114,7 +114,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 					resourceFieldsEqual("data.vcd_nsxt_alb_service_engine_group.first", "vcd_nsxt_alb_service_engine_group.first", []string{"%"}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_service_engine_group.first", "id", regexp.MustCompile(`\d*`)),
@@ -131,7 +131,7 @@ func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_service_engine_group.first", "sync_on_refresh", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_service_engine_group.first", "id", regexp.MustCompile(`\d*`)),

--- a/vcd/resource_vcd_nsxt_alb_settings.go
+++ b/vcd/resource_vcd_nsxt_alb_settings.go
@@ -38,18 +38,18 @@ func resourceVcdAlbSettings() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID",
 			},
-			"is_active": &schema.Schema{
+			"is_active": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "Defines if ALB is enabled on Edge Gateway",
 			},
-			"service_network_specification": &schema.Schema{
+			"service_network_specification": {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,

--- a/vcd/resource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/resource_vcd_nsxt_alb_settings_test.go
@@ -66,7 +66,7 @@ func TestAccVcdNsxtAlbSettings(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1, // Setup prerequisites - configure NSX-T ALB in Provider
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_controller.first", "id", regexp.MustCompile(`\d*`)),
@@ -77,7 +77,7 @@ func TestAccVcdNsxtAlbSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_settings.test", "is_active", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_settings.test", "id", regexp.MustCompile(`\d*`)),
@@ -85,14 +85,14 @@ func TestAccVcdNsxtAlbSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_settings.test", "is_active", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_settings.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdOrgNsxtVdcObject(testConfig, params["EdgeGw"].(string)),
 			},
 			// This step will "recreate" the resource because service_network_specification requires a rebuild
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_settings.test", "id", regexp.MustCompile(`\d*`)),
@@ -100,7 +100,7 @@ func TestAccVcdNsxtAlbSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_alb_settings.test", "is_active", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_settings.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_alb_virtual_service.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service.go
@@ -37,29 +37,29 @@ func resourceVcdAlbVirtualService() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway ID in which ALB Pool should be created",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of ALB Virtual Service",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Description of ALB Virtual Service",
 			},
-			"pool_id": &schema.Schema{
+			"pool_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Pool ID",
 			},
-			"service_engine_group_id": &schema.Schema{
+			"service_engine_group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -70,18 +70,18 @@ func resourceVcdAlbVirtualService() *schema.Resource {
 				Optional:    true,
 				Description: "Optional certificate ID to use for exposing service",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Virtual Service is enabled or disabled (default true)",
 			},
-			"virtual_ip_address": &schema.Schema{
+			"virtual_ip_address": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Virtual IP address (VIP) for Virtual Service",
 			},
-			"application_profile_type": &schema.Schema{
+			"application_profile_type": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "HTTP, HTTPS, L4, L4_TLS",
@@ -97,23 +97,23 @@ func resourceVcdAlbVirtualService() *schema.Resource {
 
 var nsxtAlbVirtualServicePort = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"start_port": &schema.Schema{
+		"start_port": {
 			Type:        schema.TypeInt,
 			Required:    true,
 			Description: "Starting port in the range",
 		},
-		"end_port": &schema.Schema{
+		"end_port": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Description: "Last port in the range",
 		},
-		"ssl_enabled": &schema.Schema{
+		"ssl_enabled": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
 			Description: "Defines if certificate should be used",
 		},
-		"type": &schema.Schema{
+		"type": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "One of 'TCP_PROXY', 'TCP_FAST_PATH', 'UDP_FAST_PATH'",

--- a/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
@@ -106,7 +106,7 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1, // Setup prerequisites - configure NSX-T ALB in Provider
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -124,7 +124,7 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_virtual_service.test", "vcd_nsxt_alb_virtual_service.test", nil),
@@ -134,7 +134,7 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("vcd_nsxt_alb_pool.test", "associated_virtual_services.*", t.Name()),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -151,13 +151,13 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_virtual_service.test", "vcd_nsxt_alb_virtual_service.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -183,13 +183,13 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText6, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_virtual_service.test", "vcd_nsxt_alb_virtual_service.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText7,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -217,13 +217,13 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText8, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_virtual_service.test", "vcd_nsxt_alb_virtual_service.test", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText9,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -251,13 +251,13 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_virtual_service.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, params["VirtualServiceName"].(string)),
 			},
-			resource.TestStep{
+			{
 				Config: configText11, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_nsxt_alb_virtual_service.test", "vcd_nsxt_alb_virtual_service.test", nil),
@@ -534,7 +534,7 @@ func TestAccVcdNsxtAlbVirtualServiceOrgUser(t *testing.T) {
 		),
 
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				PreConfig: configurePrerequisites, // Use temporary System session and setup all prerequisites using SDK
 				Config:    configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -553,7 +553,7 @@ func TestAccVcdNsxtAlbVirtualServiceOrgUser(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),
@@ -579,13 +579,13 @@ func TestAccVcdNsxtAlbVirtualServiceOrgUser(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_alb_virtual_service.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, params["VirtualServiceName"].(string)),
 			},
-			resource.TestStep{
+			{
 				Config: configText4, // Test data source
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_alb_virtual_service.test", "id", regexp.MustCompile(`^urn:vcloud:loadBalancerVirtualService:`)),

--- a/vcd/resource_vcd_nsxt_app_port_profile.go
+++ b/vcd/resource_vcd_nsxt_app_port_profile.go
@@ -393,7 +393,7 @@ func setNsxtAppPortProfileData(d *schema.ResourceData, appPortProfile *types.Nsx
 			appPortMap := make(map[string]interface{})
 			appPortMap["protocol"] = value.Protocol
 
-			destinationPortSet := convertStringsTotTypeSet(value.DestinationPorts)
+			destinationPortSet := convertStringsToTypeSet(value.DestinationPorts)
 			appPortMap["port"] = destinationPortSet
 
 			resultSet[index] = appPortMap

--- a/vcd/resource_vcd_nsxt_distributed_firewall.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall.go
@@ -266,16 +266,16 @@ func setDistributedFirewallData(vcdClient *VCDClient, dfwRules *types.Distribute
 	result := make([]interface{}, len(dfwRules.Values))
 	for index, value := range dfwRules.Values {
 		sourceSlice := extractIdsFromOpenApiReferences(value.SourceFirewallGroups)
-		sourceSet := convertStringsTotTypeSet(sourceSlice)
+		sourceSet := convertStringsToTypeSet(sourceSlice)
 
 		destinationSlice := extractIdsFromOpenApiReferences(value.DestinationFirewallGroups)
-		destinationSet := convertStringsTotTypeSet(destinationSlice)
+		destinationSet := convertStringsToTypeSet(destinationSlice)
 
 		appPortProfileSlice := extractIdsFromOpenApiReferences(value.ApplicationPortProfiles)
-		appPortProfileSet := convertStringsTotTypeSet(appPortProfileSlice)
+		appPortProfileSet := convertStringsToTypeSet(appPortProfileSlice)
 
 		netContextProfileSlice := extractIdsFromOpenApiReferences(value.NetworkContextProfiles)
-		netPortProfileSet := convertStringsTotTypeSet(netContextProfileSlice)
+		netPortProfileSet := convertStringsToTypeSet(netContextProfileSlice)
 
 		var actionFieldValue string
 		if vcdClient.Client.APIVCDMaxVersionIs(">= 35.2") {

--- a/vcd/resource_vcd_nsxt_firewall.go
+++ b/vcd/resource_vcd_nsxt_firewall.go
@@ -257,13 +257,13 @@ func setNsxtFirewallData(fwRules []*types.NsxtFirewallRule, d *schema.ResourceDa
 
 	for index, value := range fwRules {
 		sourceSlice := extractIdsFromOpenApiReferences(value.SourceFirewallGroups)
-		sourceSet := convertStringsTotTypeSet(sourceSlice)
+		sourceSet := convertStringsToTypeSet(sourceSlice)
 
 		destinationSlice := extractIdsFromOpenApiReferences(value.DestinationFirewallGroups)
-		destinationSet := convertStringsTotTypeSet(destinationSlice)
+		destinationSet := convertStringsToTypeSet(destinationSlice)
 
 		appPortProfileSlice := extractIdsFromOpenApiReferences(value.ApplicationPortProfiles)
-		appPortProfileSet := convertStringsTotTypeSet(appPortProfileSlice)
+		appPortProfileSet := convertStringsToTypeSet(appPortProfileSlice)
 
 		result[index] = map[string]interface{}{
 			"id":                   value.ID,

--- a/vcd/resource_vcd_nsxt_firewall.go
+++ b/vcd/resource_vcd_nsxt_firewall.go
@@ -40,54 +40,54 @@ func resourceVcdNsxtFirewall() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge Gateway ID in which Firewall Rule are located",
 			},
-			"rule": &schema.Schema{
+			"rule": {
 				Type:        schema.TypeList, // Firewall rule order matters
 				Required:    true,
 				MinItems:    1,
 				Description: "Ordered list of firewall rules",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
+						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Firewall Rule ID",
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Firewall Rule name",
 						},
-						"direction": &schema.Schema{
+						"direction": {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "Direction on which Firewall Rule applies (One of 'IN', 'OUT', 'IN_OUT')",
 							ValidateFunc: validation.StringInSlice([]string{"IN", "OUT", "IN_OUT"}, false),
 						},
-						"ip_protocol": &schema.Schema{
+						"ip_protocol": {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "Firewall Rule Protocol (One of 'IPV4', 'IPV6', 'IPV4_IPV6')",
 							ValidateFunc: validation.StringInSlice([]string{"IPV4", "IPV6", "IPV4_IPV6"}, false),
 						},
-						"action": &schema.Schema{
+						"action": {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "Defines if the rule should 'ALLOW' or 'DROP' matching traffic",
 							ValidateFunc: validation.StringInSlice([]string{"ALLOW", "DROP"}, false),
 						},
-						"enabled": &schema.Schema{
+						"enabled": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     true,
 							Description: "Defined if Firewall Rule is active",
 						},
-						"logging": &schema.Schema{
+						"logging": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     false,

--- a/vcd/resource_vcd_nsxt_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_firewall_test.go
@@ -66,7 +66,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckNsxtFirewallRulesDestroy(testConfig.Nsxt.Vdc, testConfig.Nsxt.EdgeGateway),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_firewall.testing", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*$`)),
@@ -83,7 +83,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_firewall.testing", "rule.0.app_port_profile_ids.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_firewall.testing", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*$`)),
@@ -91,7 +91,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxt_firewall.testing", "data.vcd_nsxt_firewall.testing", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_firewall.testing", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*$`)),
@@ -129,7 +129,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_firewall.testing", "rule.2.app_port_profile_ids.#", "2"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_firewall.testing", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*$`)), // Firewall resource holds ID of Edge Gateway
@@ -138,7 +138,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxt_firewall.testing", "data.vcd_nsxt_firewall.testing", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_firewall.testing", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*$`)),
@@ -176,7 +176,7 @@ func TestAccVcdNsxtFirewall(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_firewall.testing", "rule.2.app_port_profile_ids.#", "2"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_firewall.testing",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_ip_set.go
+++ b/vcd/resource_vcd_nsxt_ip_set.go
@@ -282,7 +282,7 @@ func setNsxtIpSetData(d *schema.ResourceData, ipSetType *types.NsxtFirewallGroup
 	dSet(d, "name", ipSetType.Name)
 	dSet(d, "description", ipSetType.Description)
 
-	ipSetSet := convertStringsTotTypeSet(ipSetType.IpAddresses)
+	ipSetSet := convertStringsToTypeSet(ipSetType.IpAddresses)
 
 	err := d.Set("ip_addresses", ipSetSet)
 	if err != nil {

--- a/vcd/resource_vcd_nsxt_ip_set_test.go
+++ b/vcd/resource_vcd_nsxt_ip_set_test.go
@@ -54,7 +54,7 @@ func TestAccVcdNsxtIpSetEmptyStart(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-ip-set-changed", types.FirewallGroupTypeIpSet),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -63,7 +63,7 @@ func TestAccVcdNsxtIpSetEmptyStart(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ip_set.set1", "ip_addresses.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -72,7 +72,7 @@ func TestAccVcdNsxtIpSetEmptyStart(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ip_set.set1", "ip_addresses.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText11,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -84,13 +84,13 @@ func TestAccVcdNsxtIpSetEmptyStart(t *testing.T) {
 				),
 			},
 			// Test import with no IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_ip_set.set1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-ip-set-changed"),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -105,7 +105,7 @@ func TestAccVcdNsxtIpSetEmptyStart(t *testing.T) {
 				),
 			},
 			// Test import with IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_ip_set.set1",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -158,7 +158,7 @@ func TestAccVcdNsxtIpSet(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-ip-set-changed", types.FirewallGroupTypeIpSet),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -173,7 +173,7 @@ func TestAccVcdNsxtIpSet(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -185,7 +185,7 @@ func TestAccVcdNsxtIpSet(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText11,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -200,13 +200,13 @@ func TestAccVcdNsxtIpSet(t *testing.T) {
 				),
 			},
 			// Test import with IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_ip_set.set1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-ip-set-changed"),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -339,7 +339,7 @@ func TestAccVcdNsxtIpSetOwnerVdcGroup(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-ip-set", types.FirewallGroupTypeIpSet),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -354,7 +354,7 @@ func TestAccVcdNsxtIpSetOwnerVdcGroup(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdcGroup:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_ip_set.set1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -365,7 +365,7 @@ func TestAccVcdNsxtIpSetOwnerVdcGroup(t *testing.T) {
 				),
 			},
 			// Test import with IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_ip_set.set1",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel.go
@@ -505,14 +505,14 @@ func setNsxtIpSecVpnTunnelData(d *schema.ResourceData, ipSecVpnConfig *types.Nsx
 	dSet(d, "logging", ipSecVpnConfig.Logging)
 	dSet(d, "security_profile", ipSecVpnConfig.SecurityType)
 
-	localNetworksSet := convertStringsTotTypeSet(ipSecVpnConfig.LocalEndpoint.LocalNetworks)
+	localNetworksSet := convertStringsToTypeSet(ipSecVpnConfig.LocalEndpoint.LocalNetworks)
 	err := d.Set("local_networks", localNetworksSet)
 	if err != nil {
 		return fmt.Errorf("error storing 'local_networks': %s", err)
 	}
 
 	dSet(d, "remote_ip_address", ipSecVpnConfig.RemoteEndpoint.RemoteAddress)
-	remoteNetworksSet := convertStringsTotTypeSet(ipSecVpnConfig.RemoteEndpoint.RemoteNetworks)
+	remoteNetworksSet := convertStringsToTypeSet(ipSecVpnConfig.RemoteEndpoint.RemoteNetworks)
 	err = d.Set("remote_networks", remoteNetworksSet)
 	if err != nil {
 		return fmt.Errorf("error storing 'remote_networks': %s", err)
@@ -573,15 +573,15 @@ func setNsxtIpSecVpnProfileTunnelConfigurationData(d *schema.ResourceData, tunne
 
 	secProfileMap := make(map[string]interface{})
 	secProfileMap["ike_version"] = tunnelConfig.IkeConfiguration.IkeVersion
-	secProfileMap["ike_encryption_algorithms"] = convertStringsTotTypeSet(tunnelConfig.IkeConfiguration.EncryptionAlgorithms)
-	secProfileMap["ike_digest_algorithms"] = convertStringsTotTypeSet(tunnelConfig.IkeConfiguration.DigestAlgorithms)
-	secProfileMap["ike_dh_groups"] = convertStringsTotTypeSet(tunnelConfig.IkeConfiguration.DhGroups)
+	secProfileMap["ike_encryption_algorithms"] = convertStringsToTypeSet(tunnelConfig.IkeConfiguration.EncryptionAlgorithms)
+	secProfileMap["ike_digest_algorithms"] = convertStringsToTypeSet(tunnelConfig.IkeConfiguration.DigestAlgorithms)
+	secProfileMap["ike_dh_groups"] = convertStringsToTypeSet(tunnelConfig.IkeConfiguration.DhGroups)
 	secProfileMap["ike_sa_lifetime"] = tunnelConfig.IkeConfiguration.SaLifeTime
 	secProfileMap["tunnel_pfs_enabled"] = tunnelConfig.TunnelConfiguration.PerfectForwardSecrecyEnabled
 	secProfileMap["tunnel_df_policy"] = tunnelConfig.TunnelConfiguration.DfPolicy
-	secProfileMap["tunnel_encryption_algorithms"] = convertStringsTotTypeSet(tunnelConfig.TunnelConfiguration.EncryptionAlgorithms)
-	secProfileMap["tunnel_digest_algorithms"] = convertStringsTotTypeSet(tunnelConfig.TunnelConfiguration.DigestAlgorithms)
-	secProfileMap["tunnel_dh_groups"] = convertStringsTotTypeSet(tunnelConfig.TunnelConfiguration.DhGroups)
+	secProfileMap["tunnel_encryption_algorithms"] = convertStringsToTypeSet(tunnelConfig.TunnelConfiguration.EncryptionAlgorithms)
+	secProfileMap["tunnel_digest_algorithms"] = convertStringsToTypeSet(tunnelConfig.TunnelConfiguration.DigestAlgorithms)
+	secProfileMap["tunnel_dh_groups"] = convertStringsToTypeSet(tunnelConfig.TunnelConfiguration.DhGroups)
 	secProfileMap["tunnel_sa_lifetime"] = tunnelConfig.TunnelConfiguration.SaLifeTime
 	secProfileMap["dpd_probe_internal"] = tunnelConfig.DpdConfiguration.ProbeInterval
 

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel.go
@@ -42,35 +42,35 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which IP Sec VPN configuration is located",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Enables or disables this configuration (default true)",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of IP Sec VPN Tunnel",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Description IP Sec VPN Tunnel",
 			},
-			"pre_shared_key": &schema.Schema{
+			"pre_shared_key": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Sensitive:   true,
 				Description: "Pre-Shared Key (PSK)",
 			},
-			"local_ip_address": &schema.Schema{
+			"local_ip_address": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "IPv4 Address for the endpoint. This has to be a sub-allocated IP on the Edge Gateway.",
@@ -84,7 +84,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"remote_ip_address": &schema.Schema{
+			"remote_ip_address": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Public IPv4 Address of the remote device terminating the VPN connection",
@@ -97,26 +97,26 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"logging": &schema.Schema{
+			"logging": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Sets whether logging for the tunnel is enabled or not. (default - false)",
 			},
-			"security_profile_customization": &schema.Schema{
+			"security_profile_customization": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
 				Description: "Security profile customization",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"ike_version": &schema.Schema{
+						"ike_version": {
 							Type:         schema.TypeString,
 							Required:     true,
 							Description:  "IKE version one of IKE_V1, IKE_V2, IKE_FLEX",
 							ValidateFunc: validation.StringInSlice([]string{"IKE_V1", "IKE_V2", "IKE_FLEX"}, false),
 						},
-						"ike_encryption_algorithms": &schema.Schema{
+						"ike_encryption_algorithms": {
 							Type:        schema.TypeSet,
 							Required:    true,
 							Description: "Encryption algorithms. One of SHA1, SHA2_256, SHA2_384, SHA2_512",
@@ -124,7 +124,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_digest_algorithms": &schema.Schema{
+						"ike_digest_algorithms": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Description: "Secure hashing algorithms to use during the IKE negotiation. One of SHA1, " +
@@ -133,7 +133,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_dh_groups": &schema.Schema{
+						"ike_dh_groups": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Description: "Diffie-Hellman groups to be used if Perfect Forward Secrecy is enabled. One " +
@@ -142,21 +142,21 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"ike_sa_lifetime": &schema.Schema{
+						"ike_sa_lifetime": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Description: "Security Association life time (in seconds). It is number of seconds " +
 								"before the IPsec tunnel needs to reestablish",
 						},
 
-						"tunnel_pfs_enabled": &schema.Schema{
+						"tunnel_pfs_enabled": {
 							Type:        schema.TypeBool,
 							Optional:    true,
 							Default:     true,
 							Description: "Perfect Forward Secrecy Enabled or Disabled. Default (enabled)",
 						},
 
-						"tunnel_df_policy": &schema.Schema{
+						"tunnel_df_policy": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "COPY",
@@ -164,7 +164,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"COPY", "CLEAR"}, false),
 						},
 
-						"tunnel_encryption_algorithms": &schema.Schema{
+						"tunnel_encryption_algorithms": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Description: "Encryption algorithms to use in IPSec tunnel establishment. One of AES_128, " +
@@ -174,7 +174,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_digest_algorithms": &schema.Schema{
+						"tunnel_digest_algorithms": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Description: "Digest algorithms to be used for message digest. One of SHA1, SHA2_256, " +
@@ -183,7 +183,7 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_dh_groups": &schema.Schema{
+						"tunnel_dh_groups": {
 							Type:     schema.TypeSet,
 							Required: true,
 							Description: "Diffie-Hellman groups to be used is PFS is enabled. One of GROUP2, GROUP5, " +
@@ -192,12 +192,12 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 								Type: schema.TypeString,
 							},
 						},
-						"tunnel_sa_lifetime": &schema.Schema{
+						"tunnel_sa_lifetime": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Security Association life time (in seconds)",
 						},
-						"dpd_probe_internal": &schema.Schema{
+						"dpd_probe_internal": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Description: "Value in seconds of dead probe detection interval. Minimum is 3 seconds and " +
@@ -207,23 +207,23 @@ func resourceVcdNsxtIpSecVpnTunnel() *schema.Resource {
 				},
 			},
 			// Computed attributes from here
-			"security_profile": &schema.Schema{
+			"security_profile": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "Security type which is use for IPsec VPN Tunnel. It will be 'DEFAULT' if nothing is " +
 					"customized and 'CUSTOM' if some changes are applied",
 			},
-			"status": &schema.Schema{
+			"status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Overall IPsec VPN Tunnel Status",
 			},
-			"ike_service_status": &schema.Schema{
+			"ike_service_status": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Status for the actual IKE Session for the given tunnel",
 			},
-			"ike_fail_reason": &schema.Schema{
+			"ike_fail_reason": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Provides more details of failure if the IKE service is not UP",

--- a/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
+++ b/vcd/resource_vcd_nsxt_ipsec_vpn_tunnel_test.go
@@ -70,7 +70,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 			testAccCheckNsxtIpSecVpnTunnelDestroy("test-tunnel-1-updated"),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -91,7 +91,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),
@@ -114,7 +114,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -130,7 +130,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),
@@ -148,7 +148,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -167,7 +167,7 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText6,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),
@@ -190,14 +190,14 @@ func TestAccVcdNsxtIpSecVpnTunnel(t *testing.T) {
 			},
 
 			// Test import with IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_ipsec_vpn_tunnel.tunnel1",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-tunnel-1"),
 			},
 			// Try to import by UUID
-			resource.TestStep{
+			{
 				ResourceName: "vcd_nsxt_ipsec_vpn_tunnel.tunnel1",
 				ImportState:  true,
 				// Not using pre-built complete ID because ID is not known in advance. This field allows to specify
@@ -341,7 +341,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 			testAccCheckNsxtIpSecVpnTunnelDestroy("test-tunnel-1-updated"),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -382,7 +382,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.0.dpd_probe_internal", "30"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),
@@ -426,7 +426,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.0.dpd_probe_internal", "30"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -451,7 +451,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.0.ike_encryption_algorithms.*", "AES_128"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),
@@ -478,7 +478,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.0.ike_encryption_algorithms.*", "AES_128"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "id"),
@@ -500,7 +500,7 @@ func TestAccVcdNsxtIpSecVpnTunnelCustomProfile(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "security_profile_customization.#", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText6,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("vcd_nsxt_ipsec_vpn_tunnel.tunnel1", "data.vcd_nsxt_ipsec_vpn_tunnel.tunnel1", ignoreDataSourceFields),

--- a/vcd/resource_vcd_nsxt_nat_rule.go
+++ b/vcd/resource_vcd_nsxt_nat_rule.go
@@ -41,74 +41,74 @@ func resourceVcdNsxtNatRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway_id": &schema.Schema{
+			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which NAT Rule is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of NAT rule",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				Description:  "Rule type - one of 'DNAT', 'NO_DNAT', 'SNAT', 'NO_SNAT', 'REFLEXIVE'",
 				ValidateFunc: validation.StringInSlice([]string{"DNAT", "NO_DNAT", "SNAT", "NO_SNAT", "REFLEXIVE"}, false),
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Description of NAT rule",
 			},
-			"external_address": &schema.Schema{
+			"external_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "IP address or CIDR of external network",
 			},
-			"internal_address": &schema.Schema{
+			"internal_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "IP address or CIDR of the virtual machines for which you are configuring NAT",
 			},
-			"app_port_profile_id": &schema.Schema{
+			"app_port_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Application Port Profile to apply for this rule",
 			},
-			"dnat_external_port": &schema.Schema{
+			"dnat_external_port": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "For DNAT only. Enter a port into which the DNAT rule is translating for the packets inbound to the virtual machines.",
 			},
-			"snat_destination_address": &schema.Schema{
+			"snat_destination_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "For SNAT only. If you want the rule to apply only for traffic to a specific domain, enter an IP address for this domain or an IP address range in CIDR format.",
 			},
-			"logging": &schema.Schema{
+			"logging": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Enable logging when this rule is applied",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Enables or disables this rule",
 			},
-			"firewall_match": &schema.Schema{
+			"firewall_match": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				Description:  "VCD 10.2.2+ Determines how the firewall matches the address during NATing if firewall stage is not skipped. One of 'MATCH_INTERNAL_ADDRESS', 'MATCH_EXTERNAL_ADDRESS', 'BYPASS'",
 				ValidateFunc: validation.StringInSlice([]string{"MATCH_INTERNAL_ADDRESS", "MATCH_EXTERNAL_ADDRESS", "BYPASS"}, false),
 			},
-			"priority": &schema.Schema{
+			"priority": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,

--- a/vcd/resource_vcd_nsxt_nat_rule_test.go
+++ b/vcd/resource_vcd_nsxt_nat_rule_test.go
@@ -62,7 +62,7 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 			testAccCheckNsxtNatRuleDestroy("test-dnat-rule-updated"),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
@@ -79,14 +79,14 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 					natRuleId.cacheTestResourceFieldValue("vcd_nsxt_nat_rule.dnat", "id"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
 					resourceFieldsEqual("vcd_nsxt_nat_rule.dnat", "data.vcd_nsxt_nat_rule.nat", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
@@ -103,14 +103,14 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat", "enabled", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
 					resourceFieldsEqual("vcd_nsxt_nat_rule.dnat", "data.vcd_nsxt_nat_rule.nat", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.dnat", "id"),
@@ -119,14 +119,14 @@ func TestAccVcdNsxtNatRuleDnat(t *testing.T) {
 				),
 			},
 			// Try to import by Name
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.dnat",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObject(testConfig, testConfig.Nsxt.EdgeGateway, "test-dnat-rule-updated"),
 			},
 			// Try to import by rule UUID
-			resource.TestStep{
+			{
 				ResourceName: "vcd_nsxt_nat_rule.dnat",
 				ImportState:  true,
 				// Not using pre-built complete ID because ID is not known in advance. This field allows to specify
@@ -260,7 +260,7 @@ func TestAccVcdNsxtNatRuleNoDnat(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-no-dnat-rule"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-dnat", "id"),
@@ -273,7 +273,7 @@ func TestAccVcdNsxtNatRuleNoDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-dnat", "dnat_external_port", "7777"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.no-dnat",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -344,7 +344,7 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 			testAccCheckNsxtNatRuleDestroy("test-snat-rule-updated"),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
@@ -360,14 +360,14 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
 					resourceFieldsEqual("vcd_nsxt_nat_rule.snat", "data.vcd_nsxt_nat_rule.nat", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
@@ -383,14 +383,14 @@ func TestAccVcdNsxtNatRuleSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.snat", "logging", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.snat", "id"),
 					resourceFieldsEqual("vcd_nsxt_nat_rule.snat", "data.vcd_nsxt_nat_rule.nat", nil),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.snat",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -466,7 +466,7 @@ func TestAccVcdNsxtNatRuleNoSnat(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-no-snat-rule"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_nsxt_nat_rule.no-snat", "id"),
@@ -476,7 +476,7 @@ func TestAccVcdNsxtNatRuleNoSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.no-snat", "internal_address", "11.11.11.0/24"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.no-snat",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -559,7 +559,7 @@ func TestAccVcdNsxtNatRuleFirewallMatchPriority(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-dnat-rule-match-and-priority"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      configText1,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -569,7 +569,7 @@ func TestAccVcdNsxtNatRuleFirewallMatchPriority(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "10"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:      configText2,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -579,7 +579,7 @@ func TestAccVcdNsxtNatRuleFirewallMatchPriority(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "30"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:      configText3,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -589,7 +589,7 @@ func TestAccVcdNsxtNatRuleFirewallMatchPriority(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.dnat-match", "priority", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.dnat-match",
 				ExpectError:       expectImportError,
 				ImportState:       true,
@@ -681,7 +681,7 @@ func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckNsxtNatRuleDestroy("test-dnat-rule-match-and-priority"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      configText1,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -692,7 +692,7 @@ func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.reflexive", "priority", "10"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:      configText2,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -703,7 +703,7 @@ func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.reflexive", "priority", "30"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:      configText3,
 				ExpectError: expectError,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -714,7 +714,7 @@ func TestAccVcdNsxtNatRuleReflexive(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxt_nat_rule.reflexive", "priority", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_nat_rule.reflexive",
 				ExpectError:       expectImportError,
 				ImportState:       true,

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -14,12 +14,12 @@ import (
 
 var nsxtDhcpPoolSetSchema = &schema.Resource{
 	Schema: map[string]*schema.Schema{
-		"start_address": &schema.Schema{
+		"start_address": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "Start address of DHCP pool IP range",
 		},
-		"end_address": &schema.Schema{
+		"end_address": {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "End address of DHCP pool IP range",
@@ -52,13 +52,13 @@ func resourceVcdOpenApiDhcp() *schema.Resource {
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
 
-			"org_network_id": &schema.Schema{
+			"org_network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Parent Org VDC network ID",
 			},
-			"pool": &schema.Schema{
+			"pool": {
 				Type:        schema.TypeSet,
 				Required:    true,
 				Description: "IP ranges used for DHCP pool allocation in the network",

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -40,7 +40,7 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, "nsxt-routed-dhcp"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
@@ -50,7 +50,7 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_network_dhcp.pools", "id", regexp.MustCompile(`^urn:vcloud:network:.*$`)),
@@ -64,7 +64,7 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_network_dhcp.pools",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_security_group.go
+++ b/vcd/resource_vcd_nsxt_security_group.go
@@ -353,7 +353,7 @@ func setNsxtSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGrou
 	}
 
 	// Convert `member_org_network_ids` to set
-	memberNetSet := convertStringsTotTypeSet(netIds)
+	memberNetSet := convertStringsToTypeSet(netIds)
 
 	err := d.Set("member_org_network_ids", memberNetSet)
 	if err != nil {

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -48,7 +48,7 @@ func TestAccVcdNsxtSecurityGroupEmpty(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -58,7 +58,7 @@ func TestAccVcdNsxtSecurityGroupEmpty(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_vm_ids"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -68,7 +68,7 @@ func TestAccVcdNsxtSecurityGroupEmpty(t *testing.T) {
 					resource.TestCheckNoResourceAttr("vcd_nsxt_security_group.group1", "member_vm_ids"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_security_group.group1",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -157,7 +157,7 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -174,7 +174,7 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -193,7 +193,7 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxt_security_group.group1", "data.vcd_nsxt_security_group.group1", []string{}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -204,7 +204,7 @@ func TestAccVcdNsxtSecurityGroup(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdc:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_security_group.group1",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -381,15 +381,15 @@ func TestAccVcdNsxtSecurityGroupInvalidConfigs(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config:      configText,
 				ExpectError: regexp.MustCompile(`please use 'vcd_nsxt_edgegateway' for NSX-T backed VDC`),
 			},
-			resource.TestStep{
+			{
 				Config:      configText1,
 				ExpectError: regexp.MustCompile(`error retrieving Edge Gateway structure`),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				// for NSX-T error is like: error creating NSX-T Firewall Group: error in HTTP POST request:
 				//BAD_REQUEST - [ 4533e9db-3680-435c-8f0d-d6e7636af5f7 ] Invalid Network c4472168-7e8d-4f93-b257-2194e9fc23d9
@@ -536,7 +536,7 @@ func TestAccVcdNsxtSecurityGroupOwnerVdcGroup(t *testing.T) {
 			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-ip-set", types.FirewallGroupTypeSecurityGroup),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -553,7 +553,7 @@ func TestAccVcdNsxtSecurityGroupOwnerVdcGroup(t *testing.T) {
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "owner_id", regexp.MustCompile(`^urn:vcloud:vdcGroup:.*$`)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
@@ -565,7 +565,7 @@ func TestAccVcdNsxtSecurityGroupOwnerVdcGroup(t *testing.T) {
 				),
 			},
 			// Test import with IP addresses
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxt_security_group.group1",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxt_standalone_vm_test.go
+++ b/vcd/resource_vcd_nsxt_standalone_vm_test.go
@@ -82,7 +82,7 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, orgName, vdcName),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, orgName, vdcName),
@@ -117,7 +117,7 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_vm." + standaloneVmName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -130,11 +130,11 @@ func TestAccVcdNsxtStandaloneVmTemplate(t *testing.T) {
 					"accept_all_eulas", "power_on", "computer_name", "prevent_update_power_off", "network.1.ip", "network_dhcp_wait_seconds"},
 			},
 			// This step ensures that VM and disk are removed, but networks are left
-			resource.TestStep{
+			{
 				Config: configText2,
 			},
 			// This step gives 10-second sleep timer so that cleanup bug is not hit in VCD 10.3
-			resource.TestStep{
+			{
 				Config:    configText2,
 				PreConfig: func() { time.Sleep(10 * time.Second) },
 			},
@@ -188,7 +188,7 @@ func TestAccVcdNsxtStandaloneEmptyVm(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, orgName, vdcName),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, orgName, vdcName),

--- a/vcd/resource_vcd_nsxt_vapp_raw_test.go
+++ b/vcd/resource_vcd_nsxt_vapp_raw_test.go
@@ -57,7 +57,7 @@ func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdNsxtVAppRawDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdNsxtVAppRawExists(fmt.Sprintf("vcd_vapp.%s", params["VappName"].(string)), &vapp),
@@ -73,11 +73,11 @@ func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 				),
 			},
 			// This step ensures that VM and disk are removed, but networks are left
-			resource.TestStep{
+			{
 				Config: configText2,
 			},
 			// This step gives 10-second sleep timer so that cleanup bug is not hit in VCD 10.3
-			resource.TestStep{
+			{
 				Config:    configText2,
 				PreConfig: func() { time.Sleep(10 * time.Second) },
 			},

--- a/vcd/resource_vcd_nsxv_dhcp_relay.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay.go
@@ -49,7 +49,7 @@ func resourceVcdNsxvDhcpRelay() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,

--- a/vcd/resource_vcd_nsxv_dhcp_relay.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay.go
@@ -308,13 +308,13 @@ func setDhcpRelayServerData(d *schema.ResourceData, edgeRelay *types.EdgeDhcpRel
 		return nil
 	}
 
-	relayServerIpAddressesSet := convertStringsTotTypeSet(relayServer.IpAddress)
+	relayServerIpAddressesSet := convertStringsToTypeSet(relayServer.IpAddress)
 	err := d.Set("ip_addresses", relayServerIpAddressesSet)
 	if err != nil {
 		return fmt.Errorf("could not save ip_addresses to schema: %s", err)
 	}
 
-	relayServerDomainNamesSet := convertStringsTotTypeSet(relayServer.Fqdns)
+	relayServerDomainNamesSet := convertStringsToTypeSet(relayServer.Fqdns)
 	err = d.Set("domain_names", relayServerDomainNamesSet)
 	if err != nil {
 		return fmt.Errorf("could not save domain_names to schema: %s", err)
@@ -324,7 +324,7 @@ func setDhcpRelayServerData(d *schema.ResourceData, edgeRelay *types.EdgeDhcpRel
 		return fmt.Errorf("could not find names for all IP set IDs: %s", err)
 	}
 
-	relayServerIpSetNamesSet := convertStringsTotTypeSet(ipSetNames)
+	relayServerIpSetNamesSet := convertStringsToTypeSet(ipSetNames)
 	err = d.Set("ip_sets", relayServerIpSetNamesSet)
 	if err != nil {
 		return fmt.Errorf("could not save ip_sets to schema: %s", err)

--- a/vcd/resource_vcd_nsxv_dhcp_relay_test.go
+++ b/vcd/resource_vcd_nsxv_dhcp_relay_test.go
@@ -44,7 +44,7 @@ func TestAccVcdNsxvDhcpRelay(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdDhcpRelaySettingsEmpty(),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dhcp_relay.relay_config", "id", regexp.MustCompile(`^.*:dhcpRelay$`)),
@@ -71,7 +71,7 @@ func TestAccVcdNsxvDhcpRelay(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dhcp_relay.relay_config", "id", regexp.MustCompile(`^urn:vcloud:gateway:.*:dhcpRelay$`)),
@@ -89,7 +89,7 @@ func TestAccVcdNsxvDhcpRelay(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_nsxv_dhcp_relay.relay_config",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_nsxv_dnat.go
+++ b/vcd/resource_vcd_nsxv_dnat.go
@@ -35,65 +35,65 @@ func resourceVcdNsxvDnat() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which NAT Rule is located",
 			},
-			"network_name": &schema.Schema{
+			"network_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Org or external network name",
 			},
-			"network_type": &schema.Schema{
+			"network_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"ext", "org"}, false),
 				Description:  "Network type. One of 'ext', 'org'",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Computed:    true,
 				Description: "Read only. Possible values 'user', 'internal_high'",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 				Description: "Optional. Allows to set custom rule tag",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     true,
 				Description: "Whether the rule should be enabled. Default 'true'",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     false,
 				Description: "Whether logging should be enabled for this rule. Default 'false'",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Description: "NAT rule description",
 			},
-			"original_address": &schema.Schema{
+			"original_address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 				Description: "Original address or address range. This is the " +
 					"the destination address for DNAT rules.",
 			},
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         false,
@@ -101,7 +101,7 @@ func resourceVcdNsxvDnat() *schema.Resource {
 				ValidateFunc:     validateCase("lower"),
 				Description:      "Protocol. Such as 'tcp', 'udp', 'icmp', 'any'",
 			},
-			"icmp_type": &schema.Schema{
+			"icmp_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     false,
@@ -111,20 +111,20 @@ func resourceVcdNsxvDnat() *schema.Resource {
 					"`echo-reply`, `parameter-problem`, `redirect`, `router-advertisement`, `router-solicitation`, " +
 					"`source-quench`, `time-exceeded`, `timestamp-request`, `timestamp-reply`. Default `any`",
 			},
-			"original_port": &schema.Schema{
+			"original_port": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         false,
 				DiffSuppressFunc: suppressWordToEmptyString("any"),
 				Description:      "Original port. This is the destination port for DNAT rules",
 			},
-			"translated_address": &schema.Schema{
+			"translated_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Description: "Translated address or address range",
 			},
-			"translated_port": &schema.Schema{
+			"translated_port": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         false,

--- a/vcd/resource_vcd_nsxv_dnat_test.go
+++ b/vcd/resource_vcd_nsxv_dnat_test.go
@@ -56,7 +56,7 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdNatRuleDestroy("vcd_nsxv_dnat.test2"),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // Step 0 - minimal configuration and data source
+			{ // Step 0 - minimal configuration and data source
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dnat.test", "id", regexp.MustCompile(`\d*`)),
@@ -88,7 +88,7 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 					resource.TestCheckResourceAttrPair("vcd_nsxv_dnat.test", "translated_port", "data.vcd_nsxv_dnat.data-test", "translated_port"),
 				),
 			},
-			resource.TestStep{ // Step 1 - update
+			{ // Step 1 - update
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dnat.test", "id", regexp.MustCompile(`\d*`)),
@@ -105,7 +105,7 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{ // Step 2 - update with majority defaulted fields
+			{ // Step 2 - update with majority defaulted fields
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dnat.test", "id", regexp.MustCompile(`\d*`)),
@@ -121,7 +121,7 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxv_dnat.test", "enabled", "true"),
 				),
 			},
-			resource.TestStep{ // Step 3 - switch nat rule to org network
+			{ // Step 3 - switch nat rule to org network
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dnat.test", "id", regexp.MustCompile(`\d*`)),
@@ -138,13 +138,13 @@ func TestAccVcdEdgeDnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxv_dnat.test", "enabled", "true"),
 				),
 			},
-			resource.TestStep{ // Step 4 - resource import
+			{ // Step 4 - resource import
 				ResourceName:      "vcd_nsxv_dnat.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdByResourceName("vcd_nsxv_dnat.test"),
 			},
-			resource.TestStep{ // Step 5 - Another resource with different settings
+			{ // Step 5 - Another resource with different settings
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_dnat.test2", "id", regexp.MustCompile(`\d*`)),

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -649,27 +649,27 @@ func getEndpointData(endpoint types.EdgeFirewallEndpoint, edge *govcd.EdgeGatewa
 	if err != nil {
 		return nil, fmt.Errorf("could not convert org network IDs to names: %s", err)
 	}
-	endpointNetworksSet := convertStringsTotTypeSet(endpointNetworkNames)
+	endpointNetworksSet := convertStringsToTypeSet(endpointNetworkNames)
 
 	// Convert virtual machine IDs to set
-	endpointVmSet := convertStringsTotTypeSet(endpointVMs)
+	endpointVmSet := convertStringsToTypeSet(endpointVMs)
 
 	// Convert `ip_addresses` to set
-	endpointIpsSet := convertStringsTotTypeSet(endpoint.IpAddresses)
+	endpointIpsSet := convertStringsToTypeSet(endpoint.IpAddresses)
 
 	// Convert `gateway_interfaces` vNic IDs to network names as the UI does it so
 	vnicGroupIdStrings, err := edgeVnicIdStringsToNetworkNames(endpoint.VnicGroupIds, edge)
 	if err != nil {
 		return nil, err
 	}
-	endpointGatewayInterfaceSet := convertStringsTotTypeSet(vnicGroupIdStrings)
+	endpointGatewayInterfaceSet := convertStringsToTypeSet(vnicGroupIdStrings)
 
 	// Convert ipset IDs to set of names and create a TypeSet of it
 	endpointIpSetNames, err := ipSetIdsToNames(endpointIpSets, vdc)
 	if err != nil {
 		return nil, fmt.Errorf("could not IP set IDs to names: %s", err)
 	}
-	endpointIpSetSet := convertStringsTotTypeSet(endpointIpSetNames)
+	endpointIpSetSet := convertStringsToTypeSet(endpointIpSetNames)
 
 	// TODO uncomment when Security groups are supported
 	// Convert security group IDs to set

--- a/vcd/resource_vcd_nsxv_firewall_rule.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule.go
@@ -40,50 +40,50 @@ func resourceVcdNsxvFirewallRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which Firewall Rule is located",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Firewall rule name",
 			},
-			"above_rule_id": &schema.Schema{
+			"above_rule_id": {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
 				Description: "This firewall rule will be inserted above the referred one",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 				Description: "Read only. Possible values 'user', 'internal_high'",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 				Description: "Optional. Allows to set custom rule tag",
 			},
-			"action": &schema.Schema{
+			"action": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "accept",
 				Description:  "'accept' or 'deny'. Default 'accept'",
 				ValidateFunc: validation.StringInSlice([]string{"accept", "deny"}, false),
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Whether the rule should be enabled. Default 'true'",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -69,7 +69,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.rule6"),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // Step 0 - configuration only with ip_addresses
+			{ // Step 0 - configuration only with ip_addresses
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule0", "id", regexp.MustCompile(`\d*`)),
@@ -148,7 +148,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxv_firewall_rule.rule0", "data.vcd_nsxv_firewall_rule.rule0", []string{"rule_id"}),
 				),
 			},
-			resource.TestStep{ // Step 1 - configuration only with gateway_interfaces (internal, external)
+			{ // Step 1 - configuration only with gateway_interfaces (internal, external)
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule1", "id", regexp.MustCompile(`\d*`)),
@@ -184,7 +184,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{ // Step 2 - configuration only with gateway_interfaces (lookup)
+			{ // Step 2 - configuration only with gateway_interfaces (lookup)
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule2", "id", regexp.MustCompile(`\d*`)),
@@ -219,7 +219,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{ // Step 3 - only org networks
+			{ // Step 3 - only org networks
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule3", "id", regexp.MustCompile(`\d*`)),
@@ -255,7 +255,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{ // Step 4
+			{ // Step 4
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule4", "id", regexp.MustCompile(`\d*`)),
@@ -345,7 +345,7 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					resourceFieldsEqual("vcd_nsxv_firewall_rule.rule4", "data.vcd_nsxv_firewall_rule.rule4", []string{"rule_id"}),
 				),
 			},
-			resource.TestStep{ // Step 5 -
+			{ // Step 5 -
 				Config: configText5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule5", "id", regexp.MustCompile(`\d*`)),
@@ -386,19 +386,19 @@ func TestAccVcdNsxvEdgeFirewallRule(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{ // Step 6 - resource import by real ID
+			{ // Step 6 - resource import by real ID
 				ResourceName:      "vcd_nsxv_firewall_rule.rule5",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdByResourceName("vcd_nsxv_firewall_rule.rule5"),
 			},
-			resource.TestStep{ // Step 7 - resource import by UI Number
+			{ // Step 7 - resource import by UI Number
 				ResourceName:      "vcd_nsxv_firewall_rule.rule5",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateFirewallUiNumberByResourceName("vcd_nsxv_firewall_rule.rule5"),
 			},
-			resource.TestStep{ // Step 8 - two rules - one above another
+			{ // Step 8 - two rules - one above another
 				Config: configText8,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.rule6", "id", regexp.MustCompile(`\d*`)),
@@ -911,7 +911,7 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.ip_sets"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "id", regexp.MustCompile(`\d*`)),
@@ -948,7 +948,7 @@ func TestAccVcdNsxvEdgeFirewallRuleIpSets(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.ip_sets", "id", regexp.MustCompile(`\d*`)),
@@ -1086,7 +1086,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdFirewallRuleDestroy("vcd_nsxv_firewall_rule.vms"),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),
@@ -1121,7 +1121,7 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_firewall_rule.vms", "id", regexp.MustCompile(`\d*`)),

--- a/vcd/resource_vcd_nsxv_snat.go
+++ b/vcd/resource_vcd_nsxv_snat.go
@@ -35,65 +35,65 @@ func resourceVcdNsxvSnat() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"edge_gateway": &schema.Schema{
+			"edge_gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Edge gateway name in which NAT Rule is located",
 			},
-			"network_name": &schema.Schema{
+			"network_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Org or external network name",
 			},
-			"network_type": &schema.Schema{
+			"network_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"ext", "org"}, false),
 				Description:  "Network type. One of 'ext', 'org'",
 			},
-			"rule_type": &schema.Schema{
+			"rule_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Computed:    true,
 				Description: "Read only. Possible values 'user', 'internal_high'",
 			},
-			"rule_tag": &schema.Schema{
+			"rule_tag": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 				Description: "Optional. Allows to set custom rule tag",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     true,
 				Description: "Whether the rule should be enabled. Default 'true'",
 			},
-			"logging_enabled": &schema.Schema{
+			"logging_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    false,
 				Default:     false,
 				Description: "Whether logging should be enabled for this rule. Default 'false'",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,
 				Description: "NAT rule description",
 			},
-			"original_address": &schema.Schema{
+			"original_address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 				Description: "Original address or address range. This is the " +
 					"the source address for SNAT rules",
 			},
-			"translated_address": &schema.Schema{
+			"translated_address": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    false,

--- a/vcd/resource_vcd_nsxv_snat_test.go
+++ b/vcd/resource_vcd_nsxv_snat_test.go
@@ -40,7 +40,7 @@ func TestAccVcdEdgeSnat(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckVcdNatRuleDestroy("vcd_nsxv_snat.test"),
 		Steps: []resource.TestStep{
-			resource.TestStep{ // Step 0 - minimal configuration and data source
+			{ // Step 0 - minimal configuration and data source
 				Config: configText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_snat.test", "id", regexp.MustCompile(`\d*`)),
@@ -68,7 +68,7 @@ func TestAccVcdEdgeSnat(t *testing.T) {
 					resource.TestCheckResourceAttrPair("vcd_nsxv_snat.test", "network_type", "data.vcd_nsxv_snat.data-test", "network_type"),
 				),
 			},
-			resource.TestStep{ // Step 1 - update
+			{ // Step 1 - update
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxv_snat.test", "id", regexp.MustCompile(`\d*`)),
@@ -82,7 +82,7 @@ func TestAccVcdEdgeSnat(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_nsxv_snat.test", "network_type", "org"),
 				),
 			},
-			resource.TestStep{ // Step 2 - resource import
+			{ // Step 2 - resource import
 				ResourceName:      "vcd_nsxv_snat.test",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_org_group.go
+++ b/vcd/resource_vcd_org_group.go
@@ -3,9 +3,10 @@ package vcd
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -125,7 +126,7 @@ func resourceVcdOrgGroupRead(_ context.Context, d *schema.ResourceData, meta int
 	for _, userRef := range group.Group.UsersList.UserReference {
 		users = append(users, userRef.Name)
 	}
-	err = d.Set("user_names", convertStringsTotTypeSet(users))
+	err = d.Set("user_names", convertStringsToTypeSet(users))
 	if err != nil {
 		return diag.Errorf("could not set user_names field: %s", err)
 	}

--- a/vcd/resource_vcd_org_user.go
+++ b/vcd/resource_vcd_org_user.go
@@ -270,7 +270,7 @@ func setOrgUserData(d *schema.ResourceData, orgUser *govcd.OrgUser, adminOrg *go
 	for _, groupRef := range orgUser.User.GroupReferences.GroupReference {
 		groups = append(groups, groupRef.Name)
 	}
-	err := d.Set("group_names", convertStringsTotTypeSet(groups))
+	err := d.Set("group_names", convertStringsToTypeSet(groups))
 	if err != nil {
 		return fmt.Errorf("could not set group_names field: %s", err)
 	}

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -62,22 +62,22 @@ func resourceVcdOrgVdc() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"allocation_model": &schema.Schema{
+			"allocation_model": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"AllocationVApp", "AllocationPool", "ReservationPool", "Flex"}, false),
 				Description:  "The allocation model used by this VDC; must be one of {AllocationVApp, AllocationPool, ReservationPool, Flex}",
 			},
-			"compute_capacity": &schema.Schema{
+			"compute_capacity": {
 				Required: true,
 				MinItems: 1,
 				MaxItems: 1,
@@ -90,28 +90,28 @@ func resourceVcdOrgVdc() *schema.Resource {
 				},
 				Description: "The compute capacity allocated to this VDC.",
 			},
-			"nic_quota": &schema.Schema{
+			"nic_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum number of virtual NICs allowed in this VDC. Defaults to 0, which specifies an unlimited number.",
 			},
-			"network_quota": &schema.Schema{
+			"network_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum number of network objects that can be deployed in this VDC. Defaults to 0, which means no networks can be deployed.",
 			},
-			"vm_quota": &schema.Schema{
+			"vm_quota": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "The maximum number of VMs that can be created in this VDC. Includes deployed and undeployed VMs in vApps and vApp templates. Defaults to 0, which specifies an unlimited number.",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "True if this VDC is enabled for use by the organization VDCs. Default is true.",
 			},
-			"storage_profile": &schema.Schema{
+			"storage_profile": {
 				Type:        schema.TypeSet,
 				Required:    true,
 				ForceNew:    false,
@@ -148,7 +148,7 @@ func resourceVcdOrgVdc() *schema.Resource {
 					},
 				},
 			},
-			"memory_guaranteed": &schema.Schema{
+			"memory_guaranteed": {
 				Type:     schema.TypeFloat,
 				Computed: true,
 				Optional: true,
@@ -156,7 +156,7 @@ func resourceVcdOrgVdc() *schema.Resource {
 					"For example, if this value is 0.75, then 75% of allocated resources are guaranteed. " +
 					"Required when AllocationModel is AllocationVApp or AllocationPool. When Allocation model is AllocationPool minimum value is 0.2. If the element is empty, vCD sets a value.",
 			},
-			"cpu_guaranteed": &schema.Schema{
+			"cpu_guaranteed": {
 				Type:     schema.TypeFloat,
 				Optional: true,
 				Computed: true,
@@ -164,64 +164,64 @@ func resourceVcdOrgVdc() *schema.Resource {
 					"For example, if this value is 0.75, then 75% of allocated resources are guaranteed. " +
 					"Required when AllocationModel is AllocationVApp or AllocationPool. If the element is empty, vCD sets a value",
 			},
-			"cpu_speed": &schema.Schema{
+			"cpu_speed": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
 				Description: "Specifies the clock frequency, in Megahertz, for any virtual CPU that is allocated to a VM. A VM with 2 vCPUs will consume twice as much of this value. Ignored for ReservationPool. Required when AllocationModel is AllocationVApp or AllocationPool, and may not be less than 256 MHz. Defaults to 1000 MHz if the element is empty or missing.",
 			},
-			"enable_thin_provisioning": &schema.Schema{
+			"enable_thin_provisioning": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Boolean to request thin provisioning. Request will be honored only if the underlying datastore supports it. Thin provisioning saves storage space by committing it on demand. This allows over-allocation of storage.",
 			},
-			"network_pool_name": &schema.Schema{
+			"network_pool_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "The name of a network pool in the Provider VDC. Required if this VDC will contain routed or isolated networks.",
 			},
-			"provider_vdc_name": &schema.Schema{
+			"provider_vdc_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "A reference to the Provider VDC from which this organization VDC is provisioned.",
 			},
-			"enable_fast_provisioning": &schema.Schema{
+			"enable_fast_provisioning": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "Request for fast provisioning. Request will be honored only if the underlying datas tore supports it. Fast provisioning can reduce the time it takes to create virtual machines by using vSphere linked clones. If you disable fast provisioning, all provisioning operations will result in full clones.",
 			},
 			//  Always null in the response to a GET request. On update, set to false to disallow the update if the AllocationModel is AllocationPool or ReservationPool
 			//  and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Defaults to true if empty or missing.
-			"allow_over_commit": &schema.Schema{
+			"allow_over_commit": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 				Description: "Set to false to disallow creation of the VDC if the AllocationModel is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Default is true.",
 			},
-			"enable_vm_discovery": &schema.Schema{
+			"enable_vm_discovery": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "True if discovery of vCenter VMs is enabled for resource pools backing this VDC. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.",
 			},
-			"elasticity": &schema.Schema{
+			"elasticity": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 				Description: "Set to true to indicate if the Flex VDC is to be elastic.",
 			},
-			"include_vm_memory_overhead": &schema.Schema{
+			"include_vm_memory_overhead": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
 				Description: "Set to true to indicate if the Flex VDC is to include memory overhead into its accounting for admission control.",
 			},
-			"delete_force": &schema.Schema{
+			"delete_force": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "When destroying use delete_force=True to remove a VDC and any objects it contains, regardless of their state.",
 			},
-			"delete_recursive": &schema.Schema{
+			"delete_recursive": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "When destroying use delete_recursive=True to remove the VDC and any objects it contains that are in a state that normally allows removal.",
@@ -242,7 +242,7 @@ func resourceVcdOrgVdc() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"default_vm_sizing_policy_id": &schema.Schema{
+			"default_vm_sizing_policy_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
@@ -1174,7 +1174,7 @@ func getVcdVdcInput(d *schema.ResourceData, vcdClient *VCDClient) (*types.VdcCon
 		Xmlns:           "http://www.vmware.com/vcloud/v1.5",
 		AllocationModel: d.Get("allocation_model").(string),
 		ComputeCapacity: []*types.ComputeCapacity{
-			&types.ComputeCapacity{
+			{
 				CPU:    capacityWithUsage(cpuCapacityList[0].(map[string]interface{}), "MHz"),
 				Memory: capacityWithUsage(memoryCapacityList[0].(map[string]interface{}), "MB"),
 			},

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -436,7 +436,7 @@ func setOrgVdcData(d *schema.ResourceData, vcdClient *VCDClient, adminOrg *govcd
 		for _, policy := range assignedVmSizingPolicies {
 			policyIds = append(policyIds, policy.VdcComputePolicy.ID)
 		}
-		vmSizingPoliciesSet := convertStringsTotTypeSet(policyIds)
+		vmSizingPoliciesSet := convertStringsToTypeSet(policyIds)
 
 		dSet(d, "default_vm_sizing_policy_id", adminVdc.AdminVdc.DefaultComputePolicy.ID)
 

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -71,7 +71,7 @@ func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVdcDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVdcExists("vcd_org_vdc."+TestAccVcdVdc),
@@ -132,7 +132,7 @@ func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
 						"3"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVdcExists("vcd_org_vdc."+TestAccVcdVdc),
@@ -193,7 +193,7 @@ func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
 						"1"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_org_vdc." + TestAccVcdVdc,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_rights_bundle.go
+++ b/vcd/resource_vcd_rights_bundle.go
@@ -21,38 +21,38 @@ func resourceVcdRightsBundle() *schema.Resource {
 			StateContext: resourceVcdRightsBundleImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of rights bundle.",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Rights bundle description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this rights bundle is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "list of rights assigned to this rights bundle",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"publish_to_all_tenants": &schema.Schema{
+			"publish_to_all_tenants": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "When true, publishes the rights bundle to all tenants",
 			},
-			"tenants": &schema.Schema{
+			"tenants": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "list of tenants to which this rights bundle is published",

--- a/vcd/resource_vcd_rights_bundle_test.go
+++ b/vcd/resource_vcd_rights_bundle_test.go
@@ -50,7 +50,7 @@ func TestAccVcdRightsBundle(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckRightsBundleDestroy(resourceDef),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRightsBundleExists(resourceDef),
@@ -61,7 +61,7 @@ func TestAccVcdRightsBundle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "tenants.#", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRightsBundleExists(resourceDef),
@@ -71,7 +71,7 @@ func TestAccVcdRightsBundle(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "rights.#", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceDef,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_role.go
+++ b/vcd/resource_vcd_role.go
@@ -21,7 +21,7 @@ func resourceVcdRole() *schema.Resource {
 			StateContext: resourceVcdRoleImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of Role.",
@@ -33,22 +33,22 @@ func resourceVcdRole() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Role description",
 			},
-			"bundle_key": &schema.Schema{
+			"bundle_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Key used for internationalization",
 			},
-			"read_only": &schema.Schema{
+			"read_only": {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Whether this role is read-only",
 			},
-			"rights": &schema.Schema{
+			"rights": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "list of rights assigned to this role",

--- a/vcd/resource_vcd_role_test.go
+++ b/vcd/resource_vcd_role_test.go
@@ -47,7 +47,7 @@ func TestAccVcdRole(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckRoleDestroy(resourceDef),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists(resourceDef),
@@ -55,7 +55,7 @@ func TestAccVcdRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "rights.#", "6"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRoleExists(resourceDef),
@@ -64,7 +64,7 @@ func TestAccVcdRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceDef, "rights.#", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceDef,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_standalone_vm_test.go
+++ b/vcd/resource_vcd_standalone_vm_test.go
@@ -55,7 +55,7 @@ func TestAccVcdStandaloneVmTemplate(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, orgName, vdcName),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, orgName, vdcName),
@@ -81,7 +81,7 @@ func TestAccVcdStandaloneVmTemplate(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_vm." + standaloneVmName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -134,7 +134,7 @@ func TestAccVcdStandaloneEmptyVm(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, orgName, vdcName),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, orgName, vdcName),

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -97,7 +97,7 @@ func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroyByVdc(testAccVcdVdc),
 		Steps: []resource.TestStep{
 			// Step 0 - Create using sizing policy
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExistsByVdc(testAccVcdVdc, netVmName1, "vcd_vm."+netVmName1),
@@ -150,7 +150,7 @@ func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 				),
 			},
 			// Step 1 - update
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExistsByVdc(testAccVcdVdc, netVmName1, "vcd_vm."+netVmName1),

--- a/vcd/resource_vcd_vapp.go
+++ b/vcd/resource_vcd_vapp.go
@@ -81,7 +81,7 @@ func resourceVcdVApp() *schema.Resource {
 				Computed:    true,
 				Description: "Shows the status of the vApp",
 			},
-			"lease": &schema.Schema{
+			"lease": {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
@@ -89,13 +89,13 @@ func resourceVcdVApp() *schema.Resource {
 				Description: "Defines lease parameters for this vApp",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"runtime_lease_in_sec": &schema.Schema{
+						"runtime_lease_in_sec": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  "How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires",
 							ValidateFunc: validateIntLeaseSeconds(), // Lease can be either 0 or 3600+
 						},
-						"storage_lease_in_sec": &schema.Schema{
+						"storage_lease_in_sec": {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  "How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires",

--- a/vcd/resource_vcd_vapp_access_control.go
+++ b/vcd/resource_vcd_vapp_access_control.go
@@ -35,45 +35,45 @@ func resourceVcdAccessControlVapp() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_id": &schema.Schema{
+			"vapp_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp identifier",
 			},
-			"shared_with_everyone": &schema.Schema{
+			"shared_with_everyone": {
 				Type:        schema.TypeBool,
 				Required:    true,
 				Description: "Whether the vApp is shared with everyone",
 			},
-			"everyone_access_level": &schema.Schema{
+			"everyone_access_level": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{types.ControlAccessReadOnly, types.ControlAccessReadWrite, types.ControlAccessFullControl}, true),
 				Description:  "Access level when the vApp is shared with everyone (one of ReadOnly, Change, FullControl). Required when shared_with_everyone is set",
 			},
-			"shared_with": &schema.Schema{
+			"shared_with": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"user_id": &schema.Schema{
+						"user_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "ID of the user to which we are sharing. Required if group_id is not set",
 						},
-						"group_id": &schema.Schema{
+						"group_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "ID of the group to which we are sharing. Required if user_id is not set",
 						},
-						"subject_name": &schema.Schema{
+						"subject_name": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Name of the subject (group or user) with which we are sharing",
 						},
-						"access_level": &schema.Schema{
+						"access_level": {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validation.StringInSlice([]string{types.ControlAccessReadOnly, types.ControlAccessReadWrite, types.ControlAccessFullControl}, true),

--- a/vcd/resource_vcd_vapp_access_control_test.go
+++ b/vcd/resource_vcd_vapp_access_control_test.go
@@ -76,7 +76,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 		CheckDestroy:      testAccCheckVappAccessControlDestroy(testConfig.VCD.Org, testConfig.VCD.Vdc, []string{"Vapp-AC-0", "Vapp-AC-1", "Vapp-AC-2", "Vapp-AC-3"}),
 		Steps: []resource.TestStep{
 			// Test creation
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVappAccessControlExists(resourceAC0, testConfig.VCD.Org, testConfig.VCD.Vdc),
@@ -121,7 +121,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVappAccessControlExists(resourceAC0, testConfig.VCD.Org, testConfig.VCD.Vdc),
@@ -144,7 +144,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 				)},
 
 			// Tests import by name
-			resource.TestStep{
+			{
 				Config:            configText,
 				ResourceName:      "vcd_vapp_access_control.AC-Vapp1",
 				ImportState:       true,
@@ -152,7 +152,7 @@ func TestAccVcdVappAccessControl(t *testing.T) {
 				ImportStateIdFunc: importStateIdOrgVdcObject(testConfig, "Vapp-AC-1"),
 			},
 			// Tests import by ID
-			resource.TestStep{
+			{
 				Config:            configText,
 				ResourceName:      "vcd_vapp_access_control.AC-Vapp2",
 				ImportState:       true,

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -58,7 +58,7 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create with variations of all possible NICs
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
@@ -161,7 +161,7 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 				),
 			},
 			// Step 1 - update
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_firewall_rules.go
+++ b/vcd/resource_vcd_vapp_firewall_rules.go
@@ -37,42 +37,42 @@ func resourceVcdVappFirewallRules() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_id": &schema.Schema{
+			"vapp_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp identifier",
 			},
-			"network_id": &schema.Schema{
+			"network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp network identifier",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Enable or disable firewall service. Default is `true`",
 			},
-			"default_action": &schema.Schema{
+			"default_action": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{"allow", "drop"}, false),
 				Description:  "Specifies what to do should none of the rules match. Either `allow` or `drop`",
 			},
-			"log_default_action": &schema.Schema{
+			"log_default_action": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Flag to enable logging for default action. Default value is false.",
 			},
-			"rule": &schema.Schema{
+			"rule": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Rule name",
@@ -83,67 +83,67 @@ func resourceVcdVappFirewallRules() *schema.Resource {
 							Default:     true,
 							Description: "'true' value will enable firewall rule",
 						},
-						"policy": &schema.Schema{
+						"policy": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"drop", "allow"}, false),
 							Description:  "One of: `drop` (drop packets that match the rule), `allow` (allow packets that match the rule to pass through the firewall)",
 						},
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "any",
 							ValidateFunc: validation.StringInSlice([]string{"any", "icmp", "tcp", "udp", "tcp&udp"}, true),
 							Description:  "Specify the protocols to which the rule should be applied. One of: `any`, `icmp`, `tcp`, `udp`, `tcp&udp`",
 						},
-						"destination_port": &schema.Schema{
+						"destination_port": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Destination port to which this rule applies.",
 						},
-						"destination_ip": &schema.Schema{
+						"destination_ip": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Destination IP address to which the rule applies. A value of `Any` matches any IP address.",
 						},
-						"destination_vm_id": &schema.Schema{
+						"destination_vm_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Destination VM identifier",
 						},
-						"destination_vm_ip_type": &schema.Schema{
+						"destination_vm_ip_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"assigned", "NAT"}, false),
 							Description:  "The value can be one of: `assigned` - assigned internal IP will be automatically chosen. `NAT`: NATed external IP will be automatically chosen.",
 						},
-						"destination_vm_nic_id": &schema.Schema{
+						"destination_vm_nic_id": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Destination VM NIC ID to which this rule applies.",
 						},
-						"source_port": &schema.Schema{
+						"source_port": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Source port to which this rule applies.",
 						},
-						"source_ip": &schema.Schema{
+						"source_ip": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Source IP address to which the rule applies. A value of `Any` matches any IP address.",
 						},
-						"source_vm_id": &schema.Schema{
+						"source_vm_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Source VM identifier",
 						},
-						"source_vm_ip_type": &schema.Schema{
+						"source_vm_ip_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"assigned", "NAT"}, false),
 							Description:  "The value can be one of: `assigned` - assigned internal IP will be automatically chosen. `NAT`: NATed external IP will be automatically chosen.",
 						},
-						"source_vm_nic_id": &schema.Schema{
+						"source_vm_nic_id": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Source VM NIC ID to which this rule applies.",

--- a/vcd/resource_vcd_vapp_firewall_rules_test.go
+++ b/vcd/resource_vcd_vapp_firewall_rules_test.go
@@ -59,7 +59,7 @@ func TestAccVcdVappFirewallRules(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -122,21 +122,21 @@ func TestAccVcdVappFirewallRules(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName+"2", "rule.0.enable_logging", "false"),
 				),
 			},
-			resource.TestStep{ // Step 1 - resource import
+			{ // Step 1 - resource import
 				ResourceName:            "vcd_vapp_firewall_rules." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleObject(testConfig, vappName, vappNetworkName),
 				ImportStateVerifyIgnore: []string{"org", "vdc"},
 			},
-			resource.TestStep{ // Step 2 - resource import by ID
+			{ // Step 2 - resource import by ID
 				ResourceName:            "vcd_vapp_firewall_rules." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleById(testConfig, resourceName),
 				ImportStateVerifyIgnore: []string{"org", "vdc"},
 			},
-			resource.TestStep{ // Step 3 - update
+			{ // Step 3 - update
 				Config: configTextForUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),

--- a/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
+++ b/vcd/resource_vcd_vapp_multi_vm_in_template_test.go
@@ -70,7 +70,7 @@ func TestAccVcdVAppMultiVmInTemplate(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_nat_rules.go
+++ b/vcd/resource_vcd_vapp_nat_rules.go
@@ -43,80 +43,80 @@ func resourceVcdVappNetworkNatRules() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_id": &schema.Schema{
+			"vapp_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp identifier",
 			},
-			"network_id": &schema.Schema{
+			"network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp network identifier",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Enable or disable NAT service. Default is `true`.",
 			},
-			"nat_type": &schema.Schema{
+			"nat_type": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{portForwardingNatType, ipTranslationNatType}, false),
 				Description:  "One of: `ipTranslation` (use IP translation), `portForwarding` (use port forwarding).",
 			},
-			"enable_ip_masquerade": &schema.Schema{
+			"enable_ip_masquerade": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "When enabled translates a virtual machine's private, internal IP address to a public IP address for outbound traffic.",
 			},
-			"rule": &schema.Schema{
+			"rule": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"id": &schema.Schema{
+						"id": {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "ID of the rule. Can be used to track syslog messages.",
 						},
-						"mapping_mode": &schema.Schema{
+						"mapping_mode": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"automatic", "manual"}, false),
 							Description:  "Mapping mode. One of: `automatic`, `manual`",
 						},
-						"vm_id": &schema.Schema{
+						"vm_id": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "VM to which this rule applies.",
 						},
-						"vm_nic_id": &schema.Schema{
+						"vm_nic_id": {
 							Type:        schema.TypeInt,
 							Required:    true,
 							Description: "VM NIC ID to which this rule applies.",
 						},
-						"external_ip": &schema.Schema{
+						"external_ip": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Computed:     true,
 							ValidateFunc: validation.IsIPAddress,
 							Description:  "External IP address to forward to or External IP address to map to VM",
 						},
-						"external_port": &schema.Schema{
+						"external_port": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "External port to forward.",
 						},
-						"forward_to_port": &schema.Schema{
+						"forward_to_port": {
 							Type:        schema.TypeInt,
 							Optional:    true,
 							Description: "Internal port to forward.",
 						},
-						"protocol": &schema.Schema{
+						"protocol": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"TCP", "UDP", "TCP_UDP"}, false),

--- a/vcd/resource_vcd_vapp_nat_rules_test.go
+++ b/vcd/resource_vcd_vapp_nat_rules_test.go
@@ -63,7 +63,7 @@ func TestAccVcdVappNatRules(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
@@ -95,21 +95,21 @@ func TestAccVcdVappNatRules(t *testing.T) {
 				),
 			},
 			// we can reuse importStateVappFirewallRuleObject as import is the same
-			resource.TestStep{ // Step 1 - resource import
+			{ // Step 1 - resource import
 				ResourceName:            "vcd_vapp_nat_rules." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleObject(testConfig, vappName, vappNetworkName),
 				ImportStateVerifyIgnore: []string{"enable_ip_masquerade", "network_id", "org", "vdc"},
 			},
-			resource.TestStep{ // Step 2 - resource import by ID
+			{ // Step 2 - resource import by ID
 				ResourceName:            "vcd_vapp_nat_rules." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleById(testConfig, resourceName),
 				ImportStateVerifyIgnore: []string{"enable_ip_masquerade", "network_id", "org", "vdc"},
 			},
-			resource.TestStep{ // Step 3 - update
+			{ // Step 3 - update
 				Config: configTextForUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
@@ -138,7 +138,7 @@ func TestAccVcdVappNatRules(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName+"2", "rule.1.forward_to_port", "800"),
 				),
 			},
-			resource.TestStep{ // Step 3 - delete
+			{ // Step 3 - delete
 				Config: configTextForDelete,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVappNatRulesDeleted("vcd_vapp_org_network.vappAttachedNet"),

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -22,14 +22,14 @@ func resourceVcdVappNetwork() *schema.Resource {
 			State: resourceVcdVappNetworkImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp network name",
 				// we can't change network name as this results in ID (HREF) change
 			},
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -48,41 +48,41 @@ func resourceVcdVappNetwork() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Optional description for the network",
 			},
-			"netmask": &schema.Schema{
+			"netmask": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Default:     "255.255.255.0",
 				Description: "Netmask address for a subnet. Default is 255.255.255.0",
 			},
-			"gateway": &schema.Schema{
+			"gateway": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Gateway of the network",
 			},
-			"dns1": &schema.Schema{
+			"dns1": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Primary DNS server",
 			},
-			"dns2": &schema.Schema{
+			"dns2": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Secondary DNS server",
 			},
-			"dns_suffix": &schema.Schema{
+			"dns_suffix": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "DNS suffix",
 			},
 
-			"guest_vlan_allowed": &schema.Schema{
+			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "True if Network allows guest VLAN tagging",
@@ -98,35 +98,35 @@ func resourceVcdVappNetwork() *schema.Resource {
 				Default:     false,
 				Description: "Specifies whether the network resources such as IP/MAC of router will be retained across deployments. Default is false.",
 			},
-			"dhcp_pool": &schema.Schema{
+			"dhcp_pool": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "A range of IPs to issue to virtual machines that don't have a static IP",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_address": &schema.Schema{
+						"start_address": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"end_address": &schema.Schema{
+						"end_address": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"default_lease_time": &schema.Schema{
+						"default_lease_time": {
 							Type:     schema.TypeInt,
 							Default:  3600,
 							Optional: true,
 						},
 
-						"max_lease_time": &schema.Schema{
+						"max_lease_time": {
 							Type:     schema.TypeInt,
 							Default:  7200,
 							Optional: true,
 						},
 
-						"enabled": &schema.Schema{
+						"enabled": {
 							Type:     schema.TypeBool,
 							Default:  true,
 							Optional: true,
@@ -135,18 +135,18 @@ func resourceVcdVappNetwork() *schema.Resource {
 				},
 				Set: resourceVcdDhcpPoolHash,
 			},
-			"static_ip_pool": &schema.Schema{
+			"static_ip_pool": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "A range of IPs permitted to be used as static IPs for virtual machines",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"start_address": &schema.Schema{
+						"start_address": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"end_address": &schema.Schema{
+						"end_address": {
 							Type:     schema.TypeString,
 							Required: true,
 						},

--- a/vcd/resource_vcd_vapp_network_multi_test.go
+++ b/vcd/resource_vcd_vapp_network_multi_test.go
@@ -89,7 +89,7 @@ func TestAccVcdVappNetworkMulti(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVappNetworkMultiDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVappNetworkMultiExists("vcd_vapp_network."+resourceName1),

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -140,7 +140,7 @@ func runVappNetworkTest(t *testing.T, params StringMap) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVappNetworkDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVappNetworkExists(resourceName),
@@ -177,7 +177,7 @@ func runVappNetworkTest(t *testing.T, params StringMap) {
 						resourceName, "retain_ip_mac_enabled", params["retainIpMacEnabled"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateConfigText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVappNetworkExists(resourceName),
@@ -214,7 +214,7 @@ func runVappNetworkTest(t *testing.T, params StringMap) {
 						resourceName, "retain_ip_mac_enabled", params["retainIpMacEnabledForUpdate"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_vapp_org_network.go
+++ b/vcd/resource_vcd_vapp_org_network.go
@@ -20,38 +20,38 @@ func resourceVcdVappOrgNetwork() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp network name",
 			},
-			"org": &schema.Schema{
+			"org": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"vdc": &schema.Schema{
+			"vdc": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"org_network_name": &schema.Schema{
+			"org_network_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Organization network name to which vApp network is connected to",
 			},
-			"is_fenced": &schema.Schema{
+			"is_fenced": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 				Description: "Fencing allows identical virtual machines in different vApp networks connect to organization VDC networks that are accessed in this vApp",
 			},
-			"retain_ip_mac_enabled": &schema.Schema{
+			"retain_ip_mac_enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/vcd/resource_vcd_vapp_org_network_test.go
+++ b/vcd/resource_vcd_vapp_org_network_test.go
@@ -73,7 +73,7 @@ func runVappOrgNetworkTest(t *testing.T, params StringMap) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVappNetworkDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVappNetworkExists(resourceName),
@@ -87,7 +87,7 @@ func runVappOrgNetworkTest(t *testing.T, params StringMap) {
 						resourceName, "is_fenced", params["isFenced"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateConfigText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVappNetworkExists(resourceName),
@@ -101,7 +101,7 @@ func runVappOrgNetworkTest(t *testing.T, params StringMap) {
 						resourceName, "is_fenced", params["isFencedForUpdate"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_vapp_properties_test.go
+++ b/vcd/resource_vcd_vapp_properties_test.go
@@ -47,7 +47,7 @@ func TestAccVcdVAppProperties(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+t.Name(), &vapp),
@@ -56,7 +56,7 @@ func TestAccVcdVAppProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp."+t.Name(), `guest_properties.guest.another.subkey`, "another-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+t.Name(), &vapp),
@@ -66,7 +66,7 @@ func TestAccVcdVAppProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp."+t.Name(), `guest_properties.guest.third.subkey`, "third-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+t.Name(), &vapp),

--- a/vcd/resource_vcd_vapp_raw_multi_test.go
+++ b/vcd/resource_vcd_vapp_raw_multi_test.go
@@ -43,7 +43,7 @@ func TestAccVcdVAppRawMulti(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppRawMultiDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppRawMultiExists(fmt.Sprintf("vcd_vapp.%s", params["VappName"].(string)), &vapp),

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -38,7 +38,7 @@ func TestAccVcdVAppRaw_Basic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppRawDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppRawExists(fmt.Sprintf("vcd_vapp.%s", params["VappName"].(string)), &vapp),

--- a/vcd/resource_vcd_vapp_static_routing.go
+++ b/vcd/resource_vcd_vapp_static_routing.go
@@ -31,40 +31,40 @@ func resourceVcdVappNetworkStaticRouting() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_id": &schema.Schema{
+			"vapp_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp identifier",
 			},
-			"network_id": &schema.Schema{
+			"network_id": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "vApp network identifier",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
 				Description: "Enable or disable static Routing. Default is `true`.",
 			},
-			"rule": &schema.Schema{
+			"rule": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "Name for the static route.",
 						},
-						"network_cidr": &schema.Schema{
+						"network_cidr": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "network specification in CIDR.",
 						},
-						"next_hop_ip": &schema.Schema{
+						"next_hop_ip": {
 							Type:        schema.TypeString,
 							Required:    true,
 							Description: "IP Address of Next Hop router/gateway.",

--- a/vcd/resource_vcd_vapp_static_routing_test.go
+++ b/vcd/resource_vcd_vapp_static_routing_test.go
@@ -50,7 +50,7 @@ func TestAccVcdVappStaticRouting(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVappStaticRoutesExists(resourceName, 2),
@@ -66,21 +66,21 @@ func TestAccVcdVappStaticRouting(t *testing.T) {
 				),
 			},
 			// we can reuse importStateVappFirewallRuleObject as import is the same
-			resource.TestStep{ // Step 1 - resource import
+			{ // Step 1 - resource import
 				ResourceName:            "vcd_vapp_static_routing." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleObject(testConfig, vappName, vappNetworkName),
 				ImportStateVerifyIgnore: []string{"network_id", "org", "vdc"},
 			},
-			resource.TestStep{ // Step 2 - resource import by ID
+			{ // Step 2 - resource import by ID
 				ResourceName:            "vcd_vapp_static_routing." + t.Name(),
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVappFirewallRuleById(testConfig, resourceName),
 				ImportStateVerifyIgnore: []string{"network_id", "org", "vdc"},
 			},
-			resource.TestStep{ // Step 3 - update
+			{ // Step 3 - update
 				Config: configTextForUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVappStaticRoutesExists(resourceName, 2),

--- a/vcd/resource_vcd_vapp_test.go
+++ b/vcd/resource_vcd_vapp_test.go
@@ -57,7 +57,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+vappName, &vapp),
@@ -78,7 +78,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 						"vcd_vapp."+vappName, "lease.0.storage_lease_in_sec"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists("vcd_vapp."+vappName, &vapp),
@@ -95,7 +95,7 @@ func TestAccVcdVApp_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp."+vappName, `lease.0.storage_lease_in_sec`, fmt.Sprintf("%d", storageLease)),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_vapp." + vappName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/vcd/resource_vcd_vapp_update_test.go
+++ b/vcd/resource_vcd_vapp_update_test.go
@@ -62,7 +62,7 @@ func TestAccVcdVAppUpdate(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppDestroy,
 		Steps: []resource.TestStep{
 			// Deploy vApp
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists(resourceName, &vapp),
@@ -71,7 +71,7 @@ func TestAccVcdVAppUpdate(t *testing.T) {
 				),
 			},
 			// Rename vApp and update description
-			resource.TestStep{
+			{
 				Config: configTextUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists(resourceName, &vapp),
@@ -80,7 +80,7 @@ func TestAccVcdVAppUpdate(t *testing.T) {
 				),
 			},
 			// remove description
-			resource.TestStep{
+			{
 				Config: configRemoveDescription,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists(resourceName, &vapp),
@@ -89,7 +89,7 @@ func TestAccVcdVAppUpdate(t *testing.T) {
 				),
 			},
 			// Restore original values
-			resource.TestStep{
+			{
 				Config: configTextRestore,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppExists(resourceName, &vapp),

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -69,7 +69,7 @@ func resourceVcdVAppVmUpdate(ctx context.Context, d *schema.ResourceData, meta i
 // VM Schema is defined as global so that it can be directly accessible in other places
 func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"vapp_name": &schema.Schema{
+		"vapp_name": {
 			Type:        schema.TypeString,
 			Required:    vmType == vappVmType,
 			Optional:    vmType == standaloneVmType,
@@ -77,18 +77,18 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 			ForceNew:    vmType == vappVmType,
 			Description: "The vApp this VM belongs to - Required, unless it is a standalone VM",
 		},
-		"vm_type": &schema.Schema{
+		"vm_type": {
 			Type:        schema.TypeString,
 			Computed:    true,
 			Description: fmt.Sprintf("Type of VM: either '%s' or '%s'", vappVmType, standaloneVmType),
 		},
-		"name": &schema.Schema{
+		"name": {
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    true,
 			Description: "A name for the VM, unique within the vApp",
 		},
-		"computer_name": &schema.Schema{
+		"computer_name": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
@@ -107,93 +107,93 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 			ForceNew:    true,
 			Description: "The name of VDC to use, optional if defined at provider level",
 		},
-		"template_name": &schema.Schema{
+		"template_name": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			ForceNew:    true,
 			Description: "The name of the vApp Template to use",
 		},
-		"vm_name_in_template": &schema.Schema{
+		"vm_name_in_template": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			ForceNew:    true,
 			Description: "The name of the VM in vApp Template to use. In cases when vApp template has more than one VM",
 		},
-		"catalog_name": &schema.Schema{
+		"catalog_name": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The catalog name in which to find the given vApp Template or media for boot_image",
 		},
-		"description": &schema.Schema{
+		"description": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "The VM description",
 		},
-		"memory": &schema.Schema{
+		"memory": {
 			Type:         schema.TypeInt,
 			Optional:     true,
 			Computed:     true,
 			Description:  "The amount of RAM (in MB) to allocate to the VM",
 			ValidateFunc: validateMultipleOf4(),
 		},
-		"memory_reservation": &schema.Schema{
+		"memory_reservation": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "The amount of RAM (in MB) reservation on the underlying virtualization infrastructure",
 		},
-		"memory_priority": &schema.Schema{
+		"memory_priority": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Computed:     true,
 			Description:  "Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload",
 			ValidateFunc: validation.StringInSlice([]string{"LOW", "NORMAL", "HIGH", "CUSTOM"}, false),
 		},
-		"memory_shares": &schema.Schema{
+		"memory_shares": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "Custom priority for the resource. This is a read-only, unless the `memory_priority` is CUSTOM",
 		},
-		"memory_limit": &schema.Schema{
+		"memory_limit": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "The limit for how much of memory can be consumed on the underlying virtualization infrastructure. This is only valid when the resource allocation is not unlimited.",
 		},
-		"cpus": &schema.Schema{
+		"cpus": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "The number of virtual CPUs to allocate to the VM",
 		},
-		"cpu_cores": &schema.Schema{
+		"cpu_cores": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "The number of cores per socket",
 		},
-		"cpu_reservation": &schema.Schema{
+		"cpu_reservation": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "The amount of MHz reservation on the underlying virtualization infrastructure",
 		},
-		"cpu_priority": &schema.Schema{
+		"cpu_priority": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Computed:     true,
 			Description:  "Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload",
 			ValidateFunc: validation.StringInSlice([]string{"LOW", "NORMAL", "HIGH", "CUSTOM"}, false),
 		},
-		"cpu_shares": &schema.Schema{
+		"cpu_shares": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
 			Description: "Custom priority for the resource. This is a read-only, unless the `cpu_priority` is CUSTOM",
 		},
-		"cpu_limit": &schema.Schema{
+		"cpu_limit": {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,
@@ -206,43 +206,43 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 			// a value of type String in this map.
 			Description: "Key value map of metadata to assign to this VM",
 		},
-		"href": &schema.Schema{
+		"href": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "VM Hyper Reference",
 		},
-		"accept_all_eulas": &schema.Schema{
+		"accept_all_eulas": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
 			Description: "Automatically accept EULA if OVA has it",
 		},
-		"power_on": &schema.Schema{
+		"power_on": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
 			Description: "A boolean value stating if this VM should be powered on",
 		},
-		"storage_profile": &schema.Schema{
+		"storage_profile": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "Storage profile to override the default one",
 		},
-		"os_type": &schema.Schema{
+		"os_type": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "Operating System type. Possible values can be found in documentation.",
 		},
-		"hardware_version": &schema.Schema{
+		"hardware_version": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
 			Description: "Virtual Hardware Version (e.g.`vmx-14`, `vmx-13`, `vmx-12`, etc.)",
 		},
-		"boot_image": &schema.Schema{
+		"boot_image": {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "Media name to add as boot image.",
@@ -381,7 +381,7 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 					Optional:    true,
 					Description: "Specifies the IOPS for the disk. Default is 0.",
 				},
-				"storage_profile": &schema.Schema{
+				"storage_profile": {
 					Type:        schema.TypeString,
 					ForceNew:    true,
 					Optional:    true,
@@ -429,14 +429,14 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 					Computed:    true,
 					Description: "Specifies the IOPS for the disk. Default is 0.",
 				},
-				"storage_profile": &schema.Schema{
+				"storage_profile": {
 					Type:        schema.TypeString,
 					Computed:    true,
 					Description: "Storage profile to override the VM default one",
 				},
 			}},
 		},
-		"expose_hardware_virtualization": &schema.Schema{
+		"expose_hardware_virtualization": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
@@ -447,7 +447,7 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 			Optional:    true,
 			Description: "Key/value settings for guest properties",
 		},
-		"customization": &schema.Schema{
+		"customization": {
 			Optional:    true,
 			Computed:    true,
 			MinItems:    1,
@@ -549,7 +549,7 @@ func vmSchemaFunc(vmType typeOfVm) map[string]*schema.Schema {
 						Computed:    true,
 						Description: "Account organizational unit for domain name join",
 					},
-					"initscript": &schema.Schema{
+					"initscript": {
 						Type:        schema.TypeString,
 						Optional:    true,
 						Computed:    true,
@@ -2618,7 +2618,7 @@ func addEmptyVm(d *schema.ResourceData, vcdClient *VCDClient, org *govcd.Org, vd
 			NetworkConnectionSection: &types.NetworkConnectionSection{
 				PrimaryNetworkConnectionIndex: 0,
 				NetworkConnection: []*types.NetworkConnection{
-					&types.NetworkConnection{Network: "none", NetworkConnectionIndex: 0, IPAddress: "any", IsConnected: false, IPAddressAllocationMode: "NONE"}},
+					{Network: "none", NetworkConnectionIndex: 0, IPAddress: "any", IsConnected: false, IPAddressAllocationMode: "NONE"}},
 			},
 			Description:               d.Get("description").(string),
 			GuestCustomizationSection: customizationSection,

--- a/vcd/resource_vcd_vapp_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vapp_vm_capabilities_test.go
@@ -40,7 +40,7 @@ func TestAccVcdVAppVmCapabilities(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
@@ -49,7 +49,7 @@ func TestAccVcdVAppVmCapabilities(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "memory_hot_add_enabled", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -57,7 +57,7 @@ func TestAccVcdVAppVmUpdateCustomization(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create without customization flag
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVMCustomization("vcd_vapp_vm.test-vm", false),
@@ -69,7 +69,7 @@ func TestAccVcdVAppVmUpdateCustomization(t *testing.T) {
 				),
 			},
 			// Step 1 - Update - change network configuration and force customization
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				// The plan should never be empty because force works as a flag and every update triggers "update"
 				ExpectNonEmptyPlan: true,
@@ -127,7 +127,7 @@ func TestAccVcdVAppVmCreateCustomization(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create new VM and force customization initially
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep2,
 				// The plan should never be empty because force works as a flag and every update triggers "update"
 				ExpectNonEmptyPlan: true,
@@ -327,7 +327,7 @@ func TestAccVcdVAppVmCreateCustomizationFalse(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create new VM and set set customization.force=false
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm.test-vm", &vapp, &vm),
@@ -380,7 +380,7 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 1
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm.test-vm", &vapp, &vm),
@@ -396,7 +396,7 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 				),
 			},
 			// Step 2 - join org domain (does not fail because enabled=false even though OS is not windows)
-			resource.TestStep{
+			{
 				// Taint:  []string{"vcd_vapp_vm.test-vm"},
 				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
 				// recreation of the VM
@@ -414,7 +414,7 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 				),
 			},
 			// Step 3 - join org domain enabled
-			resource.TestStep{
+			{
 				// Taint:  []string{"vcd_vapp_vm.test-vm"},
 				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
 				// recreation of the VM

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -52,7 +52,7 @@ func TestAccVcdVAppVmDhcpWait(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create with variations of all possible NICs
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
@@ -81,7 +81,7 @@ func TestAccVcdVAppVmDhcpWait(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_vapp_vm.ds", "network_dhcp_wait_seconds", "300"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextVMDhcpWaitUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vapp_vm_hot_updates_test.go
@@ -89,7 +89,7 @@ func TestAccVcdVAppHotUpdateVm(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(hotVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - create
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(hotVappName, hotVmName1, "vcd_vapp_vm."+hotVmName1, &vapp, &vm),
@@ -123,7 +123,7 @@ func TestAccVcdVAppHotUpdateVm(t *testing.T) {
 				),
 			},
 			// Step 1 - update - network changes
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(hotVappName, hotVmName1, "vcd_vapp_vm."+hotVmName1, &vapp, &vm),
@@ -156,12 +156,12 @@ func TestAccVcdVAppHotUpdateVm(t *testing.T) {
 				),
 			},
 			// Step 2 - update
-			resource.TestStep{
+			{
 				Config:      configTextVMUpdateStep2,
 				ExpectError: regexp.MustCompile(`update stopped: VM needs to power off to change properties.*`),
 			},
 			// Step 3 - update - add new network section
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(hotVappName, hotVmName1, "vcd_vapp_vm."+hotVmName1, &vapp, &vm),
@@ -196,7 +196,7 @@ func TestAccVcdVAppHotUpdateVm(t *testing.T) {
 			// Step 4 - update - remove network section
 			step4func,
 			// Step 5 - update - network changes
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(hotVappName, hotVmName1, "vcd_vapp_vm."+hotVmName1, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vapp_vm_hw_virtualization_test.go
@@ -46,7 +46,7 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappNameHwVirt),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextStep0,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappNameHwVirt, vmNameHwVirt, "vcd_vapp_vm."+vmNameHwVirt, &vapp, &vm),
@@ -56,7 +56,7 @@ func TestAccVcdVAppVm_HardwareVirtualization(t *testing.T) {
 						"vcd_vapp_vm."+vmNameHwVirt, "expose_hardware_virtualization", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextStep1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappNameHwVirt, vmNameHwVirt, "vcd_vapp_vm."+vmNameHwVirt, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -56,7 +56,7 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmMultiDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName1, vappName2, vmName1),

--- a/vcd/resource_vcd_vapp_vm_multinetwork_test.go
+++ b/vcd/resource_vcd_vapp_vm_multinetwork_test.go
@@ -66,7 +66,7 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create with variations of all possible NICs
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
@@ -160,7 +160,7 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 				),
 			},
 			// Step 1 - update
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
@@ -210,7 +210,7 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 				),
 			},
 			// Step 2 - update (remove all NICs)
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
@@ -219,7 +219,7 @@ func TestAccVcdVAppVmMultiNIC(t *testing.T) {
 				),
 			},
 			// Step 3 - Add one nic of each type
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_properties_test.go
+++ b/vcd/resource_vcd_vapp_vm_properties_test.go
@@ -77,7 +77,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
@@ -86,7 +86,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, `guest_properties.guest.another.subkey`, "another-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
@@ -96,7 +96,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, `guest_properties.guest.third.subkey`, "third-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
@@ -105,7 +105,7 @@ func TestAccVcdVAppVmProperties(t *testing.T) {
 				),
 			},
 			// Validates that if vApp is missing, resource can be recreated and no error is thrown. Covers issue #611
-			resource.TestStep{
+			{
 				Config:             configText3,
 				PreConfig:          deleteVapp,
 				PlanOnly:           true,

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -56,7 +56,7 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
@@ -78,7 +78,7 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 					}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_vapp_vm." + vmName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -131,7 +131,7 @@ func TestAccVcdVAppVm_Clone(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -94,7 +94,7 @@ func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdVAppVmDestroyByVdc(testAccVcdVdc, netVappName),
 		Steps: []resource.TestStep{
 			// Step 0 - Create using sizing policy
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExistsByVdc(testAccVcdVdc, netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vm),
@@ -147,7 +147,7 @@ func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
 				),
 			},
 			// Step 1 - update
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExistsByVdc(testAccVcdVdc, netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vm),

--- a/vcd/resource_vcd_vdc_group_test.go
+++ b/vcd/resource_vcd_vdc_group_test.go
@@ -239,10 +239,10 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 
 		Steps: []resource.TestStep{
 			// initialize new VDC, this done separately as otherwise randomly fail due choose wrong connection
-			resource.TestStep{
+			{
 				Config: configTextPre,
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "name", params["Name"].(string)),
@@ -254,7 +254,7 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "default_policy_status", params["DefaultPolicy"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "name", params["NameUpdated"].(string)),
@@ -266,7 +266,7 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "default_policy_status", params["DefaultPolicyUpdated"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "name", params["NameUpdated"].(string)),
@@ -278,7 +278,7 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "default_policy_status", params["DefaultPolicyUpdated2"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText4,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "name", params["NameUpdated"].(string)),
@@ -290,11 +290,11 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "default_policy_status", params["DefaultPolicyUpdated3"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config:      configText5,
 				ExpectError: regexp.MustCompile("`default_policy_status` must be `false` when `dfw_enabled` is `false`."),
 			},
-			resource.TestStep{
+			{
 				Config: configText6,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "name", params["NameUpdated"].(string)),
@@ -306,14 +306,14 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 					resource.TestCheckResourceAttr(resourceAddressVdcGroup, "default_policy_status", params["DefaultPolicyUpdated5"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText7,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual(resourceAddressVdcGroup, "data.vcd_vdc_group.fetchCreated", []string{"participating_vdc_ids.#",
 						"starting_vdc_id", "%", "participating_vdc_ids.0", "default_policy_status"}),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:            resourceAddressVdcGroup,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -321,11 +321,11 @@ func runVdcGroupTest(t *testing.T, params StringMap) {
 				ImportStateVerifyIgnore: []string{"starting_vdc_id"},
 			},
 			// for clean destroy, otherwise randomly fail due choose wrong connection
-			resource.TestStep{
+			{
 				Config: configTextProvider,
 			},
 			// for clean destroy, otherwise randomly fail due choose wrong connection
-			resource.TestStep{
+			{
 				Config: configTextPre,
 			},
 		},

--- a/vcd/resource_vcd_vm_advanced_compute_test.go
+++ b/vcd/resource_vcd_vm_advanced_compute_test.go
@@ -71,7 +71,7 @@ func TestAccVcdVmAdvancedComputeProperties(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -95,7 +95,7 @@ func TestAccVcdVmAdvancedComputeProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm."+emptyVmName, "cpu_limit", params["CpuLimit"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_vm."+standaloneVmName, "name", standaloneVmName),
@@ -118,7 +118,7 @@ func TestAccVcdVmAdvancedComputeProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm."+emptyVmName, "cpu_limit", params["CpuLimitUpdate"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vcd_vm."+standaloneVmName, "name", standaloneVmName),

--- a/vcd/resource_vcd_vm_affinity_rule.go
+++ b/vcd/resource_vcd_vm_affinity_rule.go
@@ -36,12 +36,12 @@ func resourceVcdVmAffinityRule() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "VM affinity rule name",
 			},
-			"polarity": &schema.Schema{
+			"polarity": {
 				Type:     schema.TypeString,
 				Required: true,
 				// Polarity can't change. If we want to, we need to create a new rule
@@ -49,14 +49,14 @@ func resourceVcdVmAffinityRule() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{types.PolarityAffinity, types.PolarityAntiAffinity}, false),
 				Description:  "One of 'Affinity', 'Anti-Affinity'",
 			},
-			"required": &schema.Schema{
+			"required": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 				Description: "True if this affinity rule is required. When a rule is mandatory, " +
 					"a host failover will not power on the VM if doing so would violate the rule",
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
@@ -132,7 +132,7 @@ func resourceToAffinityRule(d *schema.ResourceData, meta interface{}) (*types.Vm
 		IsMandatory: takeBoolPointer(required),
 		Polarity:    polarity,
 		VmReferences: []*types.VMs{
-			&types.VMs{
+			{
 				VMReference: vmReferences,
 			},
 		},

--- a/vcd/resource_vcd_vm_affinity_rule.go
+++ b/vcd/resource_vcd_vm_affinity_rule.go
@@ -242,7 +242,7 @@ func genericVcdVmAffinityRuleRead(d *schema.ResourceData, meta interface{}, orig
 			endpointVMs = append(endpointVMs, normalizeId("urn:vcloud:vm:", ref.ID))
 		}
 	}
-	endpointVmSet := convertStringsTotTypeSet(endpointVMs)
+	endpointVmSet := convertStringsToTypeSet(endpointVMs)
 	err = d.Set("vm_ids", endpointVmSet)
 	if err != nil {
 		return fmt.Errorf("[VM affinity rule read] error setting the list of VM IDs: %s ", err)

--- a/vcd/resource_vcd_vm_affinity_rule_test.go
+++ b/vcd/resource_vcd_vm_affinity_rule_test.go
@@ -49,9 +49,9 @@ func TestAccVcdVmAffinityRule(t *testing.T) {
 	}
 
 	vappDefinition := map[string][]string{
-		"Test_EmptyVmVapp1": []string{"Test_EmptyVm1a", "Test_EmptyVm1b"},
-		"Test_EmptyVmVapp2": []string{"Test_EmptyVm2a", "Test_EmptyVm2b"},
-		"Test_EmptyVmVapp3": []string{"Test_EmptyVm3a", "Test_EmptyVm3b"},
+		"Test_EmptyVmVapp1": {"Test_EmptyVm1a", "Test_EmptyVm1b"},
+		"Test_EmptyVmVapp2": {"Test_EmptyVm2a", "Test_EmptyVm2b"},
+		"Test_EmptyVmVapp3": {"Test_EmptyVm3a", "Test_EmptyVm3b"},
 	}
 	vappList, err := makeVappGroup("TestAccVcdVmAffinityRule", vdc, vappDefinition)
 	if err != nil {
@@ -256,7 +256,7 @@ func runVmAffinityRuleTest(data affinityRuleData, t *testing.T) {
 		CheckDestroy:      testAccCheckVmAffinityRuleDestroy(&rule, testConfig.VCD.Org, testConfig.VCD.Vdc),
 		Steps: []resource.TestStep{
 			// Test creation
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVmAffinityRuleExists(resourceName, testConfig.VCD.Org, testConfig.VCD.Vdc, &rule),
@@ -277,7 +277,7 @@ func runVmAffinityRuleTest(data affinityRuleData, t *testing.T) {
 				),
 			},
 			// Tests update
-			resource.TestStep{
+			{
 				Config: updateText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdVmAffinityRuleExists(resourceName, testConfig.VCD.Org, testConfig.VCD.Vdc, &rule),
@@ -294,7 +294,7 @@ func runVmAffinityRuleTest(data affinityRuleData, t *testing.T) {
 				),
 			},
 			// Tests import by name
-			resource.TestStep{
+			{
 				Config:            updateText,
 				ResourceName:      "vcd_vm_affinity_rule." + data.name,
 				ImportState:       true,
@@ -302,7 +302,7 @@ func runVmAffinityRuleTest(data affinityRuleData, t *testing.T) {
 				ImportStateIdFunc: importStateIdOrgVdcObject(testConfig, data.name+"-update"),
 			},
 			// Tests import by ID
-			resource.TestStep{
+			{
 				Config:            updateText,
 				ResourceName:      "vcd_vm_affinity_rule." + data.name,
 				ImportState:       true,

--- a/vcd/resource_vcd_vm_capabilities_test.go
+++ b/vcd/resource_vcd_vm_capabilities_test.go
@@ -41,7 +41,7 @@ func TestAccVcdStandaloneVmCapabilities(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -50,7 +50,7 @@ func TestAccVcdStandaloneVmCapabilities(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm."+standaloneVmName, "memory_hot_add_enabled", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -53,7 +53,7 @@ func TestAccVcdStandaloneVmUpdateCustomization(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
 			// Step 0 - Create without customization flag
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVMCustomization("vcd_vm.test-vm", false),
@@ -65,7 +65,7 @@ func TestAccVcdStandaloneVmUpdateCustomization(t *testing.T) {
 				),
 			},
 			// Step 1 - Update - change network configuration and force customization
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				// The plan should never be empty because force works as a flag and every update triggers "update"
 				ExpectNonEmptyPlan: true,
@@ -118,7 +118,7 @@ func TestAccVcdStandaloneVmCreateCustomization(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
 			// Step 0 - Create new VM and force customization initially
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep2,
 				// The plan should never be empty because force works as a flag and every update triggers "update"
 				ExpectNonEmptyPlan: true,
@@ -278,7 +278,7 @@ func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
 			// Step 1
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm.test-vm", "", ""),
@@ -294,7 +294,7 @@ func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
 				),
 			},
 			// Step 2 - join org domain (does not fail because enabled=false even though OS is not windows)
-			resource.TestStep{
+			{
 				// Taint:  []string{"vcd_vm.test-vm"},
 				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
 				// recreation of the VM
@@ -312,7 +312,7 @@ func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
 				),
 			},
 			// Step 3 - join org domain enabled
-			resource.TestStep{
+			{
 				// Taint:  []string{"vcd_vm.test-vm"},
 				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
 				// recreation of the VM

--- a/vcd/resource_vcd_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vm_dhcp_wait_test.go
@@ -48,7 +48,7 @@ func TestAccVcdStandaloneVmDhcpWait(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
 			// Step 0 - Create with variations of all possible NICs
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -77,7 +77,7 @@ func TestAccVcdStandaloneVmDhcpWait(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vcd_vm.ds", "network_dhcp_wait_seconds", "300"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextVMDhcpWaitUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),

--- a/vcd/resource_vcd_vm_hot_updates_test.go
+++ b/vcd/resource_vcd_vm_hot_updates_test.go
@@ -72,7 +72,7 @@ func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
 			// Step 0 - create
-			resource.TestStep{
+			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -106,7 +106,7 @@ func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
 				),
 			},
 			// Step 1 - update - network changes
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -138,12 +138,12 @@ func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
 				),
 			},
 			// Step 2 - update
-			resource.TestStep{
+			{
 				Config:      configTextVMUpdateStep2,
 				ExpectError: regexp.MustCompile(`update stopped: VM needs to power off to change properties.*`),
 			},
 			// Step 3 - update - add new network section
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -174,7 +174,7 @@ func TestAccVcdStandaloneHotUpdateVm(t *testing.T) {
 				),
 			},
 			// Step 4 - update - network changes
-			resource.TestStep{
+			{
 				Config: configTextVMUpdateStep5,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),

--- a/vcd/resource_vcd_vm_hw_virtualization_test.go
+++ b/vcd/resource_vcd_vm_hw_virtualization_test.go
@@ -44,7 +44,7 @@ func TestAccVcdStandaloneVm_HardwareVirtualization(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextStep0,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -54,7 +54,7 @@ func TestAccVcdStandaloneVm_HardwareVirtualization(t *testing.T) {
 						"vcd_vm."+standaloneVmName, "expose_hardware_virtualization", "false"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configTextStep1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),

--- a/vcd/resource_vcd_vm_internal_disk.go
+++ b/vcd/resource_vcd_vm_internal_disk.go
@@ -36,13 +36,13 @@ func resourceVmInternalDisk() *schema.Resource {
 				ForceNew:    true,
 				Description: "The name of VDC to use, optional if defined at provider level",
 			},
-			"vapp_name": &schema.Schema{
+			"vapp_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "The vApp this VM internal disk belongs to",
 			},
-			"vm_name": &schema.Schema{
+			"vm_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -83,7 +83,7 @@ func resourceVmInternalDisk() *schema.Resource {
 				Computed:    true,
 				Description: "Specifies the IOPS for the disk.",
 			},
-			"storage_profile": &schema.Schema{
+			"storage_profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -92,7 +92,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextIde,
 				// expected to fail for allow_vm_reboot=false and bus_type = "ide" (VM needs to be power off to add IDE disk)
 				ExpectError: regexp.MustCompile(`.*The attempted operation cannot be performed in the current state \(Powered on\).*`),
@@ -105,7 +105,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 					testCheckInternalDiskNonStringOutputs(internalDiskSize),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("vcd_vm_internal_disk."+diskResourceName, "size_in_mb", diskSize),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.TestInternalDiskVm", "description", "description-text"),
@@ -124,7 +124,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm_internal_disk."+diskResourceName+"_ide", "iops", "0"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText_update1,
 				Check: resource.ComposeTestCheckFunc(resource.TestCheckResourceAttr("vcd_vm_internal_disk."+diskResourceName, "size_in_mb", biggerDiskSize),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.TestInternalDiskVm", "description", "description-text"),
@@ -145,7 +145,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm_internal_disk."+diskResourceName+"_ide", "allow_vm_reboot", "true"),
 				),
 			},
-			resource.TestStep{
+			{
 				ResourceName:      "vcd_vm_internal_disk." + diskResourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -401,7 +401,7 @@ func TestAccVcdVmInternalDiskNvme(t *testing.T) {
 			testAccCheckVcdStandaloneVmDestroy(params["VmName"].(string), params["Org"].(string), params["Vdc"].(string)),
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configTextNvme,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("vcd_vm.nvme", "id"),

--- a/vcd/resource_vcd_vm_properties_test.go
+++ b/vcd/resource_vcd_vm_properties_test.go
@@ -45,7 +45,7 @@ func TestAccVcdStandaloneVmProperties(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -54,7 +54,7 @@ func TestAccVcdStandaloneVmProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm."+standaloneVmName, `guest_properties.guest.another.subkey`, "another-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),
@@ -64,7 +64,7 @@ func TestAccVcdStandaloneVmProperties(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm."+standaloneVmName, `guest_properties.guest.third.subkey`, "third-value"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: configText2,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm."+standaloneVmName, "", ""),

--- a/vcd/resource_vcd_vm_shrink_cpu_test.go
+++ b/vcd/resource_vcd_vm_shrink_cpu_test.go
@@ -37,7 +37,7 @@ func TestAccVcdStandaloneVmShrinkCpu(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(standaloneVmName, "", ""),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVcdStandaloneVmExists(standaloneVmName, "vcd_vm.shrink-vm", "", ""),

--- a/vcd/resource_vcd_vm_sizing_policy.go
+++ b/vcd/resource_vcd_vm_sizing_policy.go
@@ -34,15 +34,15 @@ func resourceVcdVmSizingPolicy() *schema.Resource {
 				Description: "The name of organization to use, optional if defined at provider " +
 					"level. Useful when connected as sysadmin working across different organizations",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"cpu": &schema.Schema{
+			"cpu": {
 				Optional: true,
 				MinItems: 0,
 				MaxItems: 1,
@@ -94,7 +94,7 @@ func resourceVcdVmSizingPolicy() *schema.Resource {
 					},
 				},
 			},
-			"memory": &schema.Schema{
+			"memory": {
 				Optional: true,
 				MinItems: 0,
 				MaxItems: 1,

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -63,7 +63,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVmSizingPolicyDestroyed,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVmSizingPolicyExists(resource1),
@@ -111,7 +111,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resource4, "memory.0.reservation_guarantee", params["MemoryReservation"].(string)),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: updateText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVmSizingPolicyExists(resource1),
@@ -160,7 +160,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 				),
 			},
 			// Tests import by id
-			resource.TestStep{
+			{
 				ResourceName:            resource4,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -168,14 +168,14 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"org"},
 			},
 			// Tests import by name
-			resource.TestStep{
+			{
 				ResourceName:            resource4,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateVmSizingPolicyByIdOrName(testConfig, resource4, false),
 				ImportStateVerifyIgnore: []string{"org"},
 			},
-			resource.TestStep{
+			{
 				Config: dataSourceText,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckOutput("description", params["Description"].(string)+"_updated"),

--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -69,9 +69,9 @@ func convertSchemaSetToSliceOfStrings(param *schema.Set) []string {
 	return result
 }
 
-// convertStringsTotTypeSet accepts a slice of strings and returns a *schema.Set suitable for storing in Terraform
+// convertStringsToTypeSet accepts a slice of strings and returns a *schema.Set suitable for storing in Terraform
 // set of strings
-func convertStringsTotTypeSet(param []string) *schema.Set {
+func convertStringsToTypeSet(param []string) *schema.Set {
 	sliceOfInterfaces := make([]interface{}, len(param))
 	for index, value := range param {
 		sliceOfInterfaces[index] = value


### PR DESCRIPTION
Go historically required type names for each  struct literal. At some Go version this requirement got lifted and now most Go Tooling recommends to remove them. As a result - our PRs start to get messy just because the places touched are removing these definitions. This unnecessarily complicates code reviews and puts additional cognitive load on the reviewer.

This PR is made to automatically remove it everywhere using native Go tool `gofmt -s -w .`.

Additionally it patches the check `make fmtcheck` to match against it.

Also patches mentioned typo in a widely used private function `convertStringsTotTypeSet`-> `convertStringsToTypeSet`

This is a completely automated conversion using a Go tool therefore no tests were run and make sure the code builds was enough.