### PR TITLE
vcd_nsxt_alb_edgegateway_service_engine_group fix when no `vdc` is specified in `provider` level 

### DIFF
--- a/.changes/v3.7.0/841-improvements.md
+++ b/.changes/v3.7.0/841-improvements.md
@@ -2,6 +2,6 @@
 * Add VDC Group compatibility for `resource/vcd_nsxt_nat_rule` and `datasource/vcd_nsxt_nat_rule` [GH-841]
 * Add VDC Group compatibility for `resource/vcd_nsxt_ipsec_vpn_tunnel` and `datasource/vcd_nsxt_ipsec_vpn_tunnel` [GH-841]
 * Add VDC Group compatibility for `resource/vcd_nsxt_alb_settings` and `datasource/vcd_nsxt_alb_settings` [GH-841]
-* Add VDC Group compatibility for `resource/vcd_nsxt_alb_edgegateway_service_engine_group` and `datasource/vcd_nsxt_alb_edgegateway_service_engine_group` [GH-841]
+* Add VDC Group compatibility for `resource/vcd_nsxt_alb_edgegateway_service_engine_group` and `datasource/vcd_nsxt_alb_edgegateway_service_engine_group` [GH-841, GH-854]
 * Add VDC Group compatibility for `resource/vcd_nsxt_alb_virtual_service` and `datasource/vcd_nsxt_alb_virtual_service` [GH-841]
 * Add VDC Group compatibility for `resource/vcd_nsxt_alb_pool` and `datasource/vcd_nsxt_alb_pool` [GH-841]

--- a/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group.go
+++ b/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group.go
@@ -218,15 +218,15 @@ func getAlbServiceEngineGroupAssignmentType(d *schema.ResourceData) *types.NsxtA
 
 // validateEdgeGatewayIdParent validates if specified field `edge_gateway_id` exists in defined Org and VDC
 func validateEdgeGatewayIdParent(d *schema.ResourceData, vcdClient *VCDClient) error {
-	org, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
+	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
 		return fmt.Errorf("error retrieving Org and VDC")
 	}
 
 	_, err = vcdClient.GetNsxtEdgeGatewayFromResourceById(d, "edge_gateway_id")
 	if err != nil {
-		return fmt.Errorf("unable to locate NSX-T Edge Gateway with ID '%s' in Org '%s' and VDC '%s': %s",
-			d.Get("edge_gateway_id").(string), org.Org.Name, vdc.Vdc.Name, err)
+		return fmt.Errorf("unable to locate NSX-T Edge Gateway with ID '%s' in Org '%s': %s",
+			d.Get("edge_gateway_id").(string), org.Org.Name, err)
 	}
 
 	return nil

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -78,7 +78,6 @@ resource "vcd_vdc_group" "test1" {
 // fill function so that binary tests are rendered correctly as well.
 func overrideDefaultVdcForTest(temporaryVdcFieldValue string) func() {
 	originalVdcValue := os.Getenv("VCD_VDC")
-	// testConfigOriginalVdcValue := testConfig.VCD.Vdc
 
 	if vcdTestVerbose {
 		fmt.Printf("# Overriding 'vdc' field in provider configuration to be '%s' instead of '%s'\n", temporaryVdcFieldValue, originalVdcValue)


### PR DESCRIPTION
After PR #841 adding support for a bunch of resources a bug still persisted in `vcd_nsxt_alb_edgegateway_service_engine_group` dependency on VDC field. This PR adds a test for replication of it (commit 5ae834e) it and introduces a fix (commit 67b4157). 

Special thanks goes to @adambarreiro  for finding it.

Acceptance tests pass on 10.2 and 10.3 using tags `network nsxt vdcGroup alb`
Binary tests passed on 10.2 using tag `alb`