### PR TITLE
Fix TestAccVcdOrgGroup

### DIFF
--- a/.changes/v3.8.0/908-notes.md
+++ b/.changes/v3.8.0/908-notes.md
@@ -1,0 +1,1 @@
+Improve website documentation for BGP IP Prefix lists and ALB Cloud data sources [GH-908]

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -49,7 +49,6 @@ func TestAccVcdOrgGroup(t *testing.T) {
 	ldapConfigParams := struct {
 		VdcGroup            string
 		VdcGroupEdgeGateway string
-		ExternalNetwork     string
 		GuestImage          string
 		CatalogName         string
 		LdapContainerName   string
@@ -57,7 +56,6 @@ func TestAccVcdOrgGroup(t *testing.T) {
 	}{
 		VdcGroup:            testConfig.Nsxt.VdcGroup,
 		VdcGroupEdgeGateway: testConfig.Nsxt.VdcGroupEdgeGateway,
-		ExternalNetwork:     testConfig.Nsxt.ExternalNetwork,
 		GuestImage:          testConfig.VCD.Catalog.CatalogItem,
 		CatalogName:         testConfig.VCD.Catalog.Name,
 		LdapContainerName:   ldapContainerName,

--- a/website/docs/d/nsxt_alb_cloud.html.markdown
+++ b/website/docs/d/nsxt_alb_cloud.html.markdown
@@ -11,7 +11,7 @@ description: |-
 
 Supported in provider *v3.4+* and VCD 10.2+ with NSX-T and ALB.
 
-Provides a data source to manage NSX-T ALB Clouds for Providers. An NSX-T Cloud is a service provider-level construct that
+Provides a data source to read NSX-T ALB Clouds for Providers. An NSX-T Cloud is a service provider-level construct that
 consists of an NSX-T Manager and an NSX-T Data Center transport zone.
 
 ~> Only `System Administrator` can use this data source.

--- a/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
@@ -3,7 +3,7 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_bgp_ip_prefix_list"
 sidebar_current: "docs-vcd-datasource-nsxt-edgegateway-bgp-ip-prefix-list"
 description: |-
-  Provides a data source to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can
+  Provides a data source to read NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can
   contain single or multiple IP addresses and can be used to assign BGP neighbors with access
   permissions for route advertisement.
 ---
@@ -12,7 +12,7 @@ description: |-
 
 Supported in provider *v3.7+* and VCD 10.2+ with NSX-T
 
-Provides a resource to manage NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can contain 
+Provides a resource to read NSX-T Edge Gateway BGP IP Prefix Lists. IP prefix lists can contain 
 single or multiple IP addresses and can be used to assign BGP neighbors with access permissions 
 for route advertisement.
 


### PR DESCRIPTION
Test `TestAccVcdOrgGroup` has a dependency on public IP being accessible because it spawns its own LDAP server. After test suite migration to NSX-T it started failing. This PR migrates all setup work to NSX-T world.