### PR TITLE
Add VDC sharing resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/mikeletux/go-vcloud-director/v2 v2.16.0-alpha.1.0.20220510103601-7e5b403ba904

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
+github.com/mikeletux/go-vcloud-director/v2 v2.16.0-alpha.1.0.20220510103601-7e5b403ba904 h1:0VDRngC35Z9qW/2dFPdo4TvFs5PhpvPUI/vVPsmVRYQ=
+github.com/mikeletux/go-vcloud-director/v2 v2.16.0-alpha.1.0.20220510103601-7e5b403ba904/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -220,8 +222,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2 h1:NFH5VGWtaf/oUoJLU10Pfwft+v/fwedKPAy+5OUnc5o=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.2/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -162,6 +162,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_alb_virtual_service":                  resourceVcdAlbVirtualService(),                // 3.5
 	"vcd_vdc_group":                                 resourceVdcGroup(),                            // 3.5
 	"vcd_nsxt_distributed_firewall":                 resourceVcdNsxtDistributedFirewall(),          // 3.6
+	"vcd_org_vdc_access_control":                    resourceVcdOrgVdcAccessControl(),              // 3.7
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_org_vdc_access_control.go
+++ b/vcd/resource_vcd_org_vdc_access_control.go
@@ -4,37 +4,188 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 func resourceVcdOrgVdcAccessControl() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: resourceVdcVdcAccessControlCreate,
+		CreateContext: resourceVdcVdcAccessControlCreateUpdate,
 		ReadContext:   resourceVdcVdcAccessControlRead,
-		UpdateContext: resourceVdcVdcAccessControlUpdate,
+		UpdateContext: resourceVdcVdcAccessControlCreateUpdate,
 		DeleteContext: resourceVdcVdcAccessControlDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: resourceVdcVdcAccessControlImport,
 		},
-		Schema: map[string]*schema.Schema{},
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The name of VDC to use, optional if defined at provider level",
+			},
+			"shared_with_everyone": {
+				Type:        schema.TypeBool,
+				Required:    true,
+				Description: "Whether the vApp is shared with everyone",
+			},
+			"everyone_access_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{types.ControlAccessReadOnly}, true),
+				Description:  "Access level when the VDC is shared with everyone (only ReadOnly is available). Required when shared_with_everyone is set",
+			},
+			"shared_with": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"user_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "ID of the user to which we are sharing. Required if group_id is not set",
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "ID of the group to which we are sharing. Required if user_id is not set",
+						},
+						"subject_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of the subject (group or user) with which we are sharing",
+						},
+						"access_level": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{types.ControlAccessReadOnly}, true),
+							Description:  "The access level for the user or group to which we are sharing. (Only ReadOnly is available)",
+						},
+					},
+				},
+			},
+		},
 	}
 }
 
-func resourceVdcVdcAccessControlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
+func resourceVdcVdcAccessControlCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	var accessControl types.ControlAccessParams
+
+	isSharedWithEveryone := d.Get("shared_with_everyone").(bool)
+	everyoneAccessLevel := d.Get("everyone_access_level").(string)
+	sharedList := d.Get("shared_with").(*schema.Set).List()
+
+	// Do some checks before proceeding to contact the API
+	if isSharedWithEveryone && len(sharedList) > 0 {
+		return diag.Errorf("if shared_with_everyone is set to true, shared_with must be an empty set")
+	}
+
+	if isSharedWithEveryone {
+		accessControl.IsSharedToEveryone = true
+		accessControl.EveryoneAccessLevel = takeStringPointer(everyoneAccessLevel)
+	} else {
+		adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+		if err != nil {
+			return diag.Errorf("error when retrieving AdminOrg - %s", err)
+		}
+
+		AccessSettings, err := sharedSetToAccessControl(adminOrg, sharedList)
+		if err != nil {
+			return diag.Errorf("error when reading shared_with from schema - %s", err)
+		}
+
+		accessControl.AccessSettings.AccessSetting = AccessSettings
+	}
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		return diag.Errorf("error when retrieving VDC - %s", err)
+	}
+
+	_, err = vdc.SetControlAccess(&accessControl)
+	if err != nil {
+		return diag.Errorf("error when setting VDC control access parameters - %s", err)
+	}
+
+	d.SetId(vdc.Vdc.ID)
+	return resourceVdcVdcAccessControlRead(ctx, d, meta)
 }
 
 func resourceVdcVdcAccessControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	return nil
-}
+	vcdClient := meta.(*VCDClient)
 
-func resourceVdcVdcAccessControlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("error while reading Org - %s", err)
+	}
+
+	vdc, err := org.GetVDCById(d.Id(), false)
+	if err != nil {
+		if govcd.IsNotFound(err) {
+			d.SetId("")
+		} else {
+			return diag.Errorf("error while reading VDC - %s", err)
+		}
+	}
+
+	controlAccessParams, err := vdc.GetControlAccess()
+	if err != nil {
+		return diag.Errorf("error getting control access parameters - %s", err)
+	}
+
+	dSet(d, "shared_with_everyone", controlAccessParams.IsSharedToEveryone)
+	dSet(d, "everyone_access_level", *controlAccessParams.EveryoneAccessLevel)
+	accessControlListSet, err := accessControlListToSharedSet(controlAccessParams.AccessSettings.AccessSetting)
+	if err != nil {
+		return diag.Errorf("error converting slice AccessSetting into set - %s", err)
+	}
+
+	err = d.Set("shared_with", accessControlListSet)
+	if err != nil {
+		return diag.Errorf("error setting shared_with attribute - %s", err)
+	}
+
 	return nil
 }
 
 func resourceVdcVdcAccessControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	// When deleting VDC access control, VDC won't be share with anyone, neither everyone not any single user/group
+	vcdClient := meta.(*VCDClient)
+
+	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	if err != nil {
+		diag.Errorf("error when retrieving VDC - %s", err)
+	}
+
+	controlAccessParams := &types.ControlAccessParams{
+		IsSharedToEveryone: false,
+		AccessSettings: &types.AccessSettingList{
+			AccessSetting: []*types.AccessSetting{},
+		},
+	}
+
+	_, err = vdc.SetControlAccess(controlAccessParams)
+	if err != nil {
+		return diag.Errorf("error when setting VDC control access parameters - %s", err)
+	}
+
+	d.SetId("")
+
 	return nil
 }
 
 func resourceVdcVdcAccessControlImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// TBD
 	return nil, nil
 }

--- a/vcd/resource_vcd_org_vdc_access_control.go
+++ b/vcd/resource_vcd_org_vdc_access_control.go
@@ -177,9 +177,6 @@ func resourceVdcVdcAccessControlDelete(ctx context.Context, d *schema.ResourceDa
 
 	controlAccessParams := &types.ControlAccessParams{
 		IsSharedToEveryone: false,
-		AccessSettings: &types.AccessSettingList{
-			AccessSetting: []*types.AccessSetting{},
-		},
 	}
 
 	_, err = vdc.SetControlAccess(controlAccessParams)

--- a/vcd/resource_vcd_org_vdc_access_control.go
+++ b/vcd/resource_vcd_org_vdc_access_control.go
@@ -1,0 +1,40 @@
+package vcd
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceVcdOrgVdcAccessControl() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVdcVdcAccessControlCreate,
+		ReadContext:   resourceVdcVdcAccessControlRead,
+		UpdateContext: resourceVdcVdcAccessControlUpdate,
+		DeleteContext: resourceVdcVdcAccessControlDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVdcVdcAccessControlImport,
+		},
+		Schema: map[string]*schema.Schema{},
+	}
+}
+
+func resourceVdcVdcAccessControlCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVdcVdcAccessControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVdcVdcAccessControlUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVdcVdcAccessControlDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVdcVdcAccessControlImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	return nil, nil
+}

--- a/vcd/resource_vcd_org_vdc_access_control_test.go
+++ b/vcd/resource_vcd_org_vdc_access_control_test.go
@@ -63,6 +63,12 @@ func TestAccVcdOrgVdcAccessControl(t *testing.T) {
 					assertVdcAccessControlIsSharedWithSpecificUser(userName2),
 				),
 			},
+			{
+				ResourceName:      fmt.Sprintf("vcd_org_vdc_access_control.%s", accessControlName),
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     testConfig.VCD.Org + "." + testConfig.VCD.Vdc,
+			},
 		},
 	})
 }

--- a/vcd/resource_vcd_org_vdc_access_control_test.go
+++ b/vcd/resource_vcd_org_vdc_access_control_test.go
@@ -1,0 +1,87 @@
+//go:build vdc || ALL || functional
+// +build vdc ALL functional
+
+package vcd
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"strings"
+	"testing"
+)
+
+func TestAccVcdOrgVdcAccessControl(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+	}
+
+	accessControlName := "test-access-control"
+
+	var params = StringMap{
+		"Org":               testConfig.VCD.Org,
+		"Vdc":               testConfig.VCD.Vdc,
+		"AccessControlName": accessControlName,
+		"UserName":          strings.ToLower(t.Name()),
+		"PasswordFile":      orgUserPasswordFile,
+		"RoleName":          govcd.OrgUserRoleOrganizationAdministrator,
+	}
+
+	params["FuncName"] = t.Name() + "step1"
+	configText := templateFill(testAccCheckVcdAccessControlStep1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	params["FuncName"] = t.Name() + "step2"
+	configTex2 := templateFill(testAccCheckVcdAccessControlStep2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		// CheckDestroy:      testAccCheckCatalogDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+			{
+				Config: configTex2,
+				Check:  resource.ComposeTestCheckFunc(),
+			},
+		},
+	})
+}
+
+const testAccCheckVcdAccessControlStep1 = `
+resource "vcd_org_vdc_access_control" "{{.AccessControlName}}" {
+  org                   = "{{.Org}}"
+  vdc                   = "{{.Vdc}}"
+  shared_with_everyone  = true
+  everyone_access_level = "ReadOnly"
+}
+`
+
+const testAccCheckVcdAccessControlStep2 = `
+resource "vcd_org_user" "{{.UserName}}" {
+  org            = "{{.Org}}"
+  name           = "{{.UserName}}"
+  password_file  = "{{.PasswordFile}}"
+  role           = "{{.RoleName}}"
+  take_ownership = true
+}
+
+resource "vcd_org_vdc_access_control" "{{.AccessControlName}}" {
+  org                   = "{{.Org}}"
+  vdc                   = "{{.Vdc}}"
+  shared_with_everyone  = false
+  shared_with {
+    user_id             = vcd_org_user.{{.UserName}}.id
+    access_level        = "ReadOnly"
+  }
+}
+`

--- a/vcd/resource_vcd_org_vdc_access_control_test.go
+++ b/vcd/resource_vcd_org_vdc_access_control_test.go
@@ -4,7 +4,9 @@
 package vcd
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"strings"
 	"testing"
@@ -16,13 +18,16 @@ func TestAccVcdOrgVdcAccessControl(t *testing.T) {
 		t.Skip(t.Name() + " requires system admin privileges")
 	}
 
+	userName1 := strings.ToLower(t.Name())
+	userName2 := strings.ToLower(t.Name()) + "2"
 	accessControlName := "test-access-control"
 
 	var params = StringMap{
 		"Org":               testConfig.VCD.Org,
 		"Vdc":               testConfig.VCD.Vdc,
 		"AccessControlName": accessControlName,
-		"UserName":          strings.ToLower(t.Name()),
+		"UserName":          userName1,
+		"UserName2":         userName2,
 		"PasswordFile":      orgUserPasswordFile,
 		"RoleName":          govcd.OrgUserRoleOrganizationAdministrator,
 	}
@@ -43,15 +48,20 @@ func TestAccVcdOrgVdcAccessControl(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		// CheckDestroy:      testAccCheckCatalogDestroy,
+		CheckDestroy:      testAccCheckVDCControlAccessDestroy(),
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
-				Check:  resource.ComposeTestCheckFunc(),
+				Check: resource.ComposeTestCheckFunc(
+					assertVdcAccessControlIsSharedWithEverybody(),
+				),
 			},
 			{
 				Config: configTex2,
-				Check:  resource.ComposeTestCheckFunc(),
+				Check: resource.ComposeTestCheckFunc(
+					assertVdcAccessControlIsSharedWithSpecificUser(userName1),
+					assertVdcAccessControlIsSharedWithSpecificUser(userName2),
+				),
 			},
 		},
 	})
@@ -75,13 +85,98 @@ resource "vcd_org_user" "{{.UserName}}" {
   take_ownership = true
 }
 
+resource "vcd_org_user" "{{.UserName2}}" {
+  org            = "{{.Org}}"
+  name           = "{{.UserName2}}"
+  password_file  = "{{.PasswordFile}}"
+  role           = "{{.RoleName}}"
+  take_ownership = true
+}
+
 resource "vcd_org_vdc_access_control" "{{.AccessControlName}}" {
   org                   = "{{.Org}}"
   vdc                   = "{{.Vdc}}"
   shared_with_everyone  = false
+
   shared_with {
     user_id             = vcd_org_user.{{.UserName}}.id
     access_level        = "ReadOnly"
   }
+
+  shared_with {
+    user_id             = vcd_org_user.{{.UserName2}}.id
+    access_level        = "ReadOnly"
+  }
 }
 `
+
+func testAccCheckVDCControlAccessDestroy() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf("error retrieving Org %s - %s", testConfig.VCD.Org, err)
+		}
+
+		controlAccessParams, err := vdc.GetControlAccess()
+		if err != nil {
+			return fmt.Errorf("error retrieving VDC controll access parameters - %s", err)
+		}
+
+		if controlAccessParams.IsSharedToEveryone || controlAccessParams.AccessSettings != nil {
+			return fmt.Errorf("expected to have VDC sharing settings set to none and got something else")
+		}
+		return nil
+	}
+}
+
+func assertVdcAccessControlIsSharedWithEverybody() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf("error retrieving Org %s - %s", testConfig.VCD.Org, err)
+		}
+
+		controlAccessParams, err := vdc.GetControlAccess()
+		if err != nil {
+			return fmt.Errorf("error retrieving VDC controll access parameters - %s", err)
+		}
+
+		if !controlAccessParams.IsSharedToEveryone {
+			fmt.Errorf("this VDC was expected to be shared with everyone but it is not")
+		}
+
+		return nil
+	}
+}
+
+func assertVdcAccessControlIsSharedWithSpecificUser(userName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		if err != nil {
+			return fmt.Errorf("error retrieving Org %s - %s", testConfig.VCD.Org, err)
+		}
+
+		controlAccessParams, err := vdc.GetControlAccess()
+		if err != nil {
+			return fmt.Errorf("error retrieving VDC controll access parameters - %s", err)
+		}
+
+		if controlAccessParams.AccessSettings == nil {
+			return fmt.Errorf("there are not users configured for sharing in this VDC and they were expected to be")
+		}
+
+		for _, accessControlEntry := range controlAccessParams.AccessSettings.AccessSetting {
+			if accessControlEntry.Subject.Name == userName {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("userName %s wasn't found in VDC %s and it was expected to be", userName, vdc.Vdc.Name)
+	}
+}

--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -96,6 +96,11 @@ func takeInt64Pointer(x int64) *int64 {
 	return &x
 }
 
+// takeStringPointer is a helper that returns the address of a `string`
+func takeStringPointer(x string) *string {
+	return &x
+}
+
 // extractUuid finds an UUID in the input string
 // Returns an empty string if no UUID was found
 func extractUuid(input string) string {


### PR DESCRIPTION
This PR is related https://github.com/vmware/terraform-provider-vcd/issues/785

## Description
This PR brings the new resource `vcd_org_vdc_access_control` to VCD Terraform provider.

## Detailed description
This PR comes with the mentioned resource (TBD and the datasource) as well as its acceptance testing. 
An example code snippet for the resource could be:

Sharing VDC with two users, `my-user` and `my-user-2`
```
resource "vcd_org_vdc_access_control" "my_access_control" {
  org                   = "my-org"
  vdc                   = "my-vdc"
  shared_with_everyone  = false

  shared_with {
    user_id             = vcd_org_user.my-user.id
    access_level        = "ReadOnly"
  }

  shared_with {
    user_id             = vcd_org_user.my-user2.id
    access_level        = "ReadOnly"
  }
}
```

Sharing VDC with everyone:
```
resource "vcd_org_vdc_access_control" "my_access_control" {
  org                   = "my-org"
  vdc                   = "my-vdc"
  shared_with_everyone  = true
  everyone_access_level = "ReadOnly"
}
```