### PR TITLE
TestAccVcdCatalogPublishedToExternalOrg workaround to avoid having this test faling

### DIFF
--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -256,6 +256,38 @@ func TestAccVcdCatalogPublishedToExternalOrg(t *testing.T) {
 		"PreserveIdentityInformationUpdate2": false,
 	}
 
+	// This code snippet is to avoid having the org catalog publishing settings set to disable.
+	// There are some bugs in VCD that disable those options. This code snippet will be removed
+	// as soon as those bugs are solved.
+	vcdClient := createTemporaryVCDConnection(false)
+	adminOrg, err := vcdClient.GetAdminOrg(testConfig.VCD.Org)
+	if err != nil {
+		t.Errorf("couldn't retrieve the adminOrg for setting workaround for VCD bug - %s", err)
+	}
+
+	if vcdClient.Client.IsSysAdmin {
+		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs = true
+		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally = true
+		adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe = true
+		task, err := adminOrg.Update()
+		if err != nil {
+			t.Errorf("couldn't update the adminOrg settings for workaround for VCD bug - %s", err)
+		}
+
+		err = task.WaitTaskCompletion()
+		if err != nil {
+			t.Errorf("the task that performs the VCD bug workaround didn't finish successfully - %s", err)
+		}
+	} else {
+		if !adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishCatalogs ||
+			!adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanPublishExternally ||
+			!adminOrg.AdminOrg.OrgSettings.OrgGeneralSettings.CanSubscribe {
+			t.Skip("TestAccVcdCatalogPublishedToExternalOrg needs to be skipped because org publishing settings are not right and org admin doesn't have permissions to set them")
+		}
+	}
+
+	// End of the workaround
+
 	configText := templateFill(testAccCheckVcdCatalogPublished, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	params["FuncName"] = t.Name() + "step1"


### PR DESCRIPTION
This PR is not associated with any issue

# Description
This PR instroduces a code snippet that avoids the test TestAccVcdCatalogPublishedToExternalOrg from failing due to catalog publishing settings not set appropriately. 

# Detailed description
Since there is a bug in VCD that randomly changes catalog publishing settings at org level, we introduce this workaround that does the following:
- If executed as a sys admin, it sets the right parameters to org level to avoid the test from failing due to that.
- If executed as org admin, since it cannot change those parameters, it checks if all parameters are enabled. If so, it execute the test. If there are not set appropriately, the test is skipped.


Signed-off-by: Miguel Sama <msama@vmware.com>