### PR TITLE
Data source and resource fixes + NVMe binary test skip for VCD <10.2.2

### DIFF
--- a/.changes/v3.7.0/838-bug-fixes.md
+++ b/.changes/v3.7.0/838-bug-fixes.md
@@ -1,0 +1,3 @@
+* Skip binary and upgrade tests for NVMe in VCD < 10.2.2 [GH-838]
+* Network lookup could return incorrect ID for `vcd_vapp_network` and `vcd_vapp_org_network` [GH-838]
+* Set missing `org` and `vdc` fields during import of `vcd_independent_disk` [GH-838]

--- a/vcd/datasource_vcd_independent_disk.go
+++ b/vcd/datasource_vcd_independent_disk.go
@@ -2,8 +2,9 @@ package vcd
 
 import (
 	"context"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
@@ -110,7 +111,7 @@ func datasourceVcIndependentDisk() *schema.Resource {
 func dataSourceVcdIndependentDiskRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	_, vdc, err := vcdClient.GetOrgAndVdc("", d.Get("vdc").(string))
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 	if err != nil {
 		return diag.Errorf(errorRetrievingOrgAndVdc, err)
 	}

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -636,6 +636,8 @@ func getDiskForImport(d *schema.ResourceData, meta interface{}, orgName, vdcName
 	}
 
 	d.SetId(disk.Disk.Id)
+	dSet(d, "org", orgName)
+	dSet(d, "vdc", vdcName)
 	dSet(d, "name", disk.Disk.Name)
 	return []*schema.ResourceData{d}, nil
 }

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -80,10 +80,17 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 	configTextWithoutOptionals := templateFill(testAccCheckVcdIndependentDiskWithoutOptionals, params)
 	params["FuncName"] = t.Name() + "-Update"
 	configTextForUpdate := templateFill(testAccCheckVcdIndependentDiskForUpdate, params)
-	params["FuncName"] = t.Name() + "-Nvme"
-	configTextNvme := templateFill(testAccCheckVcdIndependentDiskNvmeType, params)
-	params["FuncName"] = t.Name() + "-NvmeUpdate"
-	configTextNvmeUpdate := templateFill(testAccCheckVcdIndependentDiskNvmeTypeUpdate, params)
+
+	var configTextNvme string
+	var configTextNvmeUpdate string
+	if nvmeUnsupported, _ := vcdVersionIsLowerThan1022(); !nvmeUnsupported {
+		params["FuncName"] = t.Name() + "-Nvme"
+		configTextNvme = templateFill(testAccCheckVcdIndependentDiskNvmeType, params)
+		params["FuncName"] = t.Name() + "-NvmeUpdate"
+		configTextNvmeUpdate = templateFill(testAccCheckVcdIndependentDiskNvmeTypeUpdate, params)
+
+	}
+
 	params["FuncName"] = t.Name() + "-attachedToVm"
 	configTextAttachedToVm := templateFill(testAccCheckVcdIndependentDiskAttachedToVm, params)
 	params["FuncName"] = t.Name() + "-attachedToVmUpdate"

--- a/vcd/resource_vcd_vapp_network.go
+++ b/vcd/resource_vcd_vapp_network.go
@@ -282,7 +282,7 @@ func genericVappNetworkRead(d *schema.ResourceData, meta interface{}, origin str
 				return fmt.Errorf("unable to get network ID from HREF: %s", err)
 			}
 			// Check name as well to support old resource IDs that are names and datasources that have names provided by the user
-			if d.Id() == networkId || networkConfig.NetworkName == vappNetworkName {
+			if extractUuid(d.Id()) == extractUuid(networkId) || networkConfig.NetworkName == vappNetworkName {
 				vAppNetwork = networkConfig
 				break
 			}

--- a/vcd/resource_vcd_vapp_org_network.go
+++ b/vcd/resource_vcd_vapp_org_network.go
@@ -2,11 +2,12 @@ package vcd
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	"log"
-	"strings"
 )
 
 func resourceVcdVappOrgNetwork() *schema.Resource {
@@ -143,8 +144,9 @@ func genericVappOrgNetworkRead(d *schema.ResourceData, meta interface{}, origin 
 				return fmt.Errorf("unable to get network ID from HREF: %s", err)
 			}
 			// name check needed for datasource to find network as don't have ID
-			if d.Id() == networkId || networkConfig.NetworkName == d.Get("org_network_name").(string) {
+			if extractUuid(d.Id()) == extractUuid(networkId) || networkConfig.NetworkName == d.Get("org_network_name").(string) {
 				vAppNetwork = networkConfig
+				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds 3 fixes as mentioned in CHANGELOG:

* Skip binary and upgrade tests for NVMe in VCD < 10.2.2 . _NVMe is not supported in 10.2.0 and binary tests fail because of that. I have confirmed this running `make test-binary-prepare` on 10.2.0 and 10.3.3_
* Network lookup could return incorrect ID for `vcd_vapp_network` and `vcd_vapp_org_network`. _Not trivial to test this one - but it can impact environments with more networks_
* Set missing `org` and `vdc` fields during import of `vcd_independent_disk`. _This fails in a combination of parameters which are not hit by our tests_ 