### PR TITLE
Deprecate `vdc` field in vcd_nsxt_network_dhcp

### DIFF
--- a/.changes/v3.7.0/846-deprecations.md
+++ b/.changes/v3.7.0/846-deprecations.md
@@ -1,2 +1,2 @@
 * `resource/vcd_nsxt_network_dhcp` and `datasource/vcd_nsxt_network_dhcp` deprecate `vdc` field to
-  make consumption more friendly with VDC Groups [GH-YYY]
+  make consumption more friendly with VDC Groups [GH-846]

--- a/.changes/v3.7.0/yyy-deprecations.md
+++ b/.changes/v3.7.0/yyy-deprecations.md
@@ -1,0 +1,2 @@
+* `resource/vcd_nsxt_network_dhcp` and `datasource/vcd_nsxt_network_dhcp` deprecate `vdc` field to
+  make consumption more friendly with VDC Groups [GH-YYY]

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220511174553-630407ca5e57
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,5 @@ require (
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3
+	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.5
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,4 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220510104238-f4d7c1695309

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2
 )
+//replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20211018060826-c7f8ab32330e
+replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2
 )
-//replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06 h1:lsc4T0/d1NRQLrFmg8CF6wuSQ7vZZ4QSG46kjVOVLps=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -222,6 +220,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.5 h1:yjJe9pApYB8YMMZGxGlB1dJeqYyeqVU2ejas7c97Z1c=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.5/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0 h1:elfX2NnxQZgoCo6gk8aC63ktENicIgAcToX2SLz8GWo=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -220,8 +222,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2 h1:NFH5VGWtaf/oUoJLU10Pfwft+v/fwedKPAy+5OUnc5o=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220511174553-630407ca5e57 h1:Ot1lHyM0kWni68O6/uI3G2gzgLu7V3zhP9Skv2BVCe8=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220511174553-630407ca5e57/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06 h1:lsc4T0/d1NRQLrFmg8CF6wuSQ7vZZ4QSG46kjVOVLps=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220516061707-22fe988c5b06/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0 h1:elfX2NnxQZgoCo6gk8aC63ktENicIgAcToX2SLz8GWo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220509120942-575e2f58d8a0/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220510104238-f4d7c1695309 h1:2+L1CWKyDQNMkHI/PXAEGT1vZv7rqXpkhypuNILyqns=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220510104238-f4d7c1695309/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -255,12 +255,12 @@ func getOpenAPIOrgVdcNetworkDhcpType(d *schema.ResourceData) *types.OpenApiOrgVd
 	return orgVdcNetDhcp
 }
 
-func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdc *types.OpenApiOrgVdcNetworkDhcp, d *schema.ResourceData) error {
+func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdcNetwork *types.OpenApiOrgVdcNetworkDhcp, d *schema.ResourceData) error {
 	dSet(d, "org_network_id", orgNetworkId)
-	if len(orgVdc.DhcpPools) > 0 {
-		poolInterfaceSlice := make([]interface{}, len(orgVdc.DhcpPools))
+	if len(orgVdcNetwork.DhcpPools) > 0 {
+		poolInterfaceSlice := make([]interface{}, len(orgVdcNetwork.DhcpPools))
 
-		for index, pool := range orgVdc.DhcpPools {
+		for index, pool := range orgVdcNetwork.DhcpPools {
 			onePool := make(map[string]interface{})
 			onePool["start_address"] = pool.IPRange.StartAddress
 			onePool["end_address"] = pool.IPRange.EndAddress
@@ -275,8 +275,12 @@ func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdc *types.OpenApiO
 		}
 	}
 
-	if len(orgVdc.DnsServers) > 0 {
-		dSet(d, "dns_servers", orgVdc.DnsServers)
+	if len(orgVdcNetwork.DnsServers) > 0 {
+		// dSet(d, "dns_servers", orgVdcNetwork.DnsServers)
+		err := d.Set("dns_servers", orgVdcNetwork.DnsServers)
+		if err != nil {
+			return fmt.Errorf("error setting DNS servers: %s", err)
+		}
 	}
 
 	return nil

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -276,7 +276,7 @@ func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdc *types.OpenApiO
 	}
 
 	if len(orgVdc.DnsServers) > 0 {
-		d.Set("dns_servers", orgVdc.DnsServers)
+		dSet(d, "dns_servers", orgVdc.DnsServers)
 	}
 
 	return nil

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -163,7 +163,7 @@ func resourceVcdOpenApiDhcpDelete(ctx context.Context, d *schema.ResourceData, m
 
 	orgVdcNetwork, err := org.GetOpenApiOrgVdcNetworkById(d.Id())
 	if err != nil {
-		return diag.Errorf("[NSX-T DHCP pool delete] error retrieving parent Org VDC Network: %s", err)
+		return diag.Errorf("[NSX-T DHCP pool delete] error retrieving Org VDC Network: %s", err)
 	}
 
 	err = orgVdcNetwork.DeletNetworkDhcp()
@@ -182,19 +182,9 @@ func resourceVcdOpenApiDhcpImport(ctx context.Context, d *schema.ResourceData, m
 	orgName, vdcOrVdcGroupName, orgVdcNetworkName := resourceURI[0], resourceURI[1], resourceURI[2]
 
 	vcdClient := meta.(*VCDClient)
-	// define an interface type to match VDC and VDC Groups
-	var vdcOrVdcGroup vdcOrVdcGroupHandler
-	_, vdcOrVdcGroup, err := vcdClient.GetOrgAndVdc(orgName, vdcOrVdcGroupName)
-	if govcd.ContainsNotFound(err) {
-		adminOrg, err := vcdClient.GetAdminOrg(orgName)
-		if err != nil {
-			return nil, fmt.Errorf("error retrieving Admin Org for '%s': %s", orgName, err)
-		}
-
-		vdcOrVdcGroup, err = adminOrg.GetVdcGroupByName(vdcOrVdcGroupName)
-		if err != nil {
-			return nil, fmt.Errorf("error finding VDC or VDC Group by name '%s': %s", vdcOrVdcGroupName, err)
-		}
+	vdcOrVdcGroup, err := lookupVdcOrVdcGroup(vcdClient, orgName, vdcOrVdcGroupName)
+	if err != nil {
+		return nil, err
 	}
 
 	// Perform validations to only allow DHCP configuration on NSX-T backed Routed Org VDC networks

--- a/vcd/resource_vcd_nsxt_network_dhcp.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp.go
@@ -276,7 +276,6 @@ func setOpenAPIOrgVdcNetworkDhcpData(orgNetworkId string, orgVdcNetwork *types.O
 	}
 
 	if len(orgVdcNetwork.DnsServers) > 0 {
-		// dSet(d, "dns_servers", orgVdcNetwork.DnsServers)
 		err := d.Set("dns_servers", orgVdcNetwork.DnsServers)
 		if err != nil {
 			return fmt.Errorf("error setting DNS servers: %s", err)

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -99,10 +99,11 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "vcd_nsxt_network_dhcp.pools",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateIdFunc: importStateIdOrgNsxtVdcObject(testConfig, "nsxt-routed-dhcp"),
+				ResourceName:            "vcd_nsxt_network_dhcp.pools",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       importStateIdOrgNsxtVdcObject(testConfig, "nsxt-routed-dhcp"),
+				ImportStateVerifyIgnore: []string{"vdc"},
 			},
 		},
 	})

--- a/website/docs/d/nsxt_network_dhcp.html.markdown
+++ b/website/docs/d/nsxt_network_dhcp.html.markdown
@@ -10,8 +10,6 @@ description: |-
 
 Provides a data source to read DHCP pools for NSX-T Org VDC Routed network.
 
-Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
-
 ## Example Usage 1
 
 ```hcl
@@ -25,7 +23,6 @@ data "vcd_network_routed_v2" "parent" {
 
 data "vcd_nsxt_network_dhcp" "pools" {
   org = "my-org"
-  vdc = "my-vdc"
 
   org_network_id = vcd_network_routed_v2.parent.id
 }
@@ -37,8 +34,6 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level. **Note.** If the
-  parent network belongs to VDC Group, any member VDC name must be supplied.
 * `org_network_id` - (Required) ID of parent Org VDC Routed network
 
 ## Attribute Reference

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -10,7 +10,6 @@ description: |-
 
 Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
 
-
 ## Example Usage 1
 
 ```hcl

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -10,19 +10,6 @@ description: |-
 
 Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
 
-Supported in provider *v3.2+* and VCD 10.1+ with NSX-T backed VDCs.
-
-## Specific usage notes
-
-**DHCP pool support** for NSX-T Routed networks is **limited** by the API in the following ways:
-
-* DHCP pools can only be added, but not updated/removed one by one
-
-* VCD 10.2+ allows to remove all DHCP pools at once (terraform destroy/resource removal)
-
-* VCD 10.1 **does not allow to remove DHCP pools** after they are created without removing parent network
-therefore **destroying the resource will emit warning and do nothing** (to avoid breaking Terraform flow). 
-See [Example usage 2](#example-usage-2-pool-removal-on-vcd-101) to see a way for changing/removing DHCP pools
 
 ## Example Usage 1
 
@@ -56,34 +43,12 @@ resource "vcd_nsxt_network_dhcp" "pools" {
 }
 ```
 
-## Example Usage 2 (Pool removal on VCD 10.1)
-
-DHCP pool definitions cannot be removed once defined therefore the trick is to recreate parent Org VDC network.
-This can be done by following such procedure:
-
-* Define the network and DHCP pools as in [Example Usage 1](#example-usage-1)
-* Use `terraform taint` on the parent network to force recreation:
-   ```sh
-   # terraform taint vcd_network_routed_v2.parent-network
-   Resource instance vcd_network_routed_v2.parent-network has been marked as tainted.
-   ```
-* Modify/remove `vcd_nsxt_network_dhcp` definition as per your needs
-* Perform `terraform apply`. This will recreate tainted parent Org VDC network and new DHCP pools if defined.
-You will see a WARNING during removal but it will not break :
-```sh
-vcd_nsxt_network_dhcp.pools: Destroying... [id=urn:vcloud:network:209666ec-6253-418a-a816-076b15413fea]
-vcd_nsxt_network_dhcp WARNING: for VCD versions < 10.2 DHCP pool removal is not supported. Destroy is a NO-OP operation for VCD versions < 10.2. Please recreate parent network to remove DHCP pools.
-vcd_nsxt_network_dhcp.pools: Destruction complete after 0s
-```
-
 ## Argument Reference
 
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `vdc` - (Optional) The name of VDC to use, optional if defined at provider level.  **Note.** If
-  the parent network belongs to VDC Group, any member VDC name must be supplied.
 * `org_network_id` - (Required) ID of parent Org VDC Routed network
 * `pool` - (Required) One or more blocks to define DHCP pool ranges. See [Pools](#pools) and example 
 for usage details.
@@ -107,9 +72,9 @@ below:
 [docs-import]: https://www.terraform.io/docs/import/
 
 ```
-terraform import vcd_nsxt_network_dhcp.imported my-org.my-org-vdc.my-nsxt-vdc-network-name
+terraform import vcd_nsxt_network_dhcp.imported my-org.my-org-vdc-or-vdc-group.my-nsxt-vdc-network-name
 ```
 
-The above would import the DHCP config settings that are defined on VDC network 
-`my-nsxt-vdc-network-name` which is configured in organization named `my-org` and VDC named 
-`my-org-vdc`.
+The above would import the DHCP config settings that are defined on VDC network
+`my-nsxt-vdc-network-name` which is configured in organization named `my-org` and VDC or VDC Group
+named `my-org-vdc-or-vdc-group`.

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -14,7 +14,7 @@ Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
 
 **DHCP pool support** for NSX-T Org networks is **limited** by the VCD in the following ways:
 
-* VCD 10.2.0 only allows to remove all DHCP pools at once (terraform destroy/resource removal)
+* VCD 10.2 only allows to remove all DHCP pools at once (terraform destroy/resource removal)
 
 * VCD 10.3+ allows to add and remove DHCP pools one by one
 

--- a/website/docs/r/nsxt_network_dhcp.html.markdown
+++ b/website/docs/r/nsxt_network_dhcp.html.markdown
@@ -10,6 +10,14 @@ description: |-
 
 Provides a resource to manage DHCP pools for NSX-T Org VDC Routed network.
 
+## Specific usage notes
+
+**DHCP pool support** for NSX-T Org networks is **limited** by the VCD in the following ways:
+
+* VCD 10.2.0 only allows to remove all DHCP pools at once (terraform destroy/resource removal)
+
+* VCD 10.3+ allows to add and remove DHCP pools one by one
+
 ## Example Usage 1
 
 ```hcl
@@ -40,6 +48,28 @@ resource "vcd_nsxt_network_dhcp" "pools" {
     end_address   = "7.1.1.112"
   }
 }
+```
+
+## Example Usage 2 (Pool removal on VCD 10.2.0)
+
+DHCP pool definitions can only be removed all at once and not one by one. To do so in Terraform one
+needs to destroy and create the resource. One can also achieve that by tainting the resource using 
+Terraform native `taint` command. Example below:
+
+* Define the network and DHCP pools as in [Example Usage 1](#example-usage-1)
+* Use `terraform taint` on the parent network to force recreation:
+   ```sh
+   # terraform taint vcd_network_routed_v2.parent-network
+   Resource instance vcd_nsxt_network_dhcp.pools has been marked as tainted.
+   ```
+* Modify/remove `vcd_nsxt_network_dhcp` definition as per your needs
+* Perform `terraform apply`. This will recreate tainted parent Org VDC network and new DHCP pools if defined.
+You will see a WARNING during removal but it will not break :
+```sh
+vcd_nsxt_network_dhcp.pools: Destroying... [id=urn:vcloud:network:74754019-31f1-41ea-a9e2-fc21455d6d2b]
+vcd_nsxt_network_dhcp.pools: Destruction complete after 11s
+vcd_nsxt_network_dhcp.pools: Creating...
+vcd_nsxt_network_dhcp.pools: Creation complete after 21s [id=urn:vcloud:network:74754019-31f1-41ea-a9e2-fc21455d6d2b]
 ```
 
 ## Argument Reference


### PR DESCRIPTION
Fixes #819
This PR continues resource adjustment for VDC Groups. `vcd_nsxt_network_dhcp` worked with VDC Group based networks already, but still required a valid `vdc` fields which wasn't ideal. Now `vdc` field is deprecated and Org network is looked up using already existing and mandatory field `org_network_id`. 

Acceptance tests with tags `network nsxt vdcGroup` passed on 10.2.0 and 10.3.3
