### PR TITLE
Add vcd_nsxt_dynamic_security_group resource and data source

### DIFF
--- a/.changes/v3.7.0/877-features.md
+++ b/.changes/v3.7.0/877-features.md
@@ -1,0 +1,3 @@
+* **New Resource:** `vcd_nsxt_dynamic_security_group` to manage dynamic security groups [GH-877]
+* **New Data Source:** `vcd_nsxt_dynamic_security_group` to lookup existing dynamic security groups
+  [GH-877]

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220701082352-f4a9175afc79
 
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461 h1:T7akhqV1bFbV9NkpYMYlKOwH+s+6QNL9cyIgIRohTDU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -224,8 +226,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9 h1:i8OqjVqUoYuPcu/TByXxkxGg02xsX7X7lJlcjrl9y9o=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461 h1:T7akhqV1bFbV9NkpYMYlKOwH+s+6QNL9cyIgIRohTDU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220630121754-e24920f35461/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220701082352-f4a9175afc79 h1:BIyoNGax5+DRIklVzHPTbS5cOcDnaU1mjF3HOgGzfI0=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220701082352-f4a9175afc79/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/vcd/datasource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/datasource_vcd_nsxt_dynamic_security_group.go
@@ -33,22 +33,18 @@ func datasourceVcdDynamicSecurityGroup() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "dynamic security group description",
+				Description: "Dynamic Security Group description",
 			},
 			"criteria": {
 				Type:        schema.TypeSet,
 				Computed:    true,
-				Description: "Up to three criteria to be used to define the dynamic security group",
+				Description: "Criteria to be used to define the Dynamic Security Group",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rule": {
 							Type:        schema.TypeSet,
 							Description: "Up to 4 rules can be used to define single criteria",
-							// Up to 4 rules can be used to define single criteria as per documentation, but API
-							// error is human readable and this might change in future so not enforcing max of 4
-							// rules
-							// MaxItems:    4,
-							Optional: true,
+							Computed:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"type": {
@@ -88,7 +84,7 @@ func datasourceVcdDynamicSecurityGroupRead(ctx context.Context, d *schema.Resour
 
 	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf("[nsxt dynamic security group read] error retrieving Org: %s", err)
+		return diag.Errorf("[nsxt dynamic security group data source read] error retrieving Org: %s", err)
 	}
 
 	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
@@ -98,23 +94,23 @@ func datasourceVcdDynamicSecurityGroupRead(ctx context.Context, d *schema.Resour
 
 	securityGroup, err := vdcGroup.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeVmCriteria)
 	if err != nil {
-		return diag.Errorf("[nsxt dynamic security group read] error getting NSX-T dynamic security group: %s", err)
+		return diag.Errorf("[nsxt dynamic security group data source read] error getting NSX-T dynamic security group: %s", err)
 	}
 
 	err = setNsxtDynamicSecurityGroupData(d, securityGroup.NsxtFirewallGroup)
 	if err != nil {
-		return diag.Errorf("[nsxt security group read] error setting NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt security group data source read] error setting NSX-T Security Group: %s", err)
 	}
 
 	// A separate GET call is required to get all associated VMs
 	associatedVms, err := securityGroup.GetAssociatedVms()
 	if err != nil {
-		return diag.Errorf("[nsxt dynamic security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt dynamic security group data source read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
 	if err != nil {
-		return diag.Errorf("[nsxt dynamic security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+		return diag.Errorf("[nsxt dynamic security group data source read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
 	}
 
 	d.SetId(securityGroup.NsxtFirewallGroup.ID)

--- a/vcd/datasource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/datasource_vcd_nsxt_dynamic_security_group.go
@@ -99,7 +99,7 @@ func datasourceVcdDynamicSecurityGroupRead(ctx context.Context, d *schema.Resour
 
 	err = setNsxtDynamicSecurityGroupData(d, securityGroup.NsxtFirewallGroup)
 	if err != nil {
-		return diag.Errorf("[nsxt security group data source read] error setting NSX-T Security Group: %s", err)
+		return diag.Errorf("[nsxt dynamic security group data source read] error setting NSX-T Dynamic Security Group: %s", err)
 	}
 
 	// A separate GET call is required to get all associated VMs

--- a/vcd/datasource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/datasource_vcd_nsxt_dynamic_security_group.go
@@ -1,0 +1,123 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func datasourceVcdDynamicSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdDynamicSecurityGroupRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Dynamic Security Group name",
+			},
+			"vdc_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "VDC Group ID in which Dynamic Security Group is located",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "dynamic security group description",
+			},
+			"criteria": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Up to three criteria to be used to define the dynamic security group",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"rule": {
+							Type:        schema.TypeSet,
+							Description: "Up to 4 rules can be used to define single criteria",
+							// Up to 4 rules can be used to define single criteria as per documentation, but API
+							// error is human readable and this might change in future so not enforcing max of 4
+							// rules
+							// MaxItems:    4,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Type of object matching 'VM_TAG' or 'VM_NAME'",
+									},
+									"operator": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Operator can be one of 'EQUALS', 'CONTAINS', 'STARTS_WITH', 'ENDS_WITH'",
+									},
+									"value": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "Filter value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"member_vms": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Set of VM IDs",
+				Elem:        nsxtFirewallGroupMemberVms,
+			},
+		},
+	}
+}
+
+func datasourceVcdDynamicSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vdcGroupId := d.Get("vdc_group_id").(string)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		return diag.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	securityGroup, err := vdcGroup.GetNsxtFirewallGroupByName(d.Get("name").(string), types.FirewallGroupTypeVmCriteria)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error getting NSX-T dynamic security group: %s", err)
+	}
+
+	err = setNsxtDynamicSecurityGroupData(d, securityGroup.NsxtFirewallGroup)
+	if err != nil {
+		return diag.Errorf("[nsxt security group read] error setting NSX-T Security Group: %s", err)
+	}
+
+	// A separate GET call is required to get all associated VMs
+	associatedVms, err := securityGroup.GetAssociatedVms()
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	d.SetId(securityGroup.NsxtFirewallGroup.ID)
+
+	return nil
+}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -96,7 +96,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_distributed_firewall":                 datasourceVcdNsxtDistributedFirewall(),          // 3.6
 	"vcd_nsxt_network_context_profile":              datasourceVcdNsxtNetworkContextProfile(),        // 3.6
 	"vcd_nsxt_route_advertisement":                  datasourceVcdNsxtRouteAdvertisement(),           // 3.7
-
+	"vcd_nsxt_dynamic_security_group":               datasourceVcdDynamicSecurityGroup(),             // 3.7
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -166,6 +166,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_security_tag":                              resourceVcdSecurityTag(),                      // 3.7
 	"vcd_nsxt_route_advertisement":                  resourceVcdNsxtRouteAdvertisement(),           // 3.7
 	"vcd_org_vdc_access_control":                    resourceVcdOrgVdcAccessControl(),              // 3.7
+	"vcd_nsxt_dynamic_security_group":               resourceVcdDynamicSecurityGroup(),             // 3.7
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group.go
@@ -1,0 +1,337 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func resourceVcdDynamicSecurityGroup() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdDynamicSecurityGroupCreate,
+		ReadContext:   resourceVcdDynamicSecurityGroupRead,
+		UpdateContext: resourceVcdDynamicSecurityGroupUpdate,
+		DeleteContext: resourceVcdDynamicSecurityGroupDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdDynamicSecurityGroupImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"vdc_group_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "VDC Group ID in which Dynamic Security Group is located",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Dynamic Security Group name",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Dynamic Security Group description",
+			},
+			"criteria": {
+				Type:        schema.TypeSet,
+				Description: "Up to 3 criteria to be used to define the dynamic security group",
+				// Up to 3 criteria can be defined as per current documentation, but API errors are
+				// human readable so not hard-enforcing it as these limits may change in future VCD
+				// versions
+				// MaxItems: 3,
+				Optional: true,
+				Elem:     criteria,
+			},
+			"member_vms": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "Set of VM IDs",
+				Elem:        nsxtFirewallGroupMemberVms,
+			},
+		},
+	}
+}
+
+var criteria = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"rule": {
+			Type:        schema.TypeSet,
+			Description: "Up to 4 rules can be used to define single criteria",
+			// Up to 4 rules can be used to define single criteria as per documentation, but API
+			// error is human readable and this might change in future so not enforcing max of 4
+			// rules
+			// MaxItems:    4,
+			Optional: true,
+			Elem:     criteriaRule,
+		},
+	},
+}
+
+var criteriaRule = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"type": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Type of object matching 'VM_TAG' or 'VM_NAME'",
+		},
+		"operator": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Operator can be one of 'EQUALS', 'CONTAINS', 'STARTS_WITH', 'ENDS_WITH'",
+		},
+		"value": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Filter value",
+		},
+	},
+}
+
+func resourceVcdDynamicSecurityGroupCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	vdcGroupId := d.Get("vdc_group_id").(string)
+	vcdClient.lockById(vdcGroupId)
+	defer vcdClient.unlockById(vdcGroupId)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group create] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		return diag.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	securityGroup := getNsxtDynamicSecurityGroupType(d)
+	createdFwGroup, err := vdcGroup.CreateNsxtFirewallGroup(securityGroup)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group create] error creating NSX-T dynamic security group '%s': %s", securityGroup.Name, err)
+	}
+
+	d.SetId(createdFwGroup.NsxtFirewallGroup.ID)
+
+	return resourceVcdDynamicSecurityGroupRead(ctx, d, meta)
+}
+
+func resourceVcdDynamicSecurityGroupUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	vdcGroupId := d.Get("vdc_group_id").(string)
+	vcdClient.lockById(vdcGroupId)
+	defer vcdClient.unlockById(vdcGroupId)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group create] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		return diag.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	updateSecurityGroup := getNsxtDynamicSecurityGroupType(d)
+	securityGroup, err := vdcGroup.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group update] error getting NSX-T dynamic security group: %s", err)
+	}
+
+	// Inject existing ID for update
+	updateSecurityGroup.ID = d.Id()
+
+	_, err = securityGroup.Update(updateSecurityGroup)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group update] error updating NSX-T dynamic security group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	return resourceVcdDynamicSecurityGroupRead(ctx, d, meta)
+}
+
+func resourceVcdDynamicSecurityGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vdcGroupId := d.Get("vdc_group_id").(string)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		return diag.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	securityGroup, err := vdcGroup.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("[nsxt dynamic security group read] error getting NSX-T dynamic security group: %s", err)
+	}
+
+	err = setNsxtDynamicSecurityGroupData(d, securityGroup.NsxtFirewallGroup)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group resource read] error storing NSX-T dynamic security group: %s", err)
+	}
+
+	// A separate GET call is required to get all associated VMs
+	associatedVms, err := securityGroup.GetAssociatedVms()
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group resource read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	err = setNsxtSecurityGroupAssociatedVmsData(d, associatedVms)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group resource read] error getting associated VMs for Security Group '%s': %s", securityGroup.NsxtFirewallGroup.Name, err)
+	}
+
+	return nil
+}
+
+func resourceVcdDynamicSecurityGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+	vdcGroupId := d.Get("vdc_group_id").(string)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group read] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupById(vdcGroupId)
+	if err != nil {
+		return diag.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	securityGroup, err := vdcGroup.GetNsxtFirewallGroupById(d.Id())
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group delete] error getting NSX-T dynamic security group: %s", err)
+	}
+
+	err = securityGroup.Delete()
+	if err != nil {
+		return diag.Errorf("[nsxt dynamic security group resource delete] error deleting NSX-T dynamic security group: %s", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceVcdDynamicSecurityGroupImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 3 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-group-name.security_group_name")
+	}
+	orgName, vdcGroupName, securityGroupName := resourceURI[0], resourceURI[1], resourceURI[2]
+
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return nil, fmt.Errorf("[nsxt dynamic security group read] error retrieving Org: %s", err)
+	}
+
+	vdcGroup, err := org.GetVdcGroupByName(vdcGroupName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving VDC Group: %s", err)
+	}
+
+	securityGroup, err := vdcGroup.GetNsxtFirewallGroupByName(securityGroupName, types.FirewallGroupTypeVmCriteria)
+	if err != nil {
+		return nil, fmt.Errorf("[nsxt dynamic security group read] error getting NSX-T dynamic security group: %s", err)
+	}
+
+	dSet(d, "org", orgName)
+	dSet(d, "vdc_group_id", securityGroup.NsxtFirewallGroup.OwnerRef.ID)
+	d.SetId(securityGroup.NsxtFirewallGroup.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getNsxtDynamicSecurityGroupType(d *schema.ResourceData) *types.NsxtFirewallGroup {
+	fwGroup := &types.NsxtFirewallGroup{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		OwnerRef:    &types.OpenApiReference{ID: d.Get("vdc_group_id").(string)},
+		TypeValue:   types.FirewallGroupTypeVmCriteria,
+	}
+
+	criteriaSet := d.Get("criteria").(*schema.Set)
+	criteriaSlice := make([]types.NsxtFirewallGroupVmCriteria, len(criteriaSet.List()))
+	for criteriaIndex, criteria := range criteriaSet.List() {
+		criteriaMap := criteria.(map[string]interface{})
+
+		// One more level deeper
+		criteriaRuleSet := criteriaMap["rule"].(*schema.Set)
+		criteriaRuleSlice := make([]types.NsxtFirewallGroupVmCriteriaRule, len(criteriaRuleSet.List()))
+		for criteriaRuleIndex, criteriaRule := range criteriaRuleSet.List() {
+			criteriaRuleMap := criteriaRule.(map[string]interface{})
+
+			criteriaRuleSlice[criteriaRuleIndex] = types.NsxtFirewallGroupVmCriteriaRule{
+				AttributeType:  criteriaRuleMap["type"].(string),
+				Operator:       criteriaRuleMap["operator"].(string),
+				AttributeValue: criteriaRuleMap["value"].(string),
+			}
+		}
+		criteriaSlice[criteriaIndex] = types.NsxtFirewallGroupVmCriteria{
+			VmCriteriaRule: criteriaRuleSlice,
+		}
+	}
+
+	fwGroup.VmCriteria = criteriaSlice
+
+	return fwGroup
+}
+
+func setNsxtDynamicSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirewallGroup) error {
+	dSet(d, "name", fw.Name)
+	dSet(d, "description", fw.Description)
+	dSet(d, "vdc_group_id", fw.OwnerRef.ID)
+
+	if len(fw.VmCriteria) > 0 {
+		criteriaSlice := make([]interface{}, len(fw.VmCriteria))
+		for criteriaIndex, criteria := range fw.VmCriteria {
+			criteriaMap := make(map[string]interface{})
+
+			criteriaRuleSlice := make([]interface{}, len(criteria.VmCriteriaRule))
+			for ruleIndex, rule := range criteria.VmCriteriaRule {
+				criteriaRuleMap := make(map[string]interface{})
+				criteriaRuleMap["type"] = rule.AttributeType
+				criteriaRuleMap["operator"] = rule.Operator
+				criteriaRuleMap["value"] = rule.AttributeValue
+
+				criteriaRuleSlice[ruleIndex] = criteriaRuleMap
+			}
+
+			ruleSet := schema.NewSet(schema.HashResource(criteriaRule), criteriaRuleSlice)
+			criteriaMap["rule"] = ruleSet
+
+			criteriaSlice[criteriaIndex] = criteriaMap
+
+		}
+
+		criteriaSet := schema.NewSet(schema.HashResource(criteria), criteriaSlice)
+		err := d.Set("criteria", criteriaSet)
+		if err != nil {
+			return fmt.Errorf("error setting 'criteria' block: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/vcd/resource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group.go
@@ -47,7 +47,7 @@ func resourceVcdDynamicSecurityGroup() *schema.Resource {
 			},
 			"criteria": {
 				Type:        schema.TypeSet,
-				Description: "Up to 3 criteria to be used to define the dynamic security group",
+				Description: "Up to 3 criteria to be used to define the Dynamic Security Group",
 				// Up to 3 criteria can be defined as per current documentation, but API errors are
 				// human readable so not hard-enforcing it as these limits may change in future VCD
 				// versions

--- a/vcd/resource_vcd_nsxt_dynamic_security_group.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group.go
@@ -47,7 +47,7 @@ func resourceVcdDynamicSecurityGroup() *schema.Resource {
 			},
 			"criteria": {
 				Type:        schema.TypeSet,
-				Description: "Up to 3 criteria to be used to define the Dynamic Security Group",
+				Description: "Up to 3 criteria to be used to define the Dynamic Security Group (VCD 10.2, 10.3)",
 				// Up to 3 criteria can be defined as per current documentation, but API errors are
 				// human readable so not hard-enforcing it as these limits may change in future VCD
 				// versions
@@ -69,7 +69,7 @@ var criteria = &schema.Resource{
 	Schema: map[string]*schema.Schema{
 		"rule": {
 			Type:        schema.TypeSet,
-			Description: "Up to 4 rules can be used to define single criteria",
+			Description: "Up to 4 rules can be used to define single criteria (VCD 10.2, 10.3)",
 			// Up to 4 rules can be used to define single criteria as per documentation, but API
 			// error is human readable and this might change in future so not enforcing max of 4
 			// rules
@@ -318,12 +318,10 @@ func setNsxtDynamicSecurityGroupData(d *schema.ResourceData, fw *types.NsxtFirew
 
 				criteriaRuleSlice[ruleIndex] = criteriaRuleMap
 			}
-
 			ruleSet := schema.NewSet(schema.HashResource(criteriaRule), criteriaRuleSlice)
 			criteriaMap["rule"] = ruleSet
 
 			criteriaSlice[criteriaIndex] = criteriaMap
-
 		}
 
 		criteriaSet := schema.NewSet(schema.HashResource(criteria), criteriaSlice)

--- a/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
@@ -599,7 +599,6 @@ resource "vcd_security_tag" "tag2" {
   vm_ids = [vcd_vm.emptyVM.id, vcd_vapp_vm.emptyVM.id]
 }
 
-
 # This group should match single tag and contain 1 VM
 resource "vcd_nsxt_dynamic_security_group" "group1" {
   org          = "{{.Org}}"

--- a/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
@@ -1,0 +1,857 @@
+//go:build network || nsxt || ALL || functional
+// +build network nsxt ALL functional
+
+package vcd
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// TestAccVcdNsxtDynamicSecurityGroupVdcGroupEmpty
+//
+// Dynamic security groups __can only be scoped to VDC Groups__ and a self explanatory error is
+// returned if they are scoped to Edge Gateway in a VDC only:
+//
+// Error: [nsxt dynamic security group create] error creating NSX-T dynamic security group
+// 'test-dynamic-security-group': error creating NSX-T Firewall Group: error in HTTP POST request:
+// BAD_REQUEST - [ 27e7eea1-0f65-4147-93e6-b6ecc7ecc61f ] Firewall Group test-dynamic-security-group
+// cannot have type VM_CRITERIA unless it is scoped to a VDC Group
+func TestAccVcdNsxtDynamicSecurityGroupVdcGroupEmpty(t *testing.T) {
+	preTestChecks(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":         testConfig.VCD.Org,
+		"NsxtVdc":     testConfig.Nsxt.Vdc,
+		"VdcGroup":    testConfig.Nsxt.VdcGroup,
+		"NetworkName": t.Name(),
+		"Tags":        "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil || vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	configText := templateFill(testAccNsxtDynamicSecurityGroupEmpty, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configText1 := templateFill(testAccNsxtDynamicSecurityGroupEmpty2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2 := templateFill(testAccNsxtDynamicSecurityGroupEmpty2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText2)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-dynamic-security-group", types.FirewallGroupTypeVmCriteria),
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeVmCriteria),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "name", "test-dynamic-security-group"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "description", "test-security-group-description"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "member_vms.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "criteria.#", "0"),
+				),
+			},
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "name", "test-dynamic-security-group-changed"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "description", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "member_vms.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "criteria.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_dynamic_security_group.group1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgNsxtVdcGroupObject(testConfig, testConfig.Nsxt.VdcGroup, "test-dynamic-security-group-changed"),
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("data.vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group1", "vcd_nsxt_dynamic_security_group.group1", nil),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtDynamicSecurityGroupPrereqsEmpty = `
+data "vcd_vdc_group" "group1" {
+  org  = "{{.Org}}"
+  name = "{{.VdcGroup}}"
+}
+`
+
+const testAccNsxtDynamicSecurityGroupEmpty = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "test-dynamic-security-group"
+  description = "test-security-group-description"
+}
+`
+
+const testAccNsxtDynamicSecurityGroupEmpty2 = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name            = "test-dynamic-security-group-changed"
+}
+`
+
+const testAccNsxtDynamicSecurityGroupEmpty2DS = testAccNsxtDynamicSecurityGroupEmpty2 + `
+# skip-binary-test: Data Source test
+data "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name            = "test-dynamic-security-group-changed"
+}
+`
+
+// TestAccVcdNsxtDynamicSecurityGroupMaximumCriteria Tests our maximum configuration for the NSX-T
+// dynamic firewall group - 3 criteria each containing 4 rules.
+func TestAccVcdNsxtDynamicSecurityGroupVdcGroupMaximumCriteria(t *testing.T) {
+	preTestChecks(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":      testConfig.VCD.Org,
+		"NsxtVdc":  testConfig.Nsxt.Vdc,
+		"VdcGroup": testConfig.Nsxt.VdcGroup,
+		"EdgeGw":   testConfig.Nsxt.VdcGroupEdgeGateway,
+		"TestName": t.Name(),
+		"Tags":     "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil || vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	configText := templateFill(testAccNsxtDynamicSecurityGroupMaximumCriteria, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step1"
+	configTextDS := templateFill(testAccNsxtDynamicSecurityGroupMaximumCriteriaDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configTextDS)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText1 := templateFill(testAccNsxtDynamicSecurityGroupMaximumCriteria2, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "name", "test-dynamic-security-group"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "description", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "member_vms.#", "0"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "criteria.#", "3"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_TAG",
+						"operator": "EQUALS",
+						"value":    "tag-equals",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_TAG",
+						"operator": "CONTAINS",
+						"value":    "tag-contains",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_TAG",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_TAG",
+						"operator": "ENDS_WITH",
+						"value":    "ends_with",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "CONTAINS",
+						"value":    "name-contains2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with2",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "CONTAINS",
+						"value":    "name-contains22",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with22",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "CONTAINS",
+						"value":    "name-contains3",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with3",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "CONTAINS",
+						"value":    "name-contains33",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with33",
+					}),
+				),
+			},
+			{
+				Config: configTextDS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group1", "vcd_nsxt_dynamic_security_group.group1", nil),
+				),
+			},
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "name", "test-dynamic-security-group-changed"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "description", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "criteria.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "member_vms.#", "0"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "STARTS_WITH",
+						"value":    "starts_with3",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_dynamic_security_group.group1", "criteria.*.rule.*", map[string]string{
+						"type":     "VM_NAME",
+						"operator": "CONTAINS",
+						"value":    "name-contains33",
+					}),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_dynamic_security_group.group1",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgNsxtVdcGroupObject(testConfig, testConfig.Nsxt.VdcGroup, "test-dynamic-security-group-changed"),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccNsxtDynamicSecurityGroupMaximumCriteria = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "test-dynamic-security-group"
+
+  criteria {
+	rule {
+	  type = "VM_TAG"
+	  operator = "EQUALS"
+	  value = "tag-equals"
+	}
+
+	rule {
+	  type = "VM_TAG"
+	  operator = "CONTAINS"
+	  value = "tag-contains"
+	}
+
+	rule {
+	  type = "VM_TAG"
+	  operator = "STARTS_WITH"
+	  value = "starts_with"
+	}
+
+	rule {
+	  type = "VM_TAG"
+	  operator = "ENDS_WITH"
+	  value = "ends_with"
+	}
+  }
+
+  criteria {
+	rule {
+	  type     = "VM_NAME"
+	  operator = "CONTAINS"
+	  value    = "name-contains2"
+	}
+
+	rule {
+	  type     = "VM_NAME"
+	  operator = "STARTS_WITH"
+	  value    = "starts_with2"
+	}
+
+	rule {
+		type     = "VM_NAME"
+		operator = "CONTAINS"
+		value    = "name-contains22"
+	  }
+  
+	rule {
+		type     = "VM_NAME"
+		operator = "STARTS_WITH"
+		value    = "starts_with22"
+	}
+  }
+
+  criteria {
+	rule {
+	  type     = "VM_NAME"
+	  operator = "CONTAINS"
+	  value    = "name-contains3"
+	}
+
+	rule {
+	  type     = "VM_NAME"
+	  operator = "STARTS_WITH"
+	  value    = "starts_with3"
+	}
+
+	rule {
+	  type     = "VM_NAME"
+	  operator = "CONTAINS"
+	  value    = "name-contains33"
+	}
+
+	rule {
+	  type     = "VM_NAME"
+	  operator = "STARTS_WITH"
+	  value    = "starts_with33"
+	}
+  }
+}
+`
+
+const testAccNsxtDynamicSecurityGroupMaximumCriteriaDS = testAccNsxtDynamicSecurityGroupMaximumCriteria + `
+# skip-binary-test: Data Source test
+data "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "test-dynamic-security-group"
+}
+`
+
+const testAccNsxtDynamicSecurityGroupMaximumCriteria2 = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "test-dynamic-security-group-changed"
+
+  criteria {
+	rule {
+	  type     = "VM_NAME"
+	  operator = "CONTAINS"
+	  value    = "name-contains33"
+	}
+
+	rule {
+	  type     = "VM_NAME"
+	  operator = "STARTS_WITH"
+	  value    = "starts_with3"
+	}
+  }
+}
+`
+
+// TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms tests out the dynamic security groups
+// matching existing VMs both - based on Tags and on VM names.
+func TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms(t *testing.T) {
+	preTestChecks(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":      testConfig.VCD.Org,
+		"NsxtVdc":  testConfig.Nsxt.Vdc,
+		"VdcGroup": testConfig.Nsxt.VdcGroup,
+		"EdgeGw":   testConfig.Nsxt.VdcGroupEdgeGateway,
+		"TestName": t.Name(),
+		"Tags":     "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil || vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	configText := templateFill(testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsTags, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2DS := templateFill(testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsTagsDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2DS)
+
+	params["FuncName"] = t.Name() + "-step3"
+	configText3 := templateFill(testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsNames, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	params["FuncName"] = t.Name() + "-step4"
+	configText4DS := templateFill(testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsNamesDS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText4DS)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group", types.FirewallGroupTypeSecurityGroup),
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-security-group-changed", types.FirewallGroupTypeSecurityGroup),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group2", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group3", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group4", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+				),
+			},
+			{
+				// VM membership is not immediately updated sometimes therewore we apply the same step to check that VM counts are updated
+				Config: configText2DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group2", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group3", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group4", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "member_vms.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group2", "member_vms.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group3", "member_vms.#", "2"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group4", "member_vms.#", "1"),
+
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group1", "vcd_nsxt_dynamic_security_group.group1", nil),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group2", "vcd_nsxt_dynamic_security_group.group2", nil),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group3", "vcd_nsxt_dynamic_security_group.group3", nil),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group4", "vcd_nsxt_dynamic_security_group.group4", nil),
+				),
+			},
+			{
+				Config: configText3,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group5", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group6", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					// resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group5", "member_vms.#", "1"),
+					// resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group6", "member_vms.#", "2"),
+				),
+			},
+			{
+				// Apply the same config twice to give time for `member_vms` to be updated
+				Config: configText4DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group5", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group6", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group5", "member_vms.#", "1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group6", "member_vms.#", "2"),
+
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group5", "vcd_nsxt_dynamic_security_group.group5", nil),
+					resourceFieldsEqual("data.vcd_nsxt_dynamic_security_group.group6", "vcd_nsxt_dynamic_security_group.group6", nil),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsPrereqs = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_network_isolated_v2" "nsxt-backed" {
+  org = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.group1.id
+
+  name        = "{{.TestName}}-network"
+  description = "Isolated network for dynamic security group membership tests"
+
+  gateway       = "1.1.1.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "1.1.1.10"
+    end_address   = "1.1.1.40"
+  }
+}
+
+resource "vcd_vm" "emptyVM" {
+  org = "{{.Org}}"
+  vdc = tolist(data.vcd_vdc_group.group1.participating_org_vdcs)[0].vdc_name
+
+  name             = "{{.TestName}}-standalone"
+  computer_name    = "emptyVM"
+  power_on         = false
+  memory           = 512
+  cpus             = 1
+  cpu_cores        = 1
+  os_type          = "sles10_64Guest"
+  hardware_version = "vmx-14"
+
+  network {
+    type               = "org"
+    name               = vcd_network_isolated_v2.nsxt-backed.name
+    ip_allocation_mode = "POOL"
+    is_primary         = true
+  }
+}
+
+resource "vcd_vapp" "web" {
+  org  = "{{.Org}}"
+  vdc  = tolist(data.vcd_vdc_group.group1.participating_org_vdcs)[0].vdc_name
+  name = "{{.TestName}}-vapp"
+}
+
+resource "vcd_vapp_org_network" "vappOrgNet" {
+  org  = "{{.Org}}"
+  vdc  = tolist(data.vcd_vdc_group.group1.participating_org_vdcs)[0].vdc_name
+
+  vapp_name        = vcd_vapp.web.name
+  org_network_name = vcd_network_isolated_v2.nsxt-backed.name
+}
+
+resource "vcd_vapp_vm" "emptyVM" {
+  org  = "{{.Org}}"
+  vdc  = tolist(data.vcd_vdc_group.group1.participating_org_vdcs)[0].vdc_name
+
+  vapp_name        = vcd_vapp.web.name
+  name             = "{{.TestName}}-vapp-vm"
+  computer_name    = "emptyVM"
+  power_on         = false
+  memory           = 512
+  cpus             = 1
+  cpu_cores        = 1
+  os_type          = "sles10_64Guest"
+  hardware_version = "vmx-14"
+
+  network {
+    type               = "org"
+    name               = vcd_vapp_org_network.vappOrgNet.org_network_name
+    ip_allocation_mode = "POOL"
+    is_primary         = true
+  }
+}
+`
+
+const testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsTags = testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsPrereqs + `
+resource "vcd_security_tag" "tag1" {
+  org    = "{{.Org}}"
+  name   = "tag1"
+  vm_ids = [vcd_vm.emptyVM.id]
+}
+
+resource "vcd_security_tag" "tag2" {
+  org    = "{{.Org}}"
+  name   = "tag2"
+  vm_ids = [vcd_vm.emptyVM.id, vcd_vapp_vm.emptyVM.id]
+}
+
+
+# This group should match single tag and contain 1 VM
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group1"
+
+  criteria {
+	rule {
+	  type     = "VM_TAG"
+	  operator = "EQUALS"
+	  value    = vcd_security_tag.tag1.name
+	}
+  }
+}
+
+# This group should match both tags and contain 2 VMs
+resource "vcd_nsxt_dynamic_security_group" "group2" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group2"
+
+  criteria {
+    rule {
+      type     = "VM_TAG"
+      operator = "CONTAINS"
+      value    = "ag"
+	}
+  }
+}
+
+# This group should match tag1, tag2 and contain 2 VMs
+resource "vcd_nsxt_dynamic_security_group" "group3" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group3"
+
+  criteria {
+    rule {
+      type     = "VM_TAG"
+      operator = "STARTS_WITH"
+      value    = "t"
+	}
+  }
+}
+
+# This group should match only tag1 and contain 1 VMs
+resource "vcd_nsxt_dynamic_security_group" "group4" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group4"
+
+  criteria {
+    rule {
+      type     = "VM_TAG"
+      operator = "ENDS_WITH"
+      value    = "1"
+	}
+  }
+}
+`
+
+const testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsTagsDS = testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsTags + `
+# skip-binary-test: Data Source test
+data "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group1"
+}
+
+data "vcd_nsxt_dynamic_security_group" "group2" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group2"
+}
+
+data "vcd_nsxt_dynamic_security_group" "group3" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group3"
+}
+
+data "vcd_nsxt_dynamic_security_group" "group4" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group4"
+}
+`
+
+const testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsNames = testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsPrereqs + `
+# This group should match 1 VM
+resource "vcd_nsxt_dynamic_security_group" "group5" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group5"
+
+  criteria {
+	rule {
+	  type     = "VM_NAME"
+	  operator = "CONTAINS"
+	  value    = "standalone"
+	}
+  }
+}
+
+# This group should match 2 VMs
+resource "vcd_nsxt_dynamic_security_group" "group6" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group6"
+
+  criteria {
+    rule {
+      type     = "VM_NAME"
+      operator = "STARTS_WITH"
+      value    = "{{.TestName}}"
+	}
+  }
+}
+`
+
+const testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsNamesDS = testAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVmsNames + `
+# skip-binary-test: Data Source test
+# This group should match 1 VM
+data "vcd_nsxt_dynamic_security_group" "group5" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group5"
+}
+
+data "vcd_nsxt_dynamic_security_group" "group6" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group6"
+}
+`
+
+// TestAccVcdNsxtDynamicSecurityGroupIntegartion tests out how Dynamic security groups integrate
+// with firewalls - both - distributed and simple ones.
+//
+// Note. Dynamic security groups can only be created when an NSX-T Edge Gateway is a member of VDC
+// Group, but when it is - Dynamic Security Groups can be used in regular Edge Gateway firewalls.
+func TestAccVcdNsxtDynamicSecurityGroupIntegration(t *testing.T) {
+	preTestChecks(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":      testConfig.VCD.Org,
+		"NsxtVdc":  testConfig.Nsxt.Vdc,
+		"VdcGroup": testConfig.Nsxt.VdcGroup,
+		"EdgeGw":   testConfig.Nsxt.VdcGroupEdgeGateway,
+		"TestName": t.Name(),
+		"Tags":     "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil || vcdClient.Client.APIVCDMaxVersionIs("< 36.0") {
+		t.Skip(t.Name() + " requires at least API v36.0 (VCD 10.3+)")
+	}
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	configText := templateFill(testAccVcdNsxtDynamicSecurityGroupIntegration, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtFirewallGroupDestroy(testConfig.Nsxt.Vdc, "test-dynamic-security-group", types.FirewallGroupTypeVmCriteria),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
+					resource.TestCheckResourceAttr("vcd_nsxt_dynamic_security_group.group1", "name", "TestAccVcdNsxtDynamicSecurityGroupIntegration-group1"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdNsxtDynamicSecurityGroupIntegration = testAccNsxtDynamicSecurityGroupPrereqsEmpty + `
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "{{.Org}}"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "{{.TestName}}-group1"
+  criteria {
+	rule {
+		type     = "VM_NAME"
+		operator = "STARTS_WITH"
+		value    = "{{.TestName}}"
+	}
+  }
+}
+
+resource "vcd_nsxt_distributed_firewall" "t1" {
+	org          = "{{.Org}}"
+	vdc_group_id = data.vcd_vdc_group.group1.id
+  
+	rule {
+	  name        = "rule1"
+	  action      = "REJECT"
+	  description = "description"
+	  comment     = "longer text comment field filled"
+  
+	  source_ids = [vcd_nsxt_dynamic_security_group.group1.id]
+	}
+  
+	rule {
+	  name        = "rule3"
+	  action      = "DROP"
+	  ip_protocol = "IPV4"
+	}
+}
+
+data "vcd_nsxt_edgegateway" "edgegw" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.group1.id
+  name     = "{{.EdgeGw}}"
+}
+
+resource "vcd_nsxt_firewall" "testing" {
+  org = "{{.Org}}"
+  vdc = "{{.NsxtVdc}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.edgegw.id
+
+  rule {
+    action      = "ALLOW"
+    name        = "test_rule"
+    direction   = "IN"
+    ip_protocol = "IPV4"
+    source_ids  = [vcd_nsxt_dynamic_security_group.group1.id]
+    enabled     = true
+  }
+}
+`

--- a/website/docs/d/nsxt_dynamic_security_group.html.markdown
+++ b/website/docs/d/nsxt_dynamic_security_group.html.markdown
@@ -3,18 +3,18 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_dynamic_security_group"
 sidebar_current: "docs-vcd-data-source-nsxt-dynamic-security-group"
 description: |-
-  Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
-  machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
-  applies.
+  Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group Virtual
+  Machines based on specific criteria (VM Names or Security tags) to which Distributed Firewall Rules
+  apply.
 ---
 
 # vcd\_nsxt\_dynamic\_security\_group
 
 Supported in provider *v3.7+* and VCD 10.3+ with NSX-T backed VDC Groups.
 
-Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
-machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
-applies.
+Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group Virtual
+Machines based on specific criteria (VM Names or Security tags) to which Distributed Firewall Rules
+apply.
 
 ## Example Usage 1 (Existing Dynamic Security Group lookup)
 

--- a/website/docs/d/nsxt_dynamic_security_group.html.markdown
+++ b/website/docs/d/nsxt_dynamic_security_group.html.markdown
@@ -1,0 +1,45 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_dynamic_security_group"
+sidebar_current: "docs-vcd-data-source-nsxt-dynamic-security-group"
+description: |-
+  Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
+  machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
+  applies.
+---
+
+# vcd\_nsxt\_dynamic\_security\_group
+
+Supported in provider *v3.7+* and VCD 10.3+ with NSX-T backed VDC Groups.
+
+Provides a data source to read NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
+machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
+applies.
+
+## Example Usage 1 (Existing Dynamic Security Group lookup)
+
+```hcl
+data "vcd_vdc_group" "group1" {
+  org  = "cloud"
+  name = "vdc-group-cloud"
+}
+
+data "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "cloud"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "cloud-dynamic-security-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc_group_id` - (Required) VDC Group ID hosting existing Dynamic Security Group.
+* `name` - (Required) A unique name for existing Dynamic Security Group
+
+All the arguments and attributes defined in
+[`vcd_nsxt_dynamic_security_group`](/providers/vmware/vcd/latest/docs/resources/nsxt_dynamic_security_group) resource are available.

--- a/website/docs/r/nsxt_dynamic_security_group.html.markdown
+++ b/website/docs/r/nsxt_dynamic_security_group.html.markdown
@@ -177,10 +177,6 @@ Each member VM contains following attributes:
 * `vapp_id` - Parent vApp ID for member VM (empty for standalone VMs)
 * `vapp_name` - Parent vApp Name for member VM (empty for standalone VMs)
 
-~> There may be cases where Org Networks and Security Groups are already created, but
-not all VMs are already created and not shown in this structure. Additional `depends_on` can ensure
-that Dynamic Security Group is created only after all networks and VMs are there.
-
 ## Importing
 
 ~> The current implementation of Terraform import can only import resources into the state.

--- a/website/docs/r/nsxt_dynamic_security_group.html.markdown
+++ b/website/docs/r/nsxt_dynamic_security_group.html.markdown
@@ -3,21 +3,21 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_dynamic_security_group"
 sidebar_current: "docs-vcd-resource-nsxt-dynamic-security-group"
 description: |-
-  Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
-  machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
-  applies.
+  Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group Virtual
+  Machines based on specific criteria (VM Names or Security tags) to which Distributed Firewall Rules
+  apply.
 ---
 
 # vcd\_nsxt\_dynamic\_security\_group
 
 Supported in provider *v3.7+* and VCD 10.3+ with NSX-T backed VDC Groups.
 
-Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
-machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
-applies.
+Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group Virtual
+Machines based on specific criteria (VM Names or Security tags) to which Distributed Firewall Rules
+apply.
 
 -> Dynamic Security Groups can be used in both - Edge Gateway Firewall Rules (`vcd_nsxt_firewall`)
-and Distributed firewall rules (`vcd_nsxt_distributed_firewall`), however **it only works when Edge
+and Distributed Firewall Rules (`vcd_nsxt_distributed_firewall`), however **it only works when Edge
 Gateway belongs to a VDC Group**.
 
 ## Example Usage 1 (Dynamic Security Group with 3 criteria and 4 rules in each criteria)

--- a/website/docs/r/nsxt_dynamic_security_group.html.markdown
+++ b/website/docs/r/nsxt_dynamic_security_group.html.markdown
@@ -1,0 +1,200 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_dynamic_security_group"
+sidebar_current: "docs-vcd-resource-nsxt-dynamic-security-group"
+description: |-
+  Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
+  machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
+  applies.
+---
+
+# vcd\_nsxt\_dynamic\_security\_group
+
+Supported in provider *v3.7+* and VCD 10.3+ with NSX-T backed VDC Groups.
+
+Provides a resource to manage NSX-T Dynamic Security Groups. Dynamic Security Groups group virtual
+machines based on specific criteria (VM Names or Security tags) to which distributed firewall rules
+applies.
+
+-> Dynamic Security Groups can be used in both - Edge Gateway Firewall Rules (`vcd_nsxt_firewall`)
+and Distributed firewall rules (`vcd_nsxt_distributed_firewall`), however **it only works when Edge
+Gateway belongs to a VDC Group**.
+
+## Example Usage 1 (Dynamic Security Group with 3 criteria and 4 rules in each criteria)
+
+```hcl
+data "vcd_vdc_group" "group1" {
+  org  = "cloud"
+  name = "vdc-group-cloud"
+}
+
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "cloud"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "dynamic-security-group-example"
+
+  criteria { # Boolean "OR"
+    rule {   # Boolean "AND"
+      type     = "VM_TAG"
+      operator = "EQUALS"
+      value    = "tag-equals"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_TAG"
+      operator = "CONTAINS"
+      value    = "tag-contains"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_TAG"
+      operator = "STARTS_WITH"
+      value    = "tag-starts-with"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_TAG"
+      operator = "ENDS_WITH"
+      value    = "tag-ends-with"
+    }
+  }
+
+  criteria { # Boolean "OR" evaluation
+    rule {   # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "CONTAINS"
+      value    = "name-contains-4"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "STARTS_WITH"
+      value    = "starts_with2"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "CONTAINS"
+      value    = "name-contains-22"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "STARTS_WITH"
+      value    = "starts_with22"
+    }
+  }
+
+  criteria { # Boolean "OR" evaluation
+    rule {   # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "CONTAINS"
+      value    = "name-contains3"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "STARTS_WITH"
+      value    = "starts_with3"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "CONTAINS"
+      value    = "name-contains33"
+    }
+
+    rule { # Boolean "AND"
+      type     = "VM_NAME"
+      operator = "STARTS_WITH"
+      value    = "starts_with33"
+    }
+  }
+}
+```
+
+## Example Usage 2 (Empty Dynamic Security Group)
+```hcl
+data "vcd_vdc_group" "group1" {
+  org  = "cloud"
+  name = "vdc-group-cloud"
+}
+
+resource "vcd_nsxt_dynamic_security_group" "group1" {
+  org          = "cloud"
+  vdc_group_id = data.vcd_vdc_group.group1.id
+
+  name = "empty-dynamic-security-group"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `vdc_group_id` - (Required) VDC Group ID for Dynamic Security Group creation.
+* `name` - (Required) A unique name for Dynamic Security Group
+* `description` - (Optional) An optional description of the Dynamic Security Group
+* `criteria` (Optional) Up to 3 criteria for matching VMs. List of criteria is matched with boolean
+  `OR` operation and matching any of defined criteria will include objects. Each `criteria` can
+  contains up to 4 `rule` definitions.
+* `rule` (Optional) Up to 4 rules for matching VMs. List of rules are matched with boolean `AND`
+  operation and all defines rules must match to include object. See [Rule](#rule) for rule
+  definition structure.
+
+
+<a id="rule"></a>
+## Rule
+
+Each member Rule contains following attributes:
+
+* `type` - (Required) `VM_NAME` or `VM_TAG`
+* `value` - (Required) String to evaluate by given `type` and `operator`
+* `operator` - (Required) Supported operators depend on `type`. `VM_TAG` supports 4 operator types
+  with self explanatory names:
+ * `CONTAINS`
+ * `STARTS_WITH`
+ * `EQUALS`
+ * `ENDS_WITH`
+
+`VM_NAME` supports two operator types:
+ * `STARTS_WITH`
+ * `CONTAINS`
+
+## Attribute Reference
+* `member_vms` A set of member VMs (if exist). see [Member VMs](#member-vms) below for details.
+
+<a id="member-vms"></a>
+## Member VMs
+
+Each member VM contains following attributes:
+
+* `vm_id` - Member VM ID
+* `vm_name` - Member VM name
+* `vapp_id` - Parent vApp ID for member VM (empty for standalone VMs)
+* `vapp_name` - Parent vApp Name for member VM (empty for standalone VMs)
+
+~> There may be cases where Org Networks and Security Groups are already created, but
+not all VMs are already created and not shown in this structure. Additional `depends_on` can ensure
+that Dynamic Security Group is created only after all networks and VMs are there.
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing Security Group configuration can be [imported][docs-import] into this resource
+via supplying the full dot separated path for your Security Group name. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_dynamic_security_group.imported my-org.my-vdc-group.my-security-group-name
+```
+
+The above would import the `my-security-group-name` Dynamic Security Group config settings that are
+defined in VDC Group `my-vdc-group` which is configured in organization named `my-org`.

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -238,6 +238,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-network-context-profile") %>>
               <a href="/docs/providers/vcd/d/nsxt_network_context_profile.html">vcd_nsxt_network_context_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-nsxt-dynamic-security-group") %>>
+              <a href="/docs/providers/vcd/d/nsxt_network_context_profile.html">vcd_nsxt_dynamic_security_group</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -431,6 +434,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-distributed-firewall") %>>
               <a href="/docs/providers/vcd/r/nsxt_distributed_firewall.html">vcd_nsxt_distributed_firewall</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-dynamic-security-group") %>>
+              <a href="/docs/providers/vcd/r/nsxt_dynamic_security_group.html">vcd_nsxt_dynamic_security_group</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Closes #459, #787

Starting with VCD 10.3 there is a concept called Dynamic Security Groups which allows users to define dynamic rules (based on names and tags) for firewall group membership.

This PR introduces `vcd_nsxt_dynamic_security_group` resource and data source. 
**Note.** Dynamic Security Groups require VCD 10.3+ and an NSX-T VDC Group. Meeting these prerequisites allow to create these groups and consume them in both Edge Gateway firewalls (provided Edge Gateway is a member of VDC Group) and Distributed firewalls.

**Note2.** As opposed to IP Sets and Static Security Groups, Dynamic security groups __can only be scoped to VDC Groups__ and a self-explanatory error is returned if they are scoped to Edge Gateway in a VDC only:
```
Error: [nsxt dynamic security group create] error creating NSX-T dynamic security group
'test-dynamic-security-group': error creating NSX-T Firewall Group: error in HTTP POST request:
BAD_REQUEST - [ 27e7eea1-0f65-4147-93e6-b6ecc7ecc61f ] Firewall Group test-dynamic-security-group
cannot have type VM_CRITERIA unless it is scoped to a VDC Group
```

This is the reason a field is called `vdc_group_id` instead of `owner_id` where we use it to accept different objects.

More about Dynamic Security Groups in VCD official docs and VMware Blog post:
* https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-CF7FCFE1-7B1C-45CE-B8A0-774E9CD31DB5.html
* https://blogs.vmware.com/cloudprovider/2021/08/vmware-cloud-director-10-3-new-networking-security-features.html
