### PR TITLE
Add resource and data source to manage BGP IP Prefix Lists

### DIFF
--- a/.changes/v3.7.0/879-features.md
+++ b/.changes/v3.7.0/879-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_nsxt_edgegateway_bgp_ip_prefix_list` allows users to configure NSX-T Edge Gateway BGP IP Prefix Lists [GH-879]
+* **New Data Source:** `vcd_nsxt_edgegateway_bgp_ip_prefix_list` allows users to read NSX-T Edge Gateway BGP IP Prefix Lists [GH-879]

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff
 
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.11
+	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.13
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278 h1:NVh0l5ydPHFNTipX3Yx5PQEUTlVOS79ePux4SGGpu5k=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -224,8 +226,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9 h1:i8OqjVqUoYuPcu/TByXxkxGg02xsX7X7lJlcjrl9y9o=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff h1:RD0ZGdtuIQP0jBaei73Bf+C04+z/Gy8qVvG7SmjuKXM=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -226,6 +224,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.13 h1:pE/d4155tVLgguAg8Kp1wQtTLcK9/Y5/2BTArefNt5Y=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.13/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278 h1:NVh0l5ydPHFNTipX3Yx5PQEUTlVOS79ePux4SGGpu5k=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220705093021-7f13ca6b8278/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff h1:RD0ZGdtuIQP0jBaei73Bf+C04+z/Gy8qVvG7SmjuKXM=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727081454-82fc9a59bbff/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/vcd/datasource_vcd_nsxt_edgegateway_bgp_prefix_list.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_bgp_prefix_list.go
@@ -1,0 +1,93 @@
+package vcd
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdEdgeBgpIpPrefixList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdEdgeBgpIpPrefixListRead,
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway ID for BGP IP Prefix List Configuration",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "BGP IP Prefix List name",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "BGP IP Prefix List description",
+			},
+			"ip_prefix": {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "BGP IP Prefix List entry",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Network in CIDR notation (e.g. '192.168.100.0/24', '2001:db8::/48')",
+						},
+						"action": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Action 'PERMIT' or 'DENY'",
+						},
+						"greater_than_or_equal_to": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Greater than or equal to (ge) subnet mask",
+						},
+						"less_than_or_equal_to": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Less than or equal to (le) subnet mask",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceVcdEdgeBgpIpPrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	bgpIpPrefixList, err := nsxtEdge.GetBgpIpPrefixListByName(d.Get("name").(string))
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	err = setEdgeBgpIpPrefixListData(d, bgpIpPrefixList.EdgeBgpIpPrefixList)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error storing entity into schema: %s", err)
+	}
+
+	d.SetId(bgpIpPrefixList.EdgeBgpIpPrefixList.ID)
+
+	return nil
+}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -96,6 +96,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_distributed_firewall":                 datasourceVcdNsxtDistributedFirewall(),          // 3.6
 	"vcd_nsxt_network_context_profile":              datasourceVcdNsxtNetworkContextProfile(),        // 3.6
 	"vcd_nsxt_route_advertisement":                  datasourceVcdNsxtRouteAdvertisement(),           // 3.7
+	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       datasourceVcdEdgeBgpIpPrefixList(),              // 3.7
 
 }
 
@@ -166,6 +167,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_security_tag":                              resourceVcdSecurityTag(),                      // 3.7
 	"vcd_nsxt_route_advertisement":                  resourceVcdNsxtRouteAdvertisement(),           // 3.7
 	"vcd_org_vdc_access_control":                    resourceVcdOrgVdcAccessControl(),              // 3.7
+	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       resourceVcdEdgeBgpIpPrefixList(),              // 3.7
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -98,8 +98,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_edgegateway_bgp_configuration":        datasourceVcdEdgeBgpConfig(),                    // 3.7
 	"vcd_nsxt_route_advertisement":                  datasourceVcdNsxtRouteAdvertisement(),           // 3.7
 	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       datasourceVcdEdgeBgpIpPrefixList(),              // 3.7
-
-	"vcd_nsxt_dynamic_security_group": datasourceVcdDynamicSecurityGroup(), // 3.7
+	"vcd_nsxt_dynamic_security_group":               datasourceVcdDynamicSecurityGroup(),             // 3.7
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list.go
@@ -282,7 +282,6 @@ func getEdgeBgpIpPrefixListType(d *schema.ResourceData) *types.EdgeBgpIpPrefixLi
 	ipPrefixSlice := make([]types.EdgeBgpConfigPrefixListPrefixes, len(ipPrefixSet.List()))
 	for prefixIndex, prefix := range ipPrefixSet.List() {
 		ipPrefixMap := prefix.(map[string]interface{})
-
 		ipPrefixSlice[prefixIndex] = types.EdgeBgpConfigPrefixListPrefixes{
 			Network:            ipPrefixMap["network"].(string),
 			Action:             ipPrefixMap["action"].(string),
@@ -290,7 +289,6 @@ func getEdgeBgpIpPrefixListType(d *schema.ResourceData) *types.EdgeBgpIpPrefixLi
 			LessThanEqualTo:    ipPrefixMap["less_than_or_equal_to"].(int),
 		}
 	}
-
 	bgpConfig.Prefixes = ipPrefixSlice
 
 	return bgpConfig
@@ -302,9 +300,7 @@ func setEdgeBgpIpPrefixListData(d *schema.ResourceData, bgpConfig *types.EdgeBgp
 
 	if len(bgpConfig.Prefixes) > 0 {
 		ipPrefixSlice := make([]interface{}, len(bgpConfig.Prefixes))
-
 		for prefixIndex, prefix := range bgpConfig.Prefixes {
-
 			ipPrefixMap := make(map[string]interface{})
 			ipPrefixMap["network"] = prefix.Network
 			ipPrefixMap["action"] = prefix.Action

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list.go
@@ -1,0 +1,325 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func resourceVcdEdgeBgpIpPrefixList() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdEdgeBgpIpPrefixListCreate,
+		ReadContext:   resourceVcdEdgeBgpIpPrefixListRead,
+		UpdateContext: resourceVcdEdgeBgpIpPrefixListUpdate,
+		DeleteContext: resourceVcdEdgeBgpIpPrefixListDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdEdgeBgpIpPrefixListImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway ID for BGP IP Prefix List Configuration",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "BGP IP Prefix List name",
+			},
+			"description": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "BGP IP Prefix List description",
+			},
+			"ip_prefix": {
+				Type:     schema.TypeSet,
+				Required: true,
+				// Cannot create empty container without any IP prefixes
+				MinItems:    1,
+				Description: "BGP IP Prefix List entry",
+				Elem:        edgeBgpIpPrefixListHash,
+			},
+		},
+	}
+}
+
+var edgeBgpIpPrefixListHash = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		"network": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Network in CIDR notation (e.g. '192.168.100.0/24', '2001:db8::/48')",
+		},
+		"action": {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "Action 'PERMIT' or 'DENY'",
+			// API error is not friendly (complains that field is not specified at all) therefore
+			// enforcing validation
+			ValidateFunc: validation.StringInSlice([]string{"PERMIT", "DENY"}, false),
+		},
+		"greater_than_or_equal_to": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Greater than or equal to subnet mask",
+		},
+		"less_than_or_equal_to": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Less than or equal to subnet mask",
+		},
+	},
+}
+
+func resourceVcdEdgeBgpIpPrefixListCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list create] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list create] error retrieving Edge Gateway: %s", err)
+	}
+
+	bgpIpPrefixList := getEdgeBgpIpPrefixListType(d)
+
+	createdBgpIpPrefixList, err := nsxtEdge.CreateBgpIpPrefixList(bgpIpPrefixList)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list create] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	d.SetId(createdBgpIpPrefixList.EdgeBgpIpPrefixList.ID)
+
+	return resourceVcdEdgeBgpIpPrefixListRead(ctx, d, meta)
+}
+
+func resourceVcdEdgeBgpIpPrefixListUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp configuration update] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list update] error retrieving Edge Gateway: %s", err)
+	}
+
+	bgpIpPrefixList, err := nsxtEdge.GetBgpIpPrefixListById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list update] error retrieving NSX-T Edge Gateway BGP IP Prefix Lis: %s", err)
+	}
+
+	bgpIpPrefixList.EdgeBgpIpPrefixList = getEdgeBgpIpPrefixListType(d)
+	bgpIpPrefixList.EdgeBgpIpPrefixList.ID = d.Id()
+
+	_, err = bgpIpPrefixList.Update(bgpIpPrefixList.EdgeBgpIpPrefixList)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list update] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	return resourceVcdEdgeBgpIpPrefixListRead(ctx, d, meta)
+}
+
+func resourceVcdEdgeBgpIpPrefixListRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	bgpIpPrefixList, err := nsxtEdge.GetBgpIpPrefixListById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	err = setEdgeBgpIpPrefixListData(d, bgpIpPrefixList.EdgeBgpIpPrefixList)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error storing entity into schema: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdEdgeBgpIpPrefixListDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list delete] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list delete] error retrieving NSX-T Edge Gateway: %s", err)
+	}
+
+	bgpIpPrefixList, err := nsxtEdge.GetBgpIpPrefixListById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list delete] error retrieving NSX-T Edge Gateway BGP Configuration: %s", err)
+	}
+
+	err = bgpIpPrefixList.Delete()
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list delete] error deleting NSX-T Edge Gateway BGP Configuration: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdEdgeBgpIpPrefixListImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 4 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-or-vdc-group-name.edge_gateway_name.bgp_prefix_list_name")
+	}
+	orgName, vdcOrVdcGroupName, edgeGatewayName, bgpIpPrefixListName := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
+
+	vcdClient := meta.(*VCDClient)
+	vdcOrVdcGroup, err := lookupVdcOrVdcGroup(vcdClient, orgName, vdcOrVdcGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	edgeGateway, err := vdcOrVdcGroup.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if err != nil {
+		return nil, fmt.Errorf("[bgp ip prefix list import] unable to find Edge Gateway '%s': %s", edgeGatewayName, err)
+	}
+
+	bgpPrefixList, err := edgeGateway.GetBgpIpPrefixListByName(bgpIpPrefixListName)
+	if err != nil {
+		return nil, fmt.Errorf("[bgp ip prefix list import] unable to find BGP IP Prefix List with Name '%s': %s", bgpIpPrefixListName, err)
+	}
+
+	dSet(d, "org", orgName)
+	dSet(d, "edge_gateway_id", edgeGateway.EdgeGateway.ID)
+	d.SetId(bgpPrefixList.EdgeBgpIpPrefixList.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getEdgeBgpIpPrefixListType(d *schema.ResourceData) *types.EdgeBgpIpPrefixList {
+	bgpConfig := &types.EdgeBgpIpPrefixList{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	}
+
+	ipPrefixSet := d.Get("ip_prefix").(*schema.Set)
+	ipPrefixSlice := make([]types.EdgeBgpConfigPrefixListPrefixes, len(ipPrefixSet.List()))
+	for prefixIndex, prefix := range ipPrefixSet.List() {
+		ipPrefixMap := prefix.(map[string]interface{})
+
+		ipPrefixSlice[prefixIndex] = types.EdgeBgpConfigPrefixListPrefixes{
+			Network:            ipPrefixMap["network"].(string),
+			Action:             ipPrefixMap["action"].(string),
+			GreaterThanEqualTo: ipPrefixMap["greater_than_or_equal_to"].(int),
+			LessThanEqualTo:    ipPrefixMap["less_than_or_equal_to"].(int),
+		}
+	}
+
+	bgpConfig.Prefixes = ipPrefixSlice
+
+	return bgpConfig
+}
+
+func setEdgeBgpIpPrefixListData(d *schema.ResourceData, bgpConfig *types.EdgeBgpIpPrefixList) error {
+	dSet(d, "name", bgpConfig.Name)
+	dSet(d, "description", bgpConfig.Description)
+
+	if len(bgpConfig.Prefixes) > 0 {
+		ipPrefixSlice := make([]interface{}, len(bgpConfig.Prefixes))
+
+		for prefixIndex, prefix := range bgpConfig.Prefixes {
+
+			ipPrefixMap := make(map[string]interface{})
+			ipPrefixMap["network"] = prefix.Network
+			ipPrefixMap["action"] = prefix.Action
+			ipPrefixMap["greater_than_or_equal_to"] = prefix.GreaterThanEqualTo
+			ipPrefixMap["less_than_or_equal_to"] = prefix.LessThanEqualTo
+
+			ipPrefixSlice[prefixIndex] = ipPrefixMap
+		}
+
+		ipPrefixSet := schema.NewSet(schema.HashResource(edgeBgpIpPrefixListHash), ipPrefixSlice)
+		err := d.Set("ip_prefix", ipPrefixSet)
+		if err != nil {
+			return fmt.Errorf("error setting 'ip_prefix' block: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list_test.go
@@ -1,0 +1,228 @@
+//go:build gateway || network || nsxt || ALL || functional
+// +build gateway network nsxt ALL functional
+
+package vcd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdNsxtEdgeBgpIpPrefixListVdcGroup(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"NsxtVdcGroup":         testConfig.Nsxt.VdcGroup,
+		"NsxtEdgeGwInVdcGroup": testConfig.Nsxt.VdcGroupEdgeGateway,
+		"TestName":             t.Name(),
+
+		"Tags": "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	// First step of test is going to alter some settings but not enable BGP because changing some of the fields
+	configText1 := templateFill(testAccVcdNsxtBgpIpPrefixVdcGroupConfig1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["SkipTest"] = "# skip-binary-test: datasource test will fail when run together with resource"
+	params["FuncName"] = t.Name() + "-step2"
+	configText2DS := templateFill(testAccVcdNsxtBgpIpPrefixVdcGroupConfig2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2DS)
+
+	delete(params, "SkipTest")
+	params["FuncName"] = t.Name() + "-step3"
+	configText3 := templateFill(testAccVcdNsxtBgpIpPrefixVdcGroupConfig3, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	params["SkipTest"] = "# skip-binary-test: datasource test will fail when run together with resource"
+	params["FuncName"] = t.Name() + "-step4"
+	configText4DS := templateFill(testAccVcdNsxtBgpIpPrefixVdcGroupConfig4DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText4DS)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "name", t.Name()),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "description", "description"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.#", "5"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network": "10.10.10.0/24",
+							"action":  "PERMIT",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network": "20.10.10.0/24",
+							"action":  "DENY",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network": "2001:db8::/48",
+							"action":  "DENY",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network":                  "30.10.10.0/24",
+							"action":                   "DENY",
+							"greater_than_or_equal_to": "25",
+							"less_than_or_equal_to":    "27",
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network":                  "40.0.0.0/8",
+							"action":                   "PERMIT",
+							"greater_than_or_equal_to": "16",
+							"less_than_or_equal_to":    "24",
+						},
+					),
+				),
+			},
+			{
+				Config: configText2DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", nil),
+				),
+			},
+			{
+				Config: configText3,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "name", t.Name()+"-updated"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "description", ""),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.#", "1"),
+					resource.TestCheckTypeSetElemNestedAttrs("vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "ip_prefix.*",
+						map[string]string{
+							"network":                  "30.10.10.0/24",
+							"action":                   "DENY",
+							"greater_than_or_equal_to": "25",
+							"less_than_or_equal_to":    "27",
+						},
+					),
+				),
+			},
+			{
+				Config: configText4DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", "vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing", nil),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObjectUsingVdcGroup(testConfig.Nsxt.VdcGroup, testConfig.Nsxt.VdcGroupEdgeGateway, t.Name()+"-updated"),
+			},
+		},
+	})
+}
+
+const testAccVcdNsxtBgpIpPrefixConfigVdcGroupPrereqs = `
+data "vcd_vdc_group" "g1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdcGroup}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.g1.id
+
+  name = "{{.NsxtEdgeGwInVdcGroup}}"
+}
+`
+
+const testAccVcdNsxtBgpIpPrefixVdcGroupConfig1 = testAccVcdNsxtBgpIpPrefixConfigVdcGroupPrereqs + `
+resource "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name        = "{{.TestName}}"
+  description = "description"
+
+  ip_prefix {
+	network = "10.10.10.0/24"
+	action  = "PERMIT"
+  }
+
+  ip_prefix {
+	network = "20.10.10.0/24"
+	action  = "DENY"
+  }
+
+  ip_prefix {
+	network = "2001:db8::/48"
+	action  = "DENY"
+  }
+
+  ip_prefix {
+	network                  = "30.10.10.0/24"
+	action                   = "DENY"
+	greater_than_or_equal_to = "25"
+	less_than_or_equal_to    = "27"
+  }
+
+  ip_prefix {
+	network                  = "40.0.0.0/8"
+	action                   = "PERMIT"
+	greater_than_or_equal_to = "16"
+	less_than_or_equal_to    = "24"
+  }
+}
+`
+
+const testAccVcdNsxtBgpIpPrefixVdcGroupConfig2DS = testAccVcdNsxtBgpIpPrefixVdcGroupConfig1 + `
+data "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org = "{{.Org}}"
+  
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name = "{{.TestName}}"
+
+  depends_on = [vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing]
+}
+`
+
+const testAccVcdNsxtBgpIpPrefixVdcGroupConfig3 = testAccVcdNsxtBgpIpPrefixConfigVdcGroupPrereqs + `
+resource "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name = "{{.TestName}}-updated"
+
+  ip_prefix {
+	network                  = "30.10.10.0/24"
+	action                   = "DENY"
+	greater_than_or_equal_to = "25"
+	less_than_or_equal_to    = "27"
+  }
+}
+`
+
+const testAccVcdNsxtBgpIpPrefixVdcGroupConfig4DS = testAccVcdNsxtBgpIpPrefixVdcGroupConfig3 + `
+data "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name = "{{.TestName}}-updated"
+
+  depends_on = [vcd_nsxt_edgegateway_bgp_ip_prefix_list.testing]
+}
+`

--- a/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_bgp_ip_prefix_list"
+sidebar_current: "docs-vcd-datasource-nsxt-edgegateway-bgp-ip-prefix-list"
+description: |-
+  Provides a data source to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can
+  contain single or multiple IP addresses and can be used to assign BGP neighbors with access
+  permissions for route advertisement.
+---
+
+# vcd\_nsxt\_edgegateway\_bgp\_ip\_prefix\_list
+
+Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
+
+Provides a resource to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can contain 
+single or multiple IP addresses and can be used to assign BGP neighbors with access permissions 
+for route advertisement.
+
+## Example Usage
+
+```hcl
+data "vcd_nsxt_edgegateway" "existing" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  name = "nsxt-gw"
+}
+
+data "vcd_nsxt_alb_settings" "test" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+  [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
+* `name` - (Required) A name of existing BGP IP Prefix List in specified Edge Gateway
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_edgegateway_bgp_ip_prefix_list`](/providers/vmware/vcd/latest/docs/resources/nsxt_edgegateway_bgp_ip_prefix_list)
+resource are available.

--- a/website/docs/d/nsxt_ip_set.html.markdown
+++ b/website/docs/d/nsxt_ip_set.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `vdc` - (Optional) The name of VDC to use, optional if defined at provider level. **Deprecated**
 in favor of `edge_gateway_id` field.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
 * `name` - (Required)  - Unique name of existing IP Set.
 
 ## Attribute Reference

--- a/website/docs/d/nsxt_ipsec_vpn_tunnel.html.markdown
+++ b/website/docs/d/nsxt_ipsec_vpn_tunnel.html.markdown
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using `vcd_nsxt_edgegateway`
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using `vcd_nsxt_edgegateway`
   data source
 * `name` - (Required)  - Name of existing IPsec VPN Tunnel
 

--- a/website/docs/d/nsxt_security_group.html.markdown
+++ b/website/docs/d/nsxt_security_group.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `vdc` - (Deprecated; Optional) The name of VDC to use, optional if defined at provider level. **Deprecated**
   in favor of `edge_gateway_id` field.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
 * `name` - (Required)  - Unique name of existing Security Group.
 
 ## Attribute Reference

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -111,7 +111,7 @@ The following arguments are supported:
 * `description` - (Optional) An optional description of the network
 * `interface_type` - (Optional) An interface for the network. One of `internal` (default), `subinterface`, 
   `distributed` (requires the edge gateway to support distributed networks). NSX-T supports only `internal`
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-V or NSX-T)
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-V or NSX-T)
 * `gateway` (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
 * `dns1` - (Optional) First DNS server to use.

--- a/website/docs/r/nsxt_edgegateway_bgp_configuration.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_configuration.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
 * `enabled` - (Required) Defines if BGP service is enabled or not
 * `ecmp_enabled` (Optional) - A flag indicating whether ECMP is enabled or not

--- a/website/docs/r/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
 * `name` - (Required) The Name of IP Prefix List
 * `description` - (Optional) Description of IP Prefix List

--- a/website/docs/r/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
@@ -1,0 +1,107 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_bgp_ip_prefix_list"
+sidebar_current: "docs-vcd-resource-nsxt-edgegateway-bgp-ip-prefix-list"
+description: |-
+  Provides a resource to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can contain 
+  single or multiple IP addresses and can be used to assign BGP neighbors with access permissions 
+  for route advertisement.
+---
+
+# vcd\_nsxt\_edgegateway\_bgp\_ip\_prefix\_list
+
+Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
+
+Provides a resource to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can contain
+single or multiple IP addresses and can be used to assign BGP neighbors with access permissions for
+route advertisement.
+
+
+## Example Usage (BGP IP Prefix List with multiple entries)
+
+```hcl
+resource "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org = "cloud"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name        = "sample-ip-prefix-list"
+  description = "This definition is meant only to demostrate capabilities"
+
+  ip_prefix {
+    network = "10.10.10.0/24"
+    action  = "PERMIT"
+  }
+
+  ip_prefix {
+    network = "20.10.10.0/24"
+    action  = "DENY"
+  }
+
+  ip_prefix {
+    network = "2001:db8::/48"
+    action  = "DENY"
+  }
+
+  ip_prefix {
+    network                  = "30.10.10.0/24"
+    action                   = "DENY"
+    greater_than_or_equal_to = "25"
+    less_than_or_equal_to    = "27"
+  }
+
+  ip_prefix {
+    network                  = "40.0.0.0/8"
+    action                   = "PERMIT"
+    greater_than_or_equal_to = "16"
+    less_than_or_equal_to    = "24"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+  `vcd_nsxt_edgegateway` datasource
+* `name` - (Required) The Name of IP Prefix List
+* `description` - (Optional) Description of IP Prefix List
+* `ip_prefix` - (Required) At least one `ip_prefix` definition. See [IP Prefix](#ip-prefix) for
+  definition structure.
+
+<a id="ip-prefix"></a>
+## IP Prefix
+
+Each member ip_prefix contains following attributes:
+
+* `network` - (Required) Network information should be in CIDR notation. (e.g. IPv4
+  192.168.100.0/24, IPv6 2001:db8::/48)
+* `action` - (Required) Can be `PERMIT` or `DENY`
+* `greater_than_or_equal_to` - (Optional) Greater than or equal to (ge) subnet mask to match. For
+  example, 192.168.100.3/27 ge 26 le 32 modifiers match subnet masks greater than or equal to
+  26-bits and less than or equal to 32-bits in length.
+* `less_than_or_equal_to` - (Optional) Less than or equal to (le) subnet mask to match. For example,
+  192.168.100.3/27 ge 26 le 32 modifiers match subnet masks greater than or equal to 26-bits and
+  less than or equal to 32-bits in length.
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing BGP IP Prefix List configuration can be [imported][docs-import] into this resource
+via supplying path for it. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_edgegateway_bgp_ip_prefix_list.imported `my-org.my-vdc-or-vdc-group.my-edge-gateway.ip-prefix-list-name`
+```
+
+The above would import the `ip-prefix-list-name` BGP IP Prefix List that is defined in
+`my-edge-gateway` NSX-T Edge Gateway. Edge Gateway should be located in `my-vdc-or-vdc-group` VDC ir
+VDC Group in Org `my-org`

--- a/website/docs/r/nsxt_firewall.html.markdown
+++ b/website/docs/r/nsxt_firewall.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
 * `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
 

--- a/website/docs/r/nsxt_ip_set.html.markdown
+++ b/website/docs/r/nsxt_ip_set.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
   in favor of `edge_gateway_id` field.
 * `name` - (Required) A unique name for IP Set
 * `description` - (Optional) An optional description of the IP Set
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source.
 * `ip_addresses` (Optional) A set of IP addresses, subnets or ranges (IPv4 or IPv6)
 

--- a/website/docs/r/nsxt_ipsec_vpn_tunnel.html.markdown
+++ b/website/docs/r/nsxt_ipsec_vpn_tunnel.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source
 * `name` - (Required) A name for NSX-T IPsec VPN Tunnel
 * `description` - (Optional) An optional description of the NSX-T IPsec VPN Tunnel

--- a/website/docs/r/nsxt_nat_rule.html.markdown
+++ b/website/docs/r/nsxt_nat_rule.html.markdown
@@ -111,7 +111,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
   when connected as sysadmin working across different organisations.
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source
 * `name` - (Required) A name for NAT rule
 * `description` - (Optional) An optional description of the NAT rule

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
   in favor of `edge_gateway_id` field.
 * `name` - (Required) A unique name for Security Group
 * `description` - (Optional) An optional description of the Security Group
-* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+* `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source
 * `member_org_network_ids` (Optional) A set of Org Network IDs
 

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -238,6 +238,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-network-context-profile") %>>
               <a href="/docs/providers/vcd/d/nsxt_network_context_profile.html">vcd_nsxt_network_context_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-datasource-nsxt-edgegateway-bgp-ip-prefix-list") %>>
+              <a href="/docs/providers/vcd/d/nsxt_edgegateway_bgp_ip_prefix_list.html">vcd_nsxt_edgegateway_bgp_ip_prefix_list</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -431,6 +434,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-distributed-firewall") %>>
               <a href="/docs/providers/vcd/r/nsxt_distributed_firewall.html">vcd_nsxt_distributed_firewall</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-edgegateway-bgp-ip-prefix-list") %>>
+              <a href="/docs/providers/vcd/r/nsxt_edgegateway_bgp_ip_prefix_list.html">vcd_nsxt_edgegateway_bgp_ip_prefix_list</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR continues to build on #861 to cover complete BGP configuration (as requested in #755) on NSX-T Edge Gateways.
This PR adds BGP IP Prefix List managemet resource and data source `vcd_nsxt_edgegateway_bgp_ip_prefix_list`

**Note**. For non network savy guys the `greater_than_or_equal_to` and `less_than_or_equal_to` fields in `ip_prefix` block look confusing. VCD itself docs do have a note about it but could do a bit better. I was looking for better explanations and found this one to be explaining it good -> https://community.cisco.com/t5/routing/bgp-prefix-list/m-p/986282/highlight/true#M81916 . 

VCD Docs ->  https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Service-Provider-Admin-Portal-Guide/GUID-F2A3BC91-036A-4E29-A1C9-6EAB8602562E.html