### PR TITLE
Add CatalogItem metadata support for vcd_catalog_item

### DIFF
--- a/.changes/v3.7.0/851-features.md
+++ b/.changes/v3.7.0/851-features.md
@@ -1,1 +1,1 @@
-* Add `catalog_item_metadata` attribute to resource and data source `catalog_item` to support metadata on CatalogItem entities [GH-851]
+* `vcd_catalog_item` resource and data source now supports CatalogItem metadata with `catalog_item_metadata` attribute [GH-851]

--- a/.changes/v3.7.0/851-features.md
+++ b/.changes/v3.7.0/851-features.md
@@ -1,0 +1,1 @@
+* Add `catalog_item_metadata` to resource and data source `catalog_item` to support metadata on CatalogItem entities [GH-851]

--- a/.changes/v3.7.0/851-features.md
+++ b/.changes/v3.7.0/851-features.md
@@ -1,1 +1,1 @@
-* `vcd_catalog_item` resource and data source now supports CatalogItem metadata with `catalog_item_metadata` attribute [GH-851]
+* `vcd_catalog_item` resource and data source now supports metadata for the CatalogItem entity with `catalog_item_metadata` attribute [GH-851]

--- a/.changes/v3.7.0/851-features.md
+++ b/.changes/v3.7.0/851-features.md
@@ -1,1 +1,1 @@
-* Add `catalog_item_metadata` to resource and data source `catalog_item` to support metadata on CatalogItem entities [GH-851]
+* Add `catalog_item_metadata` attribute to resource and data source `catalog_item` to support metadata on CatalogItem entities [GH-851]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,5 @@ require (
 	github.com/hashicorp/go-version v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3
+	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.4
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c h1:wMl+heI6k0ZiSAYk3ZnbmYnkHwZp6h/58WRUxprjx9c=
-github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -222,6 +220,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.4 h1:ssluMUa3mtr37JuO/ADbasUTQ7e00USf7DcIciq3LZ8=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.4/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c h1:wMl+heI6k0ZiSAYk3ZnbmYnkHwZp6h/58WRUxprjx9c=
+github.com/adambarreiro/go-vcloud-director/v2 v2.15.0-alpha.1.0.20220512073349-3d7d0026542c/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
@@ -220,8 +222,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3 h1:f4uU1A5ai6M+wBwyhHHrdVCceza4mD7E1ORbAejdTFA=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_catalog_item.go
+++ b/vcd/datasource_vcd_catalog_item.go
@@ -39,7 +39,12 @@ func datasourceVcdCatalogItem() *schema.Resource {
 			"metadata": {
 				Type:        schema.TypeMap,
 				Computed:    true,
-				Description: "Key and value pairs for catalog item metadata",
+				Description: "Key and value pairs from the metadata of the vApp template associated to this catalog item",
+			},
+			"catalog_item_metadata": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: "Key and value pairs of the catalog item metadata",
 			},
 			"filter": {
 				Type:        schema.TypeList,

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -296,14 +296,38 @@ func createOrUpdateCatalogItemMetadata(d *schema.ResourceData, meta interface{})
 		for _, k := range toBeRemovedMetadata {
 			err := vAppTemplate.DeleteMetadataEntry(k)
 			if err != nil {
-				return fmt.Errorf("error deleting metadata: %s", err)
+				return fmt.Errorf("error deleting metadata from catalog item's associated vApp template: %s", err)
 			}
 		}
 		// Add new metadata
 		for k, v := range newMetadata {
 			err := vAppTemplate.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
 			if err != nil {
-				return fmt.Errorf("error adding metadata: %s", err)
+				return fmt.Errorf("error adding metadata to catalog item's associated vApp template: %s", err)
+			}
+		}
+	}
+	if d.HasChange("catalog_item_metadata") {
+		oldRaw, newRaw := d.GetChange("catalog_item_metadata")
+		oldMetadata := oldRaw.(map[string]interface{})
+		newMetadata := newRaw.(map[string]interface{})
+		var toBeRemovedMetadata []string
+		for k := range oldMetadata {
+			if _, ok := newMetadata[k]; !ok {
+				toBeRemovedMetadata = append(toBeRemovedMetadata, k)
+			}
+		}
+		for _, k := range toBeRemovedMetadata {
+			err := catalogItem.DeleteMetadataEntry(k)
+			if err != nil {
+				return fmt.Errorf("error deleting metadata from catalog item: %s", err)
+			}
+		}
+		// Add new metadata
+		for k, v := range newMetadata {
+			err := catalogItem.AddMetadataEntry(types.MetadataStringValue, k, v.(string))
+			if err != nil {
+				return fmt.Errorf("error adding metadata to catalog item: %s", err)
 			}
 		}
 	}

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -316,6 +316,7 @@ func createOrUpdateCatalogItemMetadata(d *schema.ResourceData, meta interface{})
 			}
 		}
 	}
+	// TODO: Move this code snippet to a function with generics
 	if d.HasChange("catalog_item_metadata") {
 		oldRaw, newRaw := d.GetChange("catalog_item_metadata")
 		oldMetadata := oldRaw.(map[string]interface{})

--- a/vcd/resource_vcd_catalog_item.go
+++ b/vcd/resource_vcd_catalog_item.go
@@ -79,9 +79,12 @@ func resourceVcdCatalogItem() *schema.Resource {
 			"metadata": {
 				Type:        schema.TypeMap,
 				Optional:    true,
+				Description: "Key and value pairs for the metadata of the vApp template associated to this catalog item",
+			},
+			"catalog_item_metadata": {
+				Type:        schema.TypeMap,
+				Optional:    true,
 				Description: "Key and value pairs for catalog item metadata",
-				// For now underlying go-vcloud-director repo only supports
-				// a value of type String in this map.
 			},
 		},
 	}

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -85,9 +85,13 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceCatalogItem, "description", TestAccVcdCatalogItemDescription),
 					resource.TestCheckResourceAttr(
-						resourceCatalogItem, "metadata.catalogItem_metadata", "catalogItem Metadata"),
+						resourceCatalogItem, "metadata.vapp_template_metadata", "vApp Template Metadata"),
 					resource.TestCheckResourceAttr(
-						resourceCatalogItem, "metadata.catalogItem_metadata2", "catalogItem Metadata2"),
+						resourceCatalogItem, "metadata.vapp_template_metadata2", "vApp Template Metadata2"),
+					resource.TestCheckResourceAttr(
+						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata4", "catalogItem Metadata"),
+					resource.TestCheckResourceAttr(
+						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata5", "catalogItem Metadata2"),
 				),
 			},
 			{
@@ -99,11 +103,17 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vcd_catalog_item."+TestAccVcdCatalogItem, "description", TestAccVcdCatalogItemDescription),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.catalogItem_metadata", "catalogItem Metadata v2"),
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.vapp_template_metadata", "vApp Template Metadata v2"),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.catalogItem_metadata2", "catalogItem Metadata2 v2"),
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.vapp_template_metadata2", "vApp Template Metadata2 v2"),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.catalogItem_metadata3", "catalogItem Metadata3"),
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "metadata.vapp_template_metadata3", "vApp Template Metadata3"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "catalog_item_metadata.catalogItem_metadata", "catalogItem Metadata v2"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "catalog_item_metadata.catalogItem_metadata2", "catalogItem Metadata2 v2"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItem, "catalog_item_metadata.catalogItem_metadata3", "catalogItem Metadata3"),
 				),
 			},
 			{
@@ -116,11 +126,17 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "description", TestAccVcdCatalogItemDescriptionFromUrl),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata", "catalogItem Metadata"),
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.vapp_template_metadata", "vApp Template Metadata"),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata2", "catalogItem Metadata2"),
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.vapp_template_metadata2", "vApp Template Metadata2"),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata3", "catalogItem Metadata3"),
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.vapp_template_metadata3", "vApp Template Metadata3"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "catalog_item_metadata.catalogItem_metadata", "catalogItem Metadata"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "catalog_item_metadata.catalogItem_metadata2", "catalogItem Metadata2"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "catalog_item_metadata.catalogItem_metadata3", "catalogItem Metadata3"),
 				),
 			},
 			{
@@ -133,9 +149,13 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "description", TestAccVcdCatalogItemDescriptionFromUrlUpdated),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata", "catalogItem Metadata"),
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.vapp_template_metadata", "vApp Template Metadata"),
 					resource.TestCheckResourceAttr(
-						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.catalogItem_metadata2", "catalogItem Metadata2_2"),
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "metadata.vapp_template_metadata2", "vApp Template Metadata2_2"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "catalog_item_metadata.catalogItem_metadata", "catalogItem Metadata"),
+					resource.TestCheckResourceAttr(
+						"vcd_catalog_item."+TestAccVcdCatalogItemFromUrl, "catalog_item_metadata.catalogItem_metadata2", "catalogItem Metadata2_2"),
 				),
 			},
 		},
@@ -233,6 +253,11 @@ const testAccCheckVcdCatalogItemBasic = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
+    vapp_template_metadata = "vApp Template Metadata"
+    vapp_template_metadata2 = "vApp Template Metadata2"
+  }
+
+  catalog_item_metadata = {
     catalogItem_metadata = "catalogItem Metadata"
     catalogItem_metadata2 = "catalogItem Metadata2"
   }
@@ -251,6 +276,12 @@ const testAccCheckVcdCatalogItemUpdate = `
   show_upload_progress = "{{.UploadProgress}}"
 
   metadata = {
+    vapp_template_metadata = "vApp Template Metadata v2"
+    vapp_template_metadata2 = "vApp Template Metadata2 v2"
+    vapp_template_metadata3 = "vApp Template Metadata3"
+  }
+
+  catalog_item_metadata = {
     catalogItem_metadata = "catalogItem Metadata v2"
     catalogItem_metadata2 = "catalogItem Metadata2 v2"
     catalogItem_metadata3 = "catalogItem Metadata3"
@@ -269,6 +300,12 @@ const testAccCheckVcdCatalogItemFromUrl = `
   show_upload_progress = "{{.UploadProgressFromUrl}}"
 
   metadata = {
+    vapp_template_metadata = "vApp Template Metadata"
+    vapp_template_metadata2 = "vApp Template Metadata2"
+    vapp_template_metadata3 = "vApp Template Metadata3"
+  }
+
+  catalog_item_metadata = {
     catalogItem_metadata = "catalogItem Metadata"
     catalogItem_metadata2 = "catalogItem Metadata2"
     catalogItem_metadata3 = "catalogItem Metadata3"
@@ -287,6 +324,11 @@ const testAccCheckVcdCatalogItemFromUrlUpdated = `
   show_upload_progress = "{{.UploadProgressFromUrl}}"
 
   metadata = {
+    vapp_template_metadata = "vApp Template Metadata"
+    vapp_template_metadata2 = "vApp Template Metadata2_2"
+  }
+
+  catalog_item_metadata = {
     catalogItem_metadata = "catalogItem Metadata"
     catalogItem_metadata2 = "catalogItem Metadata2_2"
   }

--- a/vcd/resource_vcd_catalog_item_test.go
+++ b/vcd/resource_vcd_catalog_item_test.go
@@ -89,9 +89,9 @@ func TestAccVcdCatalogItemBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceCatalogItem, "metadata.vapp_template_metadata2", "vApp Template Metadata2"),
 					resource.TestCheckResourceAttr(
-						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata4", "catalogItem Metadata"),
+						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata", "catalogItem Metadata"),
 					resource.TestCheckResourceAttr(
-						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata5", "catalogItem Metadata2"),
+						resourceCatalogItem, "catalog_item_metadata.catalogItem_metadata2", "catalogItem Metadata2"),
 				),
 			},
 			{

--- a/website/docs/d/catalog_item.html.markdown
+++ b/website/docs/d/catalog_item.html.markdown
@@ -54,7 +54,8 @@ The following arguments are supported:
 ## Attribute Reference
 
 * `description` - Catalog item description.
-* `metadata` -  Key value map of metadata.
+* `metadata` - Key value map of metadata for the associated vApp template.
+* `catalog_item_metadata` - Key value map of metadata for the catalog item.
 
 ## Filter arguments
 

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -47,8 +47,8 @@ The following arguments are supported:
 * `ovf_url` - (Optional; *v3.6+*) URL to OVF file. Only OVF (not OVA) files are supported by VCD uploading by URL
 * `upload_piece_size` - (Optional) - Size in MB for splitting upload size. It can possibly impact upload performance. Default 1MB.
 * `show_upload_progress` - (Optional) - Default false. Allows seeing upload progress. (See note below)
-* `metadata` - (Optional; *v2.5+*) Key value map of metadata to assign to the associated vApp template
-* `catalog_item_metadata` - (Optional; *v3.7+*) Key value map of metadata to assign to the catalog item
+* `metadata` - (Optional; *v2.5+*) Key value map of metadata to assign to the associated vApp Template
+* `catalog_item_metadata` - (Optional; *v3.7+*) Key value map of metadata to assign to the Catalog Item
 
 ### A note about upload progress
 

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -29,7 +29,6 @@ resource "vcd_catalog_item" "myNewCatalogItem" {
     license = "public"
     version = "v1"
   }
-  
   catalog_item_metadata = {
     environment = "production"
   }

--- a/website/docs/r/catalog_item.html.markdown
+++ b/website/docs/r/catalog_item.html.markdown
@@ -29,6 +29,10 @@ resource "vcd_catalog_item" "myNewCatalogItem" {
     license = "public"
     version = "v1"
   }
+  
+  catalog_item_metadata = {
+    environment = "production"
+  }
 }
 ```
 
@@ -44,7 +48,8 @@ The following arguments are supported:
 * `ovf_url` - (Optional; *v3.6+*) URL to OVF file. Only OVF (not OVA) files are supported by VCD uploading by URL
 * `upload_piece_size` - (Optional) - Size in MB for splitting upload size. It can possibly impact upload performance. Default 1MB.
 * `show_upload_progress` - (Optional) - Default false. Allows seeing upload progress. (See note below)
-* `metadata` - (Optional; *v2.5+*) Key value map of metadata to assign
+* `metadata` - (Optional; *v2.5+*) Key value map of metadata to assign to the associated vApp template
+* `catalog_item_metadata` - (Optional; *v3.7+*) Key value map of metadata to assign to the catalog item
 
 ### A note about upload progress
 


### PR DESCRIPTION
## Description

This PR adds the capability of including metadata in the `vcd_catalog_item` resource that belongs to the CatalogItem itself, as right now the `metadata` attribute belongs to the associated vApp template. The new attribute for this is called **catalog_item_metadata**.

The data source has been also updated to fetch the CatalogItem metadata into that attribute.

Documentation and log messages have been updated accordingly.

The changes somehow relate to the issue #502 