### PR TITLE
Add independent disk sharing_type missing value

### DIFF
--- a/.changes/v3.7.0/849-bug-fixes.md
+++ b/.changes/v3.7.0/849-bug-fixes.md
@@ -1,0 +1,1 @@
+* Add missing `None` mode in independent disk `sharing_type` [GH-849]

--- a/vcd/datasource_vcd_independent_disk.go
+++ b/vcd/datasource_vcd_independent_disk.go
@@ -84,7 +84,7 @@ func datasourceVcIndependentDisk() *schema.Resource {
 			"sharing_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "This is the sharing type. This attribute can only have values defined one of: `DiskSharing`,`ControllerSharing`",
+				Description: "This is the sharing type. This attribute can only have values defined one of: `DiskSharing`,`ControllerSharing`, `None`",
 			},
 			"uuid": {
 				Type:        schema.TypeString,

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -260,6 +260,13 @@ func resourceVcdIndependentDiskUpdate(ctx context.Context, d *schema.ResourceDat
 		return diag.Errorf("error fetching independent disk: %s", err)
 	}
 
+	if d.HasChanges("sharing_type") {
+		oldValue, newValue := d.GetChange("sharing_type")
+		if !strings.EqualFold(newValue.(string), oldValue.(string)) {
+			// See docs at https://developer.vmware.com/apis/1232/vmware-cloud-director/doc/doc///types/DiskType.html
+			return diag.Errorf("[independent disk update] sharing_type is immutable. It can only be set during disk creation")
+		}
+	}
 	if d.HasChanges("size_in_mb", "storage_profile", "description") {
 		storageProfileValue := d.Get("storage_profile").(string)
 		var storageProfileRef *types.Reference

--- a/vcd/resource_vcd_independent_disk.go
+++ b/vcd/resource_vcd_independent_disk.go
@@ -86,8 +86,8 @@ func resourceVcdIndependentDisk() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Computed:     true,
-				ValidateFunc: validation.StringInSlice([]string{"DiskSharing", "ControllerSharing"}, false),
-				Description:  "This is the sharing type. This attribute can only have values defined one of: `DiskSharing`,`ControllerSharing`",
+				ValidateFunc: validation.StringInSlice([]string{"DiskSharing", "ControllerSharing", "None"}, false),
+				Description:  "This is the sharing type. This attribute can only have values defined one of: `DiskSharing`,`ControllerSharing`, `None`",
 			},
 			"uuid": {
 				Type:        schema.TypeString,

--- a/website/docs/r/independent_disk.html.markdown
+++ b/website/docs/r/independent_disk.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `bus_type` - (Optional) Disk bus type. Values can be: `IDE`, `SCSI`, `SATA`, (*v3.6+*) `NVME`. **Note** When the disk type is IDE then VM is required to be powered off
 * `bus_sub_type` - (Optional) Disk bus subtype. Values can be: `buslogic`, `lsilogic`, `lsilogicsas`, `VirtualSCSI` for `SCSI`, `ahci` for `SATA` and (*v3.6+*) `nvmecontroller` for `NVME`
 * `storage_profile` - (Optional) The name of storage profile where disk will be created
-* `sharing_type` - (Optional, *v3.6+* and VCD 10.2+) This is the sharing type. Values can be: `DiskSharing`,`ControllerSharing`"
+* `sharing_type` - (Optional, *v3.6+* and VCD 10.2+) This is the sharing type. Values can be: `DiskSharing`,`ControllerSharing`, or `None`
 * `metadata` - (Optional; *v3.6+*) Key value map of metadata to assign to this independent disk.
 
 


### PR DESCRIPTION
The independent disk `sharing_type` property can have two active modes, which are already provided, but there is also an inactive mode (`None`) which was not recognized by the validation function.