### PR TITLE
Specify that only TKGm clusters are supported in CSE guide

### DIFF
--- a/examples/container-service-extension-3.1.x/3.7-cse-3.1.x-install.tf
+++ b/examples/container-service-extension-3.1.x/3.7-cse-3.1.x-install.tf
@@ -5,6 +5,10 @@
 #   http://vmware.github.io/vcd-cli/install.html
 #   https://vmware.github.io/container-service-extension/cse3_0/INSTALLATION.html#getting_cse
 #
+# * This example allows to create TKGm clusters using VCD UI once applied. Read the guide present in
+#   https://registry.terraform.io/providers/vmware/vcd/latest/docs/guides/container_service_extension_3_1_x for more
+#   information.
+#
 # * This HCL should be run as System administrator, as it involves creating provider elements such as Organizations,
 #   VDCs or Tier 0 Gateways.
 #

--- a/examples/container-service-extension-3.1.x/terraform.tfvars.example
+++ b/examples/container-service-extension-3.1.x/terraform.tfvars.example
@@ -55,6 +55,6 @@ routed-dns      = ["8.8.8.8", "8.8.8.4"]
 avi-controller-name  = "aviController1"
 avi-importable-cloud = "NSXT https://my-importable-cloud.company.com"
 
-# OVA name should be something like "ubuntu-2022-kube-v1.22.0+vmware.1-tkg.1-1234567891234567890.ova"
+# TKGm OVA name should be something like "ubuntu-2022-kube-v1.22.0+vmware.1-tkg.1-1234567891234567890.ova"
 tkgm-ova-name   = "ubuntu-2022-kube-v1.22.0+vmware.1-tkg.1-1234567891234567890.ova"
 tkgm-ova-folder = "/Users/username/Downloads"

--- a/website/docs/guides/container_service_extension_3_1_x.html.markdown
+++ b/website/docs/guides/container_service_extension_3_1_x.html.markdown
@@ -11,7 +11,7 @@ Provides guidance on configuring VCD to be able to install Container Service Ext
 ## About
 
 This guide describes the required steps to configure VCD to install the Container Service Extension (CSE) v3.1.x, that
-will allow tenant users to deploy Kubernetes clusters on VCD using the UI. For that purpose, after completing the steps described below you
+will allow tenant users to deploy **Tanzu Kubernetes Grid Multi-cloud (TKGm)** clusters on VCD using the UI. For that purpose, after completing the steps described below you
 will need also to **publish the Container UI Plugin** to the desired tenants and **run the CSE server** in your infrastructure.
 
 To know more about CSE v3.1.x, you can explore [the official website](https://vmware.github.io/container-service-extension/).
@@ -268,7 +268,7 @@ Then you can upload TKGm OVAs to this catalog. These can be downloaded from **VM
 To upload them, use the [Catalog Item](/providers/vmware/vcd/latest/docs/resources/catalog_item) resource with
 `catalog_item_metadata`.
 
-~> CSE is **not compatible** yet with PhotonOS
+~> Only TKGm OVAs are supported. CSE is **not compatible** yet with PhotonOS
 
 ```hcl
 resource "vcd_catalog_item" "tkgm_ova" {


### PR DESCRIPTION
During #856 there was a lack of precision about the type of clusters supported by the CSE guide and examples created. This tiny PR just adds/modifies pieces of text to specify that only TKGm clusters are supported.