### PR TITLE
Update insert media locking to be concise with internal disk locking

### DIFF
--- a/.changes/v3.7.0/870-bug-fixes.md
+++ b/.changes/v3.7.0/870-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix `vcd_inserted_media` locking mechanism to avoid race condition with `vcd_vm_internal_disk` [GH-870]

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -245,7 +245,7 @@ func TestAccVcdMediaLockTest(t *testing.T) {
 		"CatalogItem":      testConfig.VCD.Catalog.CatalogItem,
 		"VappName":         t.Name(),
 		"VmName":           t.Name(),
-		"CatalogMediaName": testConfig.Media.MediaName,
+		"CatalogMediaName": t.Name(),
 		"Description":      t.Name() + "_description",
 		"MediaPath":        testConfig.Media.MediaPath,
 		"UploadPieceSize":  testConfig.Media.UploadPieceSize,

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -245,7 +245,7 @@ func TestAccVcdMediaLockTest(t *testing.T) {
 		"CatalogItem":      testConfig.VCD.Catalog.CatalogItem,
 		"VappName":         t.Name(),
 		"VmName":           t.Name(),
-		"CatalogMediaName": t.Name(),
+		"CatalogMediaName": testConfig.Media.MediaName,
 		"Description":      t.Name() + "_description",
 		"MediaPath":        testConfig.Media.MediaPath,
 		"UploadPieceSize":  testConfig.Media.UploadPieceSize,

--- a/vcd/resource_vcd_inserted_media_test.go
+++ b/vcd/resource_vcd_inserted_media_test.go
@@ -23,8 +23,8 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 	preTestChecks(t)
 	var params = StringMap{
 		"Org":              testConfig.VCD.Org,
-		"Vdc":              testConfig.VCD.Vdc,
-		"EdgeGateway":      testConfig.Networking.EdgeGateway,
+		"Vdc":              testConfig.Nsxt.Vdc,
+		"EdgeGateway":      testConfig.Nsxt.EdgeGateway,
 		"Catalog":          testSuiteCatalogName,
 		"CatalogItem":      testSuiteCatalogOVAItem,
 		"VappName":         vappNameForInsert,
@@ -55,8 +55,8 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckMediaInserted("vcd_inserted_media."+TestAccVcdMediaInsert),
-					testAccCheckMediaEjected("vcd_inserted_media."+TestAccVcdMediaInsert),
+					testAccCheckMediaInserted("vcd_inserted_media."+TestAccVcdMediaInsert, params),
+					testAccCheckMediaEjected("vcd_inserted_media."+TestAccVcdMediaInsert, params),
 				),
 			},
 		},
@@ -64,7 +64,7 @@ func TestAccVcdMediaInsertBasic(t *testing.T) {
 	postTestChecks(t)
 }
 
-func testAccCheckMediaInserted(itemName string) resource.TestCheckFunc {
+func testAccCheckMediaInserted(itemName string, params StringMap) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		injectItemRs, ok := s.RootModule().Resources[itemName]
 		if !ok {
@@ -77,17 +77,17 @@ func testAccCheckMediaInserted(itemName string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*VCDClient)
 
-		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		_, vdc, err := conn.GetOrgAndVdc(params["Org"].(string), params["Vdc"].(string))
 		if err != nil {
-			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+			return fmt.Errorf(errorRetrievingVdcFromOrg, params["Vdc"].(string), params["Org"], err)
 		}
 
-		vapp, err := vdc.GetVAppByName(vappNameForInsert, false)
+		vapp, err := vdc.GetVAppByName(params["VappName"].(string), false)
 		if err != nil {
 			return err
 		}
 
-		vm, err := vapp.GetVMByName(vmNameForInsert, false)
+		vm, err := vapp.GetVMByName(params["VmName"].(string), false)
 
 		if err != nil {
 			return err
@@ -102,7 +102,7 @@ func testAccCheckMediaInserted(itemName string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckMediaEjected(itemName string) resource.TestCheckFunc {
+func testAccCheckMediaEjected(itemName string, params StringMap) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		injectItemRs, ok := s.RootModule().Resources[itemName]
 		if !ok {
@@ -115,17 +115,17 @@ func testAccCheckMediaEjected(itemName string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*VCDClient)
 
-		_, vdc, err := conn.GetOrgAndVdc(testConfig.VCD.Org, testConfig.VCD.Vdc)
+		_, vdc, err := conn.GetOrgAndVdc(params["Org"].(string), params["Vdc"].(string))
 		if err != nil {
-			return fmt.Errorf(errorRetrievingVdcFromOrg, testConfig.VCD.Vdc, testConfig.VCD.Org, err)
+			return fmt.Errorf(errorRetrievingVdcFromOrg, params["Vdc"].(string), params["Org"], err)
 		}
 
-		vapp, err := vdc.GetVAppByName(vappNameForInsert, false)
+		vapp, err := vdc.GetVAppByName(params["VappName"].(string), false)
 		if err != nil {
 			return err
 		}
 
-		vm, err := vapp.GetVMByName(vmNameForInsert, false)
+		vm, err := vapp.GetVMByName(params["VmName"].(string), false)
 
 		if err != nil {
 			return err
@@ -229,8 +229,124 @@ resource "vcd_inserted_media" "{{.InsertMediaName}}" {
 
   vapp_name  = vcd_vapp.{{.VappName}}.name
   vm_name    = vcd_vapp_vm.{{.VmName}}.name
-  depends_on = ["vcd_vapp_vm.{{.VmName}}", "vcd_catalog_media.{{.CatalogMediaName}}"]
+  depends_on = [vcd_vapp_vm.{{.VmName}}, vcd_catalog_media.{{.CatalogMediaName}}]
 
   eject_force = "{{.EjectForce}}"
+}
+`
+
+func TestAccVcdMediaLockTest(t *testing.T) {
+	preTestChecks(t)
+	var params = StringMap{
+		"Org":              testConfig.VCD.Org,
+		"Vdc":              testConfig.Nsxt.Vdc,
+		"EdgeGateway":      testConfig.Nsxt.EdgeGateway,
+		"Catalog":          testConfig.VCD.Catalog.Name,
+		"CatalogItem":      testConfig.VCD.Catalog.CatalogItem,
+		"VappName":         t.Name(),
+		"VmName":           t.Name(),
+		"CatalogMediaName": testConfig.Media.MediaName,
+		"Description":      t.Name() + "_description",
+		"MediaPath":        testConfig.Media.MediaPath,
+		"UploadPieceSize":  testConfig.Media.UploadPieceSize,
+		"UploadProgress":   testConfig.Media.UploadProgress,
+		"NetworkName":      t.Name(),
+		"EjectForce":       true,
+		"Tags":             "catalog",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccCheckVcdInsertEjectLock, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccResourcesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMediaInserted("vcd_inserted_media."+params["CatalogMediaName"].(string), params),
+					testAccCheckMediaEjected("vcd_inserted_media."+params["CatalogMediaName"].(string), params),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccCheckVcdInsertEjectLock = `
+resource "vcd_network_routed" "{{.NetworkName}}" {
+  name         = "{{.NetworkName}}"
+  org          = "{{.Org}}"
+  vdc          = "{{.Vdc}}"
+  edge_gateway = "{{.EdgeGateway}}"
+  gateway      = "10.10.102.1"
+
+  static_ip_pool {
+    start_address = "10.10.102.2"
+    end_address   = "10.10.102.254"
+  }
+}
+
+resource "vcd_vapp" "{{.VappName}}" {
+  name       = "{{.VappName}}"
+  org        = "{{.Org}}"
+  vdc        = "{{.Vdc}}"
+}
+
+resource "vcd_vapp_org_network" "vappNetwork1" {
+  org                = "{{.Org}}"
+  vdc                = "{{.Vdc}}"
+  vapp_name          = vcd_vapp.{{.VappName}}.name
+  org_network_name   = vcd_network_routed.{{.NetworkName}}.name 
+}
+
+resource "vcd_vapp_vm" "{{.VmName}}" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.{{.VappName}}.name
+  name          = "{{.VmName}}"
+  catalog_name  = "{{.Catalog}}"
+  template_name = "{{.CatalogItem}}"
+  memory        = 1024
+  cpus          = 1
+  power_on      = "false"
+  network {
+    type               = "org"
+    name               = vcd_vapp_org_network.vappNetwork1.org_network_name
+    ip_allocation_mode = "POOL"
+  }
+}
+
+resource "vcd_inserted_media" "{{.CatalogMediaName}}" {
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+  catalog = "{{.Catalog}}"
+  name    = "{{.CatalogMediaName}}"
+
+  vapp_name  = vcd_vapp.{{.VappName}}.name
+  vm_name    = vcd_vapp_vm.{{.VmName}}.name
+
+  eject_force = "{{.EjectForce}}"
+
+}
+
+resource "vcd_vm_internal_disk" "internal_disk1" {
+  org     = "{{.Org}}"
+  vdc     = "{{.Vdc}}"
+
+  vapp_name  = vcd_vapp.{{.VappName}}.name
+  vm_name    = vcd_vapp_vm.{{.VmName}}.name
+
+  bus_type    = "paravirtual"
+  size_in_mb  = 10 * 1024
+  bus_number  = 1
+  unit_number = 0
+
 }
 `

--- a/vcd/resource_vcd_vm_internal_disk.go
+++ b/vcd/resource_vcd_vm_internal_disk.go
@@ -259,7 +259,7 @@ func getVm(vcdClient *VCDClient, d *schema.ResourceData) (*govcd.VM, *govcd.Vdc,
 	if err != nil {
 		return nil, nil, fmt.Errorf(errorRetrievingOrgAndVdc, err)
 	}
-	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), false)
+	vapp, err := vdc.GetVAppByName(d.Get("vapp_name").(string), true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("[getVm] failed to get vApp: %s", err)
 	}


### PR DESCRIPTION
Ref: https://github.com/vmware/terraform-provider-vcd/issues/868

* update deprecated methods
* update insert media locking mechanism to match internal disk locking to avoid race conditions

Signed-off-by: Vaidotas Bauzys <vbauzys@vmware.com>