### PR TITLE
Add 'vcd_nsxt_edgegateway_bgp_neighbor' for managing BGP Neighbors

### DIFF
--- a/.changes/v3.7.0/880-features.md
+++ b/.changes/v3.7.0/880-features.md
@@ -1,0 +1,2 @@
+* **New Resource:** `vcd_nsxt_edgegateway_bgp_neighbor` allows users to configure NSX-T Edge Gateway BGP Neighbors [GH-879]
+* **New Data Source:** `vcd_nsxt_edgegateway_bgp_neighbor` allows users to read NSX-T Edge Gateway BGP Neighbors [GH-879]

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b
 
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,5 @@ require (
 	github.com/hashicorp/go-version v1.5.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.17.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.13
+	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.14
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 	github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211
 
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3 h1:SvB/203DZ9Lmv8YbcG9/+Pgb+EwEcjrPMoZP+NUZGeo=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211 h1:scshK+38zAif82Oyx3zv9m/4swIdXxyeMYfe0HkbdJI=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3 h1:SvB/203DZ9Lmv8YbcG9/+Pgb+EwEcjrPMoZP+NUZGeo=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220707195938-d8283d6b65d3/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -224,8 +226,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9 h1:i8OqjVqUoYuPcu/TByXxkxGg02xsX7X7lJlcjrl9y9o=
-github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.9/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211 h1:scshK+38zAif82Oyx3zv9m/4swIdXxyeMYfe0HkbdJI=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220708061018-87c4f0c45211/go.mod h1:2BS1yw61VN34WI0/nUYoInFvBc3Zcuf84d4ESiAAl68=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b h1:13tmH4puLmAd/W9C+8LcKixRTmnVjZTq3fs5Gpv3/LU=
+github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b h1:13tmH4puLmAd/W9C+8LcKixRTmnVjZTq3fs5Gpv3/LU=
-github.com/Didainius/go-vcloud-director/v2 v2.15.0-alpha.7.0.20220727094444-92b33282247b/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -226,6 +224,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.14 h1:R3h9H/8oRVdMPBSy0cUaZ8IM5+dDMnIKKi38O4dcHcw=
+github.com/vmware/go-vcloud-director/v2 v2.16.0-alpha.14/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/vcd/datasource_vcd_nsxt_edgegateway_bgp_neighbor.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_bgp_neighbor.go
@@ -58,7 +58,7 @@ func datasourceVcdEdgeBgpNeighbor() *schema.Resource {
 			"allow_as_in": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "A flag indicating whether BGP neighbors can receive routes with same AS (default 'false')",
+				Description: "A flag indicating whether BGP neighbors can receive routes with same Autonomous System (AS)",
 			},
 			"bfd_enabled": {
 				Type:        schema.TypeBool,

--- a/vcd/datasource_vcd_nsxt_edgegateway_bgp_neighbor.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_bgp_neighbor.go
@@ -1,0 +1,121 @@
+package vcd
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdEdgeBgpNeighbor() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdEdgeBgpNeighborRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway ID for BGP Neighbor Configuration",
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "BGP Neighbor IP address (IPv4 or IPv6)",
+			},
+			"remote_as_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Remote Autonomous System (AS) number",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Neighbor password",
+			},
+			"keep_alive_timer": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time interval (in seconds) between sending keep alive messages to a peer",
+			},
+			"hold_down_timer": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time interval (in seconds) before declaring a peer dead",
+			},
+			"graceful_restart_mode": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "One of 'DISABLE', 'HELPER_ONLY', 'GRACEFUL_AND_HELPER'",
+			},
+			"allow_as_in": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "A flag indicating whether BGP neighbors can receive routes with same AS (default 'false')",
+			},
+			"bfd_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "BFD configuration for failure detection",
+			},
+			"bfd_interval": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Time interval (in milliseconds) between heartbeat packets",
+			},
+			"bfd_dead_multiple": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Number of times a heartbeat packet is missed before BFD declares that the neighbor is down",
+			},
+			"route_filtering": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "One of 'DISABLED', 'IPV4', 'IPV6'",
+			},
+			"in_filter_ip_prefix_list_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An optional IP Prefix List ID for filtering 'IN' direction.",
+			},
+			"out_filter_ip_prefix_list_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "An optional IP Prefix List ID for filtering 'OUT' direction.",
+			},
+		},
+	}
+}
+
+func datasourceVcdEdgeBgpNeighborRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	bgpIpPrefixList, err := nsxtEdge.GetBgpNeighborByIp(d.Get("ip_address").(string))
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error retrieving NSX-T Edge Gateway BGP Neighbor: %s", err)
+	}
+
+	err = setEdgeBgpNeighborData(d, bgpIpPrefixList.EdgeBgpNeighbor)
+	if err != nil {
+		return diag.Errorf("[bgp ip prefix list read] error storing entity into schema: %s", err)
+	}
+
+	d.SetId(bgpIpPrefixList.EdgeBgpNeighbor.ID)
+
+	return nil
+}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -95,8 +95,8 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_vdc_group":                                 datasourceVdcGroup(),                            // 3.5
 	"vcd_nsxt_distributed_firewall":                 datasourceVcdNsxtDistributedFirewall(),          // 3.6
 	"vcd_nsxt_network_context_profile":              datasourceVcdNsxtNetworkContextProfile(),        // 3.6
-	"vcd_nsxt_edgegateway_bgp_configuration":        datasourceVcdEdgeBgpConfig(),                    // 3.7
 	"vcd_nsxt_route_advertisement":                  datasourceVcdNsxtRouteAdvertisement(),           // 3.7
+	"vcd_nsxt_edgegateway_bgp_configuration":        datasourceVcdEdgeBgpConfig(),                    // 3.7
 	"vcd_nsxt_edgegateway_bgp_neighbor":             datasourceVcdEdgeBgpNeighbor(),                  // 3.7
 	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       datasourceVcdEdgeBgpIpPrefixList(),              // 3.7
 	"vcd_nsxt_dynamic_security_group":               datasourceVcdDynamicSecurityGroup(),             // 3.7
@@ -169,9 +169,9 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_security_tag":                              resourceVcdSecurityTag(),                      // 3.7
 	"vcd_nsxt_route_advertisement":                  resourceVcdNsxtRouteAdvertisement(),           // 3.7
 	"vcd_org_vdc_access_control":                    resourceVcdOrgVdcAccessControl(),              // 3.7
+	"vcd_nsxt_dynamic_security_group":               resourceVcdDynamicSecurityGroup(),             // 3.7
 	"vcd_nsxt_edgegateway_bgp_neighbor":             resourceVcdEdgeBgpNeighbor(),                  // 3.7
 	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       resourceVcdEdgeBgpIpPrefixList(),              // 3.7
-	"vcd_nsxt_dynamic_security_group":               resourceVcdDynamicSecurityGroup(),             // 3.7
 	"vcd_nsxt_edgegateway_bgp_configuration":        resourceVcdEdgeBgpConfig(),                    // 3.7
 }
 

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -96,6 +96,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_distributed_firewall":                 datasourceVcdNsxtDistributedFirewall(),          // 3.6
 	"vcd_nsxt_network_context_profile":              datasourceVcdNsxtNetworkContextProfile(),        // 3.6
 	"vcd_nsxt_route_advertisement":                  datasourceVcdNsxtRouteAdvertisement(),           // 3.7
+	"vcd_nsxt_edgegateway_bgp_neighbor":             datasourceVcdEdgeBgpNeighbor(),                  // 3.7
 
 }
 
@@ -166,6 +167,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_security_tag":                              resourceVcdSecurityTag(),                      // 3.7
 	"vcd_nsxt_route_advertisement":                  resourceVcdNsxtRouteAdvertisement(),           // 3.7
 	"vcd_org_vdc_access_control":                    resourceVcdOrgVdcAccessControl(),              // 3.7
+	"vcd_nsxt_edgegateway_bgp_neighbor":             resourceVcdEdgeBgpNeighbor(),                  // 3.7
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
@@ -1,0 +1,367 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceVcdEdgeBgpNeighbor() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdEdgeBgpNeighborCreate,
+		ReadContext:   resourceVcdEdgeBgpNeighborRead,
+		UpdateContext: resourceVcdEdgeBgpNeighborUpdate,
+		DeleteContext: resourceVcdEdgeBgpNeighborDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdEdgeBgpNeighborImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway ID for BGP Neighbor Configuration",
+			},
+			"ip_address": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "BGP Neighbor IP address (IPv4 or IPv6)",
+			},
+			"remote_as_number": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Remote Autonomous System (AS) number",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Neighbor password",
+			},
+			"keep_alive_timer": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Time interval (in seconds) between sending keep alive messages to a peer",
+			},
+			"hold_down_timer": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Time interval (in seconds) before declaring a peer dead",
+			},
+			"graceful_restart_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "One of 'DISABLE', 'HELPER_ONLY', 'GRACEFUL_AND_HELPER'",
+				ValidateFunc: validation.StringInSlice([]string{"DISABLE", "HELPER_ONLY", "GRACEFUL_AND_HELPER"}, false),
+			},
+			"allow_as_in": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "A flag indicating whether BGP neighbors can receive routes with same AS (default 'false')",
+			},
+			"bfd_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "BFD configuration for failure detection",
+			},
+			"bfd_interval": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Time interval (in milliseconds) between heartbeat packets",
+			},
+			"bfd_dead_multiple": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Number of times a heartbeat packet is missed before BFD declares that the neighbor is down",
+			},
+			"route_filtering": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				Description:  "One of 'DISABLED', 'IPV4', 'IPV6'",
+				ValidateFunc: validation.StringInSlice([]string{"DISABLED", "IPV4", "IPV6"}, false),
+			},
+			"in_filter_ip_prefix_list_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "An optional IP Prefix List ID for filtering 'IN' direction.",
+			},
+			"out_filter_ip_prefix_list_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "An optional IP Prefix List ID for filtering 'OUT' direction.",
+			},
+		},
+	}
+}
+
+func resourceVcdEdgeBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor create] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor create] error retrieving Edge Gateway: %s", err)
+	}
+
+	bgpNeighbor := getEdgeBgpNeighborType(d)
+
+	createdbgpNeighbor, err := nsxtEdge.CreateBgpNeighbor(bgpNeighbor)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor create] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	d.SetId(createdbgpNeighbor.EdgeBgpNeighbor.ID)
+	return resourceVcdEdgeBgpNeighborRead(ctx, d, meta)
+}
+
+func resourceVcdEdgeBgpNeighborUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp configuration update] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor update] error retrieving Edge Gateway: %s", err)
+	}
+
+	bgpNeighbor, err := nsxtEdge.GetBgpNeighborById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp neighbor update] error retrieving NSX-T Edge Gateway BGP IP Prefix Lis: %s", err)
+	}
+
+	bgpNeighbor.EdgeBgpNeighbor = getEdgeBgpNeighborType(d)
+	bgpNeighbor.EdgeBgpNeighbor.ID = d.Id()
+
+	_, err = bgpNeighbor.Update(bgpNeighbor.EdgeBgpNeighbor)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor update] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	return resourceVcdEdgeBgpNeighborRead(ctx, d, meta)
+}
+
+func resourceVcdEdgeBgpNeighborRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	bgpNeighbor, err := nsxtEdge.GetBgpNeighborById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+	}
+
+	err = setEdgeBgpNeighborData(d, bgpNeighbor.EdgeBgpNeighbor)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor read] error storing entity into schema: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdEdgeBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor delete] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[bgp neighbor delete] error retrieving NSX-T Edge Gateway: %s", err)
+	}
+
+	bgpNeighbor, err := nsxtEdge.GetBgpNeighborById(d.Id())
+	if err != nil {
+		return diag.Errorf("[bgp neighbor delete] error retrieving NSX-T Edge Gateway BGP Configuration: %s", err)
+	}
+
+	err = bgpNeighbor.Delete()
+	if err != nil {
+		return diag.Errorf("[bgp neighbor delete] error deleting NSX-T Edge Gateway BGP Configuration: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdEdgeBgpNeighborImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	resourceURI := strings.SplitN(d.Id(), ImportSeparator, 4)
+	if len(resourceURI) != 4 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-or-vdc-group-name.edge_gateway_name.bgp_neighbor_ip, got '%s'", d.Id())
+	}
+	orgName, vdcOrVdcGroupName, edgeGatewayName, bgpNeighborIp := resourceURI[0], resourceURI[1], resourceURI[2], resourceURI[3]
+
+	vcdClient := meta.(*VCDClient)
+	vdcOrVdcGroup, err := lookupVdcOrVdcGroup(vcdClient, orgName, vdcOrVdcGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	edgeGateway, err := vdcOrVdcGroup.GetNsxtEdgeGatewayByName(edgeGatewayName)
+	if err != nil {
+		return nil, fmt.Errorf("[bgp neighbor import] unable to find Edge Gateway '%s': %s", edgeGatewayName, err)
+	}
+
+	bgpPrefixList, err := edgeGateway.GetBgpNeighborByIp(bgpNeighborIp)
+	if err != nil {
+		return nil, fmt.Errorf("[bgp neighbor import] unable to find BGP Neighbor with Name '%s': %s", bgpNeighborIp, err)
+	}
+
+	dSet(d, "org", orgName)
+	dSet(d, "edge_gateway_id", edgeGateway.EdgeGateway.ID)
+	d.SetId(bgpPrefixList.EdgeBgpNeighbor.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getEdgeBgpNeighborType(d *schema.ResourceData) *types.EdgeBgpNeighbor {
+	bgpNeighborConfig := &types.EdgeBgpNeighbor{
+		NeighborAddress:        d.Get("ip_address").(string),
+		RemoteASNumber:         d.Get("remote_as_number").(string),
+		KeepAliveTimer:         d.Get("keep_alive_timer").(int),
+		HoldDownTimer:          d.Get("hold_down_timer").(int),
+		NeighborPassword:       d.Get("password").(string),
+		AllowASIn:              d.Get("allow_as_in").(bool),
+		GracefulRestartMode:    d.Get("graceful_restart_mode").(string),
+		IpAddressTypeFiltering: d.Get("route_filtering").(string),
+	}
+
+	bgpNeighborConfig.Bfd = &types.EdgeBgpNeighborBfd{
+		Enabled:             d.Get("bfd_enabled").(bool),
+		BfdInterval:         d.Get("bfd_interval").(int),
+		DeclareDeadMultiple: d.Get("bfd_dead_multiple").(int),
+	}
+
+	if inRoutesInterface, exists := d.GetOk("in_filter_ip_prefix_list_id"); exists {
+		bgpNeighborConfig.InRoutesFilterRef = &types.OpenApiReference{ID: inRoutesInterface.(string)}
+	}
+
+	if outRoutesInterface, exists := d.GetOk("out_filter_ip_prefix_list_id"); exists {
+		bgpNeighborConfig.OutRoutesFilterRef = &types.OpenApiReference{ID: outRoutesInterface.(string)}
+	}
+
+	return bgpNeighborConfig
+}
+
+func setEdgeBgpNeighborData(d *schema.ResourceData, bgpNeighborConfig *types.EdgeBgpNeighbor) error {
+	dSet(d, "ip_address", bgpNeighborConfig.NeighborAddress)
+	dSet(d, "remote_as_number", bgpNeighborConfig.RemoteASNumber)
+
+	dSet(d, "keep_alive_timer", bgpNeighborConfig.KeepAliveTimer)
+	dSet(d, "remote_as_number", bgpNeighborConfig.RemoteASNumber)
+	dSet(d, "hold_down_timer", bgpNeighborConfig.HoldDownTimer)
+	// Password is a "write-only" field. It cannot be read afterwards.
+	//dSet(d, "password", bgpNeighborConfig.NeighborPassword)
+	dSet(d, "allow_as_in", bgpNeighborConfig.AllowASIn)
+
+	dSet(d, "graceful_restart_mode", bgpNeighborConfig.GracefulRestartMode)
+	dSet(d, "route_filtering", bgpNeighborConfig.IpAddressTypeFiltering)
+
+	if bgpNeighborConfig.Bfd != nil {
+		dSet(d, "bfd_enabled", bgpNeighborConfig.Bfd.Enabled)
+		dSet(d, "bfd_interval", bgpNeighborConfig.Bfd.BfdInterval)
+		dSet(d, "bfd_dead_multiple", bgpNeighborConfig.Bfd.DeclareDeadMultiple)
+	}
+
+	if bgpNeighborConfig.InRoutesFilterRef != nil {
+		dSet(d, "in_filter_ip_prefix_list_id", bgpNeighborConfig.InRoutesFilterRef.ID)
+	} else {
+		dSet(d, "in_filter_ip_prefix_list_id", "")
+	}
+	if bgpNeighborConfig.OutRoutesFilterRef != nil {
+		dSet(d, "out_filter_ip_prefix_list_id", bgpNeighborConfig.OutRoutesFilterRef.ID)
+	} else {
+		dSet(d, "out_filter_ip_prefix_list_id", "")
+	}
+
+	return nil
+}

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
@@ -75,7 +75,7 @@ func resourceVcdEdgeBgpNeighbor() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				Description: "A flag indicating whether BGP neighbors can receive routes with same AS (default 'false')",
+				Description: "A flag indicating whether BGP neighbors can receive routes with same Autonomous System (AS) (default 'false')",
 			},
 			"bfd_enabled": {
 				Type:        schema.TypeBool,
@@ -121,7 +121,7 @@ func resourceVcdEdgeBgpNeighbor() *schema.Resource {
 func resourceVcdEdgeBgpNeighborCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// Handling locks for BGP configuration is conditional. There are two scenarios:
 	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
 	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
 	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
@@ -161,7 +161,7 @@ func resourceVcdEdgeBgpNeighborCreate(ctx context.Context, d *schema.ResourceDat
 func resourceVcdEdgeBgpNeighborUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// Handling locks for BGP configuration is conditional. There are two scenarios:
 	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
 	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
 	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
@@ -234,7 +234,7 @@ func resourceVcdEdgeBgpNeighborRead(ctx context.Context, d *schema.ResourceData,
 func resourceVcdEdgeBgpNeighborDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
-	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// Handling locks for BGP configuration is conditional. There are two scenarios:
 	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
 	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
 	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor.go
@@ -3,10 +3,11 @@ package vcd
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"github.com/vmware/go-vcloud-director/v2/types/v56"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -151,7 +152,7 @@ func resourceVcdEdgeBgpNeighborCreate(ctx context.Context, d *schema.ResourceDat
 
 	createdbgpNeighbor, err := nsxtEdge.CreateBgpNeighbor(bgpNeighbor)
 	if err != nil {
-		return diag.Errorf("[bgp neighbor create] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+		return diag.Errorf("[bgp neighbor create] error updating NSX-T Edge Gateway BGP Neighbor configuration: %s", err)
 	}
 
 	d.SetId(createdbgpNeighbor.EdgeBgpNeighbor.ID)
@@ -189,7 +190,7 @@ func resourceVcdEdgeBgpNeighborUpdate(ctx context.Context, d *schema.ResourceDat
 
 	bgpNeighbor, err := nsxtEdge.GetBgpNeighborById(d.Id())
 	if err != nil {
-		return diag.Errorf("[bgp neighbor update] error retrieving NSX-T Edge Gateway BGP IP Prefix Lis: %s", err)
+		return diag.Errorf("[bgp neighbor update] error retrieving NSX-T Edge Gateway BGP Neighbor configuration: %s", err)
 	}
 
 	bgpNeighbor.EdgeBgpNeighbor = getEdgeBgpNeighborType(d)
@@ -197,7 +198,7 @@ func resourceVcdEdgeBgpNeighborUpdate(ctx context.Context, d *schema.ResourceDat
 
 	_, err = bgpNeighbor.Update(bgpNeighbor.EdgeBgpNeighbor)
 	if err != nil {
-		return diag.Errorf("[bgp neighbor update] error updating NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+		return diag.Errorf("[bgp neighbor update] error updating NSX-T Edge Gateway BGP Neighbor configuration: %s", err)
 	}
 
 	return resourceVcdEdgeBgpNeighborRead(ctx, d, meta)
@@ -215,12 +216,12 @@ func resourceVcdEdgeBgpNeighborRead(ctx context.Context, d *schema.ResourceData,
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP Neighbor configuration: %s", err)
 	}
 
 	bgpNeighbor, err := nsxtEdge.GetBgpNeighborById(d.Id())
 	if err != nil {
-		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP IP Prefix List: %s", err)
+		return diag.Errorf("[bgp neighbor read] error retrieving NSX-T Edge Gateway BGP Neighbor configuration: %s", err)
 	}
 
 	err = setEdgeBgpNeighborData(d, bgpNeighbor.EdgeBgpNeighbor)

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
@@ -1,0 +1,264 @@
+//go:build gateway || network || nsxt || ALL || functional
+// +build gateway network nsxt ALL functional
+
+package vcd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdNsxtEdgeBgpNeighbor(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+		return
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"NsxtVdcGroup":         testConfig.Nsxt.VdcGroup,
+		"NsxtEdgeGwInVdcGroup": testConfig.Nsxt.VdcGroupEdgeGateway,
+		"TestName":             t.Name(),
+
+		"Tags": "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText1 := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["SkipTest"] = "# skip-binary-test: datasource test will fail when run together with resource"
+	params["FuncName"] = t.Name() + "-step2"
+	configText2DS := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2DS)
+
+	delete(params, "SkipTest")
+	params["FuncName"] = t.Name() + "-step3"
+	configText3 := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig3, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 3: %s", configText3)
+
+	params["SkipTest"] = "# skip-binary-test: datasource test will fail when run together with resource"
+	params["FuncName"] = t.Name() + "-step4"
+	configText4DS := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig4DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 4: %s", configText4DS)
+
+	delete(params, "SkipTest")
+	params["FuncName"] = t.Name() + "-step6"
+	configText6 := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig6, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 6: %s", configText6)
+
+	params["SkipTest"] = "# skip-binary-test: datasource test will fail when run together with resource"
+	params["FuncName"] = t.Name() + "-step7"
+	configText7DS := templateFill(testAccVcdNsxtBgpNeighborVdcGroupConfig7DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 7: %s", configText7DS)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "ip_address", "1.1.1.1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "remote_as_number", "65211"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "keep_alive_timer", "80"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "hold_down_timer", "321"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "password", "phinai0ca,iS"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "graceful_restart_mode", "HELPER_ONLY"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "allow_as_in", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "route_filtering", "DISABLED"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_interval"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_dead_multiple"),
+				),
+			},
+			{
+				Config: configText2DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that all fields are the same in resource and data source except `password` as `password` cannot be read at all
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_bgp_neighbor.testing", "vcd_nsxt_edgegateway_bgp_neighbor.testing", []string{"password"}),
+				),
+			},
+			{
+				Config: configText3,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "ip_address", "1.1.1.1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "remote_as_number", "62513"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "password", ""),
+
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "keep_alive_timer", "78"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "hold_down_timer", "235"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "graceful_restart_mode", "HELPER_ONLY"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "allow_as_in", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "route_filtering", "DISABLED"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_interval", "800"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_dead_multiple", "5"),
+				),
+			},
+			{
+				Config: configText4DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that all fields are the same in resource and data source except `password` as `password` cannot be read at all
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_bgp_neighbor.testing", "vcd_nsxt_edgegateway_bgp_neighbor.testing", []string{"password"}),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_edgegateway_bgp_neighbor.testing",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdNsxtEdgeGatewayObjectUsingVdcGroup(testConfig.Nsxt.VdcGroup, testConfig.Nsxt.VdcGroupEdgeGateway, `1.1.1.1`),
+				// 'password' field cannot be retrieved once it is set
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+			{
+				Config: configText6,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "id"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "ip_address", "1.1.1.1"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "remote_as_number", "62513"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "keep_alive_timer", "78"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "hold_down_timer", "400"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "graceful_restart_mode", "GRACEFUL_AND_HELPER"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "allow_as_in", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_interval", "800"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "bfd_dead_multiple", "5"),
+					resource.TestCheckResourceAttr("vcd_nsxt_edgegateway_bgp_neighbor.testing", "route_filtering", "IPV4"),
+
+					// TODO - integrate tests when BGP IP Prefix List PRs are merged
+					//resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "in_filter_ip_prefix_list_id"),
+					//resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_bgp_neighbor.testing", "out_filter_ip_prefix_list_id"),
+				),
+			},
+			{
+				Config: configText7DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Check that all fields are the same in resource and data source except `password` as `password` cannot be read at all
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_bgp_neighbor.testing", "vcd_nsxt_edgegateway_bgp_neighbor.testing", []string{"password"}),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdNsxtBgpNeighborConfigVdcGroupPrereqs = `
+data "vcd_vdc_group" "g1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdcGroup}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.g1.id
+
+  name = "{{.NsxtEdgeGwInVdcGroup}}"
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig1 = testAccVcdNsxtBgpNeighborConfigVdcGroupPrereqs + `
+resource "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address       = "1.1.1.1"
+  remote_as_number = "65211"
+  
+  password              = "phinai0ca,iS"
+  keep_alive_timer      = 80
+  hold_down_timer       = 321
+  graceful_restart_mode = "HELPER_ONLY"
+  allow_as_in           = true
+  bfd_enabled           = true
+  route_filtering       = "DISABLED"
+  
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig2DS = testAccVcdNsxtBgpNeighborVdcGroupConfig1 + `
+data "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+  
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address = vcd_nsxt_edgegateway_bgp_neighbor.testing.ip_address
+
+  depends_on = [vcd_nsxt_edgegateway_bgp_neighbor.testing]
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig3 = testAccVcdNsxtBgpNeighborConfigVdcGroupPrereqs + `
+resource "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address       = "1.1.1.1"
+  remote_as_number = "62513"
+
+  keep_alive_timer      = 78
+  hold_down_timer       = 235
+  graceful_restart_mode = "HELPER_ONLY"
+  allow_as_in           = true
+  bfd_enabled           = true
+  bfd_interval          = 800
+  bfd_dead_multiple     = 5
+  route_filtering       = "DISABLED"
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig4DS = testAccVcdNsxtBgpNeighborVdcGroupConfig3 + `
+data "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address = vcd_nsxt_edgegateway_bgp_neighbor.testing.ip_address
+  
+
+  depends_on = [vcd_nsxt_edgegateway_bgp_neighbor.testing]
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig6 = testAccVcdNsxtBgpNeighborConfigVdcGroupPrereqs + `
+resource "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address       = "1.1.1.1"
+  remote_as_number = "62513"
+
+  keep_alive_timer      = 78
+  hold_down_timer       = 400
+  graceful_restart_mode = "GRACEFUL_AND_HELPER"
+  allow_as_in           = false
+  bfd_enabled           = false
+  bfd_interval          = 800
+  bfd_dead_multiple     = 5
+  route_filtering       = "IPV4"
+  
+  # TODO - integrate tests when BGP IP Prefix List PRs are merged
+  # in_filter_ip_prefix_list_id = "3a2021ed-eaf8-4ae6-a651-fb7870b2807e"
+  # out_filter_ip_prefix_list_id = "84019fbc-e895-4247-be0e-a3e39ee4da81"
+}
+`
+
+const testAccVcdNsxtBgpNeighborVdcGroupConfig7DS = testAccVcdNsxtBgpNeighborVdcGroupConfig6 + `
+data "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
+  org = "{{.Org}}"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address = vcd_nsxt_edgegateway_bgp_neighbor.testing.ip_address
+  
+
+  depends_on = [vcd_nsxt_edgegateway_bgp_neighbor.testing]
+}
+`

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
@@ -177,7 +177,6 @@ resource "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
   allow_as_in           = true
   bfd_enabled           = true
   route_filtering       = "DISABLED"
-  
 }
 `
 
@@ -220,7 +219,6 @@ data "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
 
   ip_address = vcd_nsxt_edgegateway_bgp_neighbor.testing.ip_address
-  
 
   depends_on = [vcd_nsxt_edgegateway_bgp_neighbor.testing]
 }
@@ -257,7 +255,6 @@ data "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
 
   ip_address = vcd_nsxt_edgegateway_bgp_neighbor.testing.ip_address
-  
 
   depends_on = [vcd_nsxt_edgegateway_bgp_neighbor.testing]
 }

--- a/website/docs/d/nsxt_alb_edgegateway_service_engine_group.html.markdown
+++ b/website/docs/d/nsxt_alb_edgegateway_service_engine_group.html.markdown
@@ -53,7 +53,7 @@ data "vcd_nsxt_alb_edgegateway_service_engine_group" "test" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
-* `edge_gateway_id` - (Optional) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Optional) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 * `service_engine_group_id` - (Required) An ID of NSX-T Service Engine Group. Can be looked up using
   [vcd_nsxt_alb_service_engine_group](/providers/vmware/vcd/latest/docs/data-sources/nsxt_alb_service_engine_group) data

--- a/website/docs/d/nsxt_alb_pool.html.markdown
+++ b/website/docs/d/nsxt_alb_pool.html.markdown
@@ -39,7 +39,7 @@ data "vcd_nsxt_alb_pool" "test" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
-* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 * `name` - (Required) Name of existing NSX-T ALB Pool.
 

--- a/website/docs/d/nsxt_alb_settings.html.markdown
+++ b/website/docs/d/nsxt_alb_settings.html.markdown
@@ -34,7 +34,7 @@ data "vcd_nsxt_alb_settings" "test" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
-* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 
 ## Attribute Reference

--- a/website/docs/d/nsxt_alb_virtual_service.html.markdown
+++ b/website/docs/d/nsxt_alb_virtual_service.html.markdown
@@ -39,7 +39,7 @@ data "vcd_nsxt_alb_virtual_service" "test" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level
-* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 * `name` - (Required) The name of ALB Virtual Service
 

--- a/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_bgp_neighbor"
+sidebar_current: "docs-vcd-resource-nsxt-edgegateway-bgp-neighbor"
+description: |-
+  Provides a data source to read NSX-T Edge Gateway BGP Neighbors and their configuration.
+---
+
+# vcd\_nsxt\_edgegateway\_bgp\_neighbor
+
+Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
+
+Provides a data source to read NSX-T Edge Gateway BGP Neighbors and their configuration.
+
+## Example Usage
+
+```hcl
+data "vcd_nsxt_edgegateway" "existing" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  name = "nsxt-gw"
+}
+
+data "vcd_nsxt_edgegateway_bgp_neighbor" "first" {
+  org = "my-org"
+  vdc = "nsxt-vdc"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  
+  ip_address = "192.168.102.45"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+  [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
+* `ip_address` - (Required) An IP Address (IPv4 or IPv6) of existing BGP Neighbor in specified Edge Gateway
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_edgegateway_bgp_neighbor`](/providers/vmware/vcd/latest/docs/resources/nsxt_edgegateway_bgp_neighbor)
+resource are available.

--- a/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
@@ -37,7 +37,7 @@ data "vcd_nsxt_edgegateway_bgp_neighbor" "first" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
-* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 * `ip_address` - (Required) An IP Address (IPv4 or IPv6) of existing BGP Neighbor in specified Edge Gateway
 

--- a/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_neighbor.html.markdown
@@ -27,7 +27,7 @@ data "vcd_nsxt_edgegateway_bgp_neighbor" "first" {
   vdc = "nsxt-vdc"
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
-  
+
   ip_address = "192.168.102.45"
 }
 ```

--- a/website/docs/r/nsxt_alb_settings.html.markdown
+++ b/website/docs/r/nsxt_alb_settings.html.markdown
@@ -42,7 +42,7 @@ resource "vcd_nsxt_alb_settings" "org1" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to which the edge gateway belongs. Optional if defined at provider level.
-* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be lookup up using
+* `edge_gateway_id` - (Required) An ID of NSX-T Edge Gateway. Can be looked up using
   [vcd_nsxt_edgegateway](/providers/vmware/vcd/latest/docs/data-sources/nsxt_edgegateway) data source
 * `is_active` - (Required) Boolean value `true` or `false` if ALB is enabled. **Note** Delete operation of this resource
   will set it to `false`

--- a/website/docs/r/nsxt_edgegateway_bgp_neighbor.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_neighbor.html.markdown
@@ -12,7 +12,6 @@ Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
 
 Provides a resource to manage NSX-T Edge Gateway BGP Neighbors and their configuration.
 
-
 ## Example Usage (BGP Neighbor configuration with route filtering with referenced BGP IP Prefix List)
 
 ```hcl
@@ -31,9 +30,9 @@ resource "vcd_nsxt_edgegateway_bgp_neighbor" "neighbor-one" {
   bfd_enabled           = true
   bfd_interval          = 800
   bfd_dead_multiple     = 5
-  
-  route_filtering       = "IPV4"
-  in_filter_ip_prefix_list_id = data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.in-1.id
+
+  route_filtering              = "IPV4"
+  in_filter_ip_prefix_list_id  = data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.in-1.id
   out_filter_ip_prefix_list_id = data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.out-1.id
 }
 ```
@@ -46,7 +45,6 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations
 * `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
-
 * `ip_address` - (Required) BGP Neighbor IP Address (IPv4 or IPv6)
 * `remote_as_number` - (Required) BGP Neighbor Remote Autonomous System (AS) Number
 * `password` - (Optional) BGP Neighbor Password
@@ -63,7 +61,6 @@ The following arguments are supported:
 * `route_filtering` - (Optional) Route filtering by IP Address family. One of `DISABLED`, `IPV4`, `IPV6`
 * `in_filter_ip_prefix_list_id` - (Optional) The ID of the IP Prefix List to be used for filtering incoming BGP routes
 * `out_filter_ip_prefix_list_id` - (Optional) The ID of the IP Prefix List to be used for filtering outgoing BGP routes
-
 
 ## Importing
 

--- a/website/docs/r/nsxt_edgegateway_bgp_neighbor.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_neighbor.html.markdown
@@ -1,0 +1,85 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_bgp_neighbor"
+sidebar_current: "docs-vcd-resource-nsxt-edgegateway-bgp-neighbor"
+description: |-
+  Provides a resource to manage NSX-T Edge Gateway BGP Neighbors and their configuration.
+---
+
+# vcd\_nsxt\_edgegateway\_bgp\_neighbor
+
+Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
+
+Provides a resource to manage NSX-T Edge Gateway BGP Neighbors and their configuration.
+
+
+## Example Usage (BGP Neighbor configuration with route filtering with referenced BGP IP Prefix List)
+
+```hcl
+resource "vcd_nsxt_edgegateway_bgp_neighbor" "neighbor-one" {
+  org = "datacloud"
+
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  ip_address       = "1.1.1.1"
+  remote_as_number = "62513"
+
+  keep_alive_timer      = 78
+  hold_down_timer       = 400
+  graceful_restart_mode = "GRACEFUL_AND_HELPER"
+  allow_as_in           = false
+  bfd_enabled           = true
+  bfd_interval          = 800
+  bfd_dead_multiple     = 5
+  
+  route_filtering       = "IPV4"
+  in_filter_ip_prefix_list_id = data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.in-1.id
+  out_filter_ip_prefix_list_id = data.vcd_nsxt_edgegateway_bgp_ip_prefix_list.out-1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations
+* `edge_gateway_id` - (Required) The ID of the edge gateway (NSX-T only). Can be looked up using
+  `vcd_nsxt_edgegateway` datasource
+
+* `ip_address` - (Required) BGP Neighbor IP Address (IPv4 or IPv6)
+* `remote_as_number` - (Required) BGP Neighbor Remote Autonomous System (AS) Number
+* `password` - (Optional) BGP Neighbor Password
+* `keep_alive_timer` - (Optional) Time interval (in seconds) between sending keep-alive messages to a BGP peer
+* `hold_down_timer` - (Optional) Time interval (in seconds) before declaring a BGP peer dead
+* `graceful_restart_mode` - (Optional) BGP Neighbor Graceful Restart Mode. One of:
+  * `DISABLE` - Overrides the global edge gateway settings and disables graceful restart mode for this neighbor.
+  * `HELPER_ONLY` - Overrides the global edge gateway settings and configures graceful restart mode as Helper only for this neighbor.
+  * `GRACEFUL_AND_HELPER` - Overrides the global edge gateway settings and configures graceful restart mode as Graceful restart and Helper for this neighbor.
+* `allow_as_in` - (Optional) BGP Allow-as-in feature is used to allow the BGP speaker to accept the BGP updates even if its own BGP AS number is in the AS-Path attribute.
+* `bfd_enabled` - (Optional) Should Bidirectional Forwarding Detection (BFD) be enabled 
+* `bfd_interval` - (Optional) Time interval (in milliseconds) between heartbeat packets
+* `bfd_dead_multiple` - (Optional) Number of times a heartbeat packet is missed before BFD declares that the neighbor is down
+* `route_filtering` - (Optional) Route filtering by IP Address family. One of `DISABLED`, `IPV4`, `IPV6`
+* `in_filter_ip_prefix_list_id` - (Optional) The ID of the IP Prefix List to be used for filtering incoming BGP routes
+* `out_filter_ip_prefix_list_id` - (Optional) The ID of the IP Prefix List to be used for filtering outgoing BGP routes
+
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing BGP IP Prefix List configuration can be [imported][docs-import] into this resource
+via supplying path for it. An example is
+below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_edgegateway_bgp_neighbor.imported `my-org.my-vdc-or-vdc-group.my-edge-gateway.bgp-neighbor-ip`
+```
+
+The above would import the `bgp-neighbor-ip` BGP Neighbor that is defined in
+`my-edge-gateway` NSX-T Edge Gateway. Edge Gateway should be located in `my-vdc-or-vdc-group` VDC or
+VDC Group in Org `my-org`

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -238,6 +238,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-network-context-profile") %>>
               <a href="/docs/providers/vcd/d/nsxt_network_context_profile.html">vcd_nsxt_network_context_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-datasource-nsxt-edgegateway-bgp-neighbor") %>>
+              <a href="/docs/providers/vcd/d/nsxt_edgegateway_bgp_neighbor.html">vcd_nsxt_edgegateway_bgp_neighbor</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -431,6 +434,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-distributed-firewall") %>>
               <a href="/docs/providers/vcd/r/nsxt_distributed_firewall.html">vcd_nsxt_distributed_firewall</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-edgegateway-bgp-neighbor") %>>
+              <a href="/docs/providers/vcd/r/nsxt_edgegateway_bgp_neighbor.html">vcd_nsxt_edgegateway_bgp_neighbor</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR continues work of #861 and #879 and completes full coverage of NSX-T Edge Gateway BGP configuration (3x resources and 3x data sources in total for complete BGP configuration management +1 more resource for route advertisement which is already in `main` #858)

This last PR adds BGP neighbor configuration resource and data source `vcd_nsxt_edgegateway_bgp_neighbor`.

Tested on 10.2.0, 10.2.2, 10.3.3.

**Note.** Once all PRs are merged, additional tests will be done to integrate all components together. This was not done now to avoid making huge PRs containing all code.