### PR TITLE
Org LDAP resource and data source

### DIFF
--- a/.changes/v3.8.0/909-features.md
+++ b/.changes/v3.8.0/909-features.md
@@ -1,2 +1,2 @@
 * **New Resource**: `vcd_org_ldap` that allows configuring LDAP settings for an organization [GH-909]
-* **New Datasource**: `vcd_org_ldap` that allows exploring LDAP settings for an organization [GH-909]
+* **New Data Source**: `vcd_org_ldap` that allows exploring LDAP settings for an organization [GH-909]

--- a/.changes/v3.8.0/909-features.md
+++ b/.changes/v3.8.0/909-features.md
@@ -1,2 +1,2 @@
-* New Resource: `vcd_org_ldap` that allows configuring LDAP settings for an organization [GH-909]
-* New Datasource: `vcd_org_ldap` that allows exploring LDAP settings for an organization [GH-909]
+* **New Resource**: `vcd_org_ldap` that allows configuring LDAP settings for an organization [GH-909]
+* **New Datasource**: `vcd_org_ldap` that allows exploring LDAP settings for an organization [GH-909]

--- a/.changes/v3.8.0/909-features.md
+++ b/.changes/v3.8.0/909-features.md
@@ -1,0 +1,2 @@
+* New Resource: `vcd_org_ldap` that allows configuring LDAP settings for an organization [GH-909]
+* New Datasource: `vcd_org_ldap` that allows exploring LDAP settings for an organization [GH-909]

--- a/vcd/config.go
+++ b/vcd/config.go
@@ -715,15 +715,13 @@ func logForScreen(origin, msg string) {
 // Use only for scalar values (strings, booleans, and numbers)
 func dSet(d *schema.ResourceData, key string, value interface{}) {
 	if value != nil && !isScalar(value) {
-		starLine := strings.Repeat("*", 80)
-
-		logForScreen("", starLine)
-		// This warning should never reach the final user.
+		msg1 := "*** ERROR: only scalar values should be used for dSet()"
+		msg2 := fmt.Sprintf("*** detected '%s' for key '%s' (called from %s)",
+			reflect.TypeOf(value).Kind(), key, callFuncName())
+		starLine := strings.Repeat("*", len(msg2))
+		// This panic should never reach the final user.
 		// Its purpose is to alert the developer that there was an improper use of `dSet`
-		// The warning will work when testing with either `go test` or `make install` + `terraform apply`
-		logForScreen("config", fmt.Sprintf("*** ERROR: only scalar values should be used for dSet() - detected '%s' (called from %s) \n",
-			reflect.TypeOf(value).Kind(), callFuncName()))
-		logForScreen("", starLine)
+		panic(fmt.Sprintf("\n%s\n%s\n%s\n%s\n", starLine, msg1, msg2, starLine))
 	}
 	err := d.Set(key, value)
 	if err != nil {

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -1,5 +1,5 @@
-//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbServiceMonitor || lbServerPool || lbAppProfile || lbAppRule || lbVirtualServer || access_control || user || standaloneVm || search || auth || nsxt || role || alb || certificate || vdcGroup || ALL
-// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool lbAppProfile lbAppRule lbVirtualServer access_control user standaloneVm search auth nsxt role alb certificate vdcGroup ALL
+//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbServiceMonitor || lbServerPool || lbAppProfile || lbAppRule || lbVirtualServer || access_control || user || standaloneVm || search || auth || nsxt || role || alb || certificate || vdcGroup || ldap || ALL
+// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbServiceMonitor lbServerPool lbAppProfile lbAppRule lbVirtualServer access_control user standaloneVm search auth nsxt role alb certificate vdcGroup ldap ALL
 
 package vcd
 
@@ -121,6 +121,7 @@ type TestConfig struct {
 		ExternalNetwork              string `json:"externalNetwork,omitempty"`
 		ExternalNetworkPortGroup     string `json:"externalNetworkPortGroup,omitempty"`
 		ExternalNetworkPortGroupType string `json:"externalNetworkPortGroupType,omitempty"`
+		LdapServer                   string `json:"ldap_server,omitempty"`
 		Local                        struct {
 			LocalIp            string `json:"localIp"`
 			LocalSubnetGateway string `json:"localSubnetGw"`

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -121,7 +121,7 @@ type TestConfig struct {
 		ExternalNetwork              string `json:"externalNetwork,omitempty"`
 		ExternalNetworkPortGroup     string `json:"externalNetworkPortGroup,omitempty"`
 		ExternalNetworkPortGroupType string `json:"externalNetworkPortGroupType,omitempty"`
-		LdapServer                   string `json:"ldap_server,omitempty"`
+		LdapServer                   string `json:"ldapServer,omitempty"`
 		Local                        struct {
 			LocalIp            string `json:"localIp"`
 			LocalSubnetGateway string `json:"localSubnetGw"`

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -170,9 +170,6 @@ type TestConfig struct {
 		MediaName           string `json:"mediaName,omitempty"`
 		NsxtBackedMediaName string `json:"nsxtBackedMediaName,omitempty"`
 	} `json:"media"`
-	Misc struct {
-		LdapContainer string `json:"ldapContainer,omitempty"`
-	} `json:"misc"`
 	Certificates struct {
 		Certificate1Path           string `json:"certificate1Path,omitempty"`           // absolute path to pem file
 		Certificate1PrivateKeyPath string `json:"certificate1PrivateKeyPath,omitempty"` // absolute path to private key pem file

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -115,7 +115,7 @@ func datasourceVcdOrgLdap() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVcdOrgLdapRead,
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"org_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Organization name",

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -35,7 +35,7 @@ var datasourceLdapUserAttributes = &schema.Schema{
 				Computed:    true,
 				Description: "LDAP attribute to use for the user's email address. For example, mail",
 			},
-			"full_name": { // FullName
+			"display_name": { // FullName
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "LDAP attribute to use for the user's full name. For example, displayName",

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -25,7 +25,7 @@ var datasourceLdapUserAttributes = &schema.Schema{
 				Computed:    true,
 				Description: "LDAP attribute to use as the unique identifier for a user. For example, objectGuid",
 			},
-			"user_name": { // Username
+			"username": { // Username
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName",

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -1,0 +1,185 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// datasourceLdapUserAttributes defines the elements of types.OrgLdapUserAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which structure field each one corresponds to
+var datasourceLdapUserAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Computed:    true,
+	Description: "Custom settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP objectClass of which imported users are members. For example, user or person",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use as the unique identifier for a user. For example, objectGuid",
+			},
+			"user_name": { // Username
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName",
+			},
+			"email": { // Email
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's email address. For example, mail",
+			},
+			"full_name": { // FullName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's full name. For example, displayName",
+			},
+			"given_name": { // GivenName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's given name. For example, givenName",
+			},
+			"surname": { // Surname
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's surname. For example, sn",
+			},
+			"telephone": { // Telephone
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the user's telephone number. For example, telephoneNumber",
+			},
+			"group_membership_identifier": { // GroupMembershipIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that identifies a user as a member of a group. For example, dn",
+			},
+			"group_back_link_identifier": { // GroupBackLinkIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that returns the identifiers of all the groups of which the user is a member",
+			},
+		},
+	},
+}
+
+// datasourceLdapGroupAttributes defines the elements of types.OrgLdapGroupAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which structure field each one corresponds to
+var datasourceLdapGroupAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Computed:    true,
+	Description: "Custom settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP objectClass of which imported groups are members. For example, group",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use as the unique identifier for a group. For example, objectGuid",
+			},
+			"name": { // GroupName
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use for the group name. For example, cn",
+			},
+			"membership": { // Membership
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute to use when getting the members of a group. For example, member",
+			},
+			"group_membership_identifier": { // MembershipIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP attribute that identifies a group as a member of another group. For example, dn",
+			},
+			"group_back_link_identifier": { // BackLinkIdentifier
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "LDAP group attribute used to identify a group member",
+			},
+		},
+	},
+}
+
+func datasourceVcdOrgLdap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdOrgLdapRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Organization name",
+			},
+			"ldap_mode": { // OrgLdapMode
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
+			},
+			"custom_settings": { // CustomOrgLdapSettings
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "Custom settings when `ldap_mode` is CUSTOM",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server": { // Hostname
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "host name or IP of the LDAP server",
+						},
+						"port": { // Port
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "Port number for LDAP service",
+						},
+						"authentication_method": { // AuthenticationMechanism
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "authentication method: one of SIMPLE, MD5DIGEST, NTLM",
+						},
+						"connector_type": { // ConnectorType
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "type of connector: one of OPEN_LDAP, ACTIVE_DIRECTORY",
+						},
+						"base_distinguished_name": { //SearchBase
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "LDAP search base",
+						},
+						"is_ssl": { // IsSsl
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "True if the LDAP service requires an SSL connection",
+						},
+						"username": { // Username
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Username to use when logging in to LDAP, specified using LDAP attribute=value pairs (for example: cn="ldap-admin", c="example", dc="com")`,
+						},
+						"password": { // Password
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `Password for the user identified by UserName. This value is never returned by GET. It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed`,
+						},
+						"user_attributes":  datasourceLdapUserAttributes,
+						"group_attributes": datasourceLdapGroupAttributes,
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcdOrgLdapRead(ctx, d, meta, "datasource")
+}

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -115,10 +115,10 @@ func datasourceVcdOrgLdap() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVcdOrgLdapRead,
 		Schema: map[string]*schema.Schema{
-			"org_name": {
+			"org_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Organization name",
+				Description: "Organization ID",
 			},
 			"ldap_mode": { // OrgLdapMode
 				Type:        schema.TypeString,

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -3,9 +3,10 @@ package vcd
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"os"
 	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -102,6 +103,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_edgegateway_bgp_neighbor":             datasourceVcdEdgeBgpNeighbor(),                  // 3.7
 	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       datasourceVcdEdgeBgpIpPrefixList(),              // 3.7
 	"vcd_nsxt_dynamic_security_group":               datasourceVcdDynamicSecurityGroup(),             // 3.7
+	"vcd_org_ldap":                                  datasourceVcdOrgLdap(),                          // 3.8
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -175,6 +177,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_edgegateway_bgp_neighbor":             resourceVcdEdgeBgpNeighbor(),                  // 3.7
 	"vcd_nsxt_edgegateway_bgp_ip_prefix_list":       resourceVcdEdgeBgpIpPrefixList(),              // 3.7
 	"vcd_nsxt_edgegateway_bgp_configuration":        resourceVcdEdgeBgpConfig(),                    // 3.7
+	"vcd_org_ldap":                                  resourceVcdOrgLdap(),                          // 3.8
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider_test.go
+++ b/vcd/provider_test.go
@@ -1,5 +1,5 @@
-//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbAppProfile || lbAppRule || lbServiceMonitor || lbServerPool || lbVirtualServer || user || access_control || standaloneVm || search || auth || nsxt || role || alb || certificate || vdcGroup || ALL
-// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbAppProfile lbAppRule lbServiceMonitor lbServerPool lbVirtualServer user access_control standaloneVm search auth nsxt role alb certificate vdcGroup ALL
+//go:build api || functional || catalog || vapp || network || extnetwork || org || query || vm || vdc || gateway || disk || binary || lb || lbAppProfile || lbAppRule || lbServiceMonitor || lbServerPool || lbVirtualServer || user || access_control || standaloneVm || search || auth || nsxt || role || alb || certificate || vdcGroup || ldap || ALL
+// +build api functional catalog vapp network extnetwork org query vm vdc gateway disk binary lb lbAppProfile lbAppRule lbServiceMonitor lbServerPool lbVirtualServer user access_control standaloneVm search auth nsxt role alb certificate vdcGroup ldap ALL
 
 package vcd
 

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -87,7 +87,6 @@ func TestAccVcdOrgGroup(t *testing.T) {
 				Config: ldapSetupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrgLdapExists(ldapResourceDef),
-					resource.TestCheckResourceAttr(ldapResourceDef, "org_name", testConfig.VCD.Org),
 					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -1,32 +1,23 @@
-//go:build user || functional || ALL
-// +build user functional ALL
+//go:build user || ldap || functional || ALL
+// +build user ldap functional ALL
 
 package vcd
 
 import (
-	"bytes"
 	"fmt"
-	"net"
 	"regexp"
 	"testing"
-	"text/template"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 // TestAccVcdOrgGroup tests INTEGRATED (LDAP) group management in Terraform.
-// In step 0 it spawns its own testing LDAP container with Terraform config held in `ldapSetup` var.
-// In step 1 PreConfig it uses SDK to configure LDAP settings in vCD and tests group management
-// LDAP configuration will be removed after test run
-// More about LDAP testing container - https://github.com/rroemhild/docker-test-openldap
+// In step 0 it configures the LDAP identity provider using vcd_org_ldap
+// LDAP configuration will be removed automatically after test run
 //
-// Note: External network must be properly configured (including DNS records) and must be able to
-// access internet so that it can download docker image. Also the environment where test is run must
-// be able to access external network IP so that monitoring is possible.
+// Note: This test requires an existing LDAP server and its IP set in testConfig.Networking.LdapServer
 func TestAccVcdOrgGroup(t *testing.T) {
 	preTestChecks(t)
 	if !usingSysAdmin() {
@@ -40,117 +31,71 @@ func TestAccVcdOrgGroup(t *testing.T) {
 		return
 	}
 
-	ldapContainerName := "rroemhild/test-openldap"
-	// Override LDAP container name if it is specified in config
-	if testConfig.Misc.LdapContainer != "" {
-		ldapContainerName = testConfig.Misc.LdapContainer
+	if testConfig.Networking.LdapServer == "" {
+		t.Skip("TestAccVcdOrgGroup requires a working LDAP server (set the IP in testConfig.Networking.LdapServer)")
+		return
 	}
 
-	ldapConfigParams := struct {
-		ExternalNetwork   string
-		GuestImage        string
-		CatalogName       string
-		LdapContainerName string
-	}{
-		ExternalNetwork:   testConfig.Networking.ExternalNetwork,
-		GuestImage:        testConfig.VCD.Catalog.CatalogItem,
-		CatalogName:       testConfig.VCD.Catalog.Name,
-		LdapContainerName: ldapContainerName,
-	}
 	testParamsNotEmpty(t, StringMap{"Networking.ExternalNetwork": testConfig.Networking.ExternalNetwork,
 		"VCD.Catalog.CatalogItem": testConfig.VCD.Catalog.CatalogItem, "VCD.Catalog.Name": testConfig.VCD.Catalog.Name})
-
-	// getLdapSetupTemplate does not use regular templateFill because this part is used for
-	// automated LDAP configuration setup
-	ldapSetupConfig, err := getLdapSetupTemplate(ldapSetup, ldapConfigParams)
-	if err != nil {
-		t.Errorf("failed processing LDAP setup template: %s", err)
-	}
-	debugPrintf("#[DEBUG] CONFIGURATION for step 0 (LDAP server configuration): %s", ldapSetupConfig)
 
 	role1 := govcd.OrgUserRoleOrganizationAdministrator
 	role2 := govcd.OrgUserRoleVappAuthor
 
 	var params = StringMap{
-		"Org":          testConfig.VCD.Org,
+		"OrgName":      testConfig.VCD.Org,
+		"LdapServerIp": testConfig.Networking.LdapServer,
 		"ProviderType": "INTEGRATED",
 		"RoleName":     role1,
 		"Tags":         "user",
-		"FuncName":     t.Name() + "-Step1",
+		"FuncName":     t.Name() + "-Step0",
 		"Description":  "Description1",
 	}
 	testParamsNotEmpty(t, params)
 
-	groupConfigText := templateFill(testAccOrgGroup, params)
+	ldapSetupConfig := templateFill(testAccOrgLdap, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 0 (LDAP server configuration): %s", ldapSetupConfig)
+
+	params["FuncName"] = t.Name() + "-Step1"
+	groupConfigText := templateFill(testAccOrgLdap+testAccOrgGroup, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", groupConfigText)
 
 	params["FuncName"] = t.Name() + "-Step2"
 	params["RoleName"] = role2
 	params["Description"] = "Description2"
-	groupConfigText2 := templateFill(testAccOrgGroup, params)
+	groupConfigText2 := templateFill(testAccOrgLdap+testAccOrgGroup, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", groupConfigText2)
-
-	nic0Ip := testCachedFieldValue{}
-
-	// Instantiate LDAP configuration functions.
-	// Variables passed:
-	// t *testing.T - inserted because TestCase `PreConfig` function does not allow parameters but
-	// we want to fail the test if something breaks in between
-	// nic0Ip - using a `testCachedFieldValue` the IP will be captured after step 0 and will be
-	// available in Step 1 to configure LDAP server
-	ldapConfig := ldapConfigurator{
-		t:      t,
-		nic0Ip: &nic0Ip,
-	}
-
-	// make a function with no arguments to suit signature of TestStep.PreConfig
-	configureLdapFunc := func() {
-		ldapConfig.configureOrgLdap()
-	}
-
-	// Remove LDAP settings at the end of test
-	defer func() {
-		if ldapConfig.org != nil && ldapConfig.org.AdminOrg != nil {
-			fmt.Printf("# Removing LDAP settings for Org '%s'\n", ldapConfig.org.AdminOrg.Name)
-			err := ldapConfig.org.LdapDisable()
-			if err != nil {
-				ldapConfig.t.Errorf("error removing LDAP settings for Org '%s': %s", ldapConfig.org.AdminOrg.Name, err)
-			}
-		}
-	}()
 
 	// groupIdRegex is reused a few times in tests to match IDs
 	groupIdRegex := regexp.MustCompile(`^urn:vcloud:group:`)
-
+	ldapResourceDef := "vcd_org_ldap." + testConfig.VCD.Org
+	// Note: don't run this test in parallel, as it would clash with TestAccVcdOrgLdap
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testAccCheckVcdGroupDestroy("admin_staff"),
 			testAccCheckVcdGroupDestroy("ship_crew"),
+			testAccCheckOrgLdapDestroy(ldapResourceDef),
 		),
 		// CheckDestroy: testAccCheckVcdGroupDestroy(params["GroupName"].(string)),
 		Steps: []resource.TestStep{
-			// Step 0 - sets up direct network, vApp and VM with LDAP server and captures NIC 0 IP
-			// so that before step 1 LDAP can be configured (using TestStep.PreConfig)
+			// Step 0 - uses an existing LDAP server to set up the identity provider
 			{
-				PreConfig: func() { fmt.Println("# Setting up LDAP server") },
-				Config:    ldapSetupConfig,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("vcd_network_direct.net", "id"),
-					resource.TestCheckResourceAttrSet("vcd_vapp.ldap-server", "id"),
-					resource.TestCheckResourceAttrSet("vcd_vapp_org_network.direct-net", "id"),
-					resource.TestCheckResourceAttrSet("vcd_vapp_vm.ldap-container", "id"),
-					nic0Ip.cacheTestResourceFieldValue("vcd_vapp_vm.ldap-container", "network.0.ip"),
+				Config: ldapSetupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgLdapExists(ldapResourceDef),
+					resource.TestCheckResourceAttr(ldapResourceDef, "name", testConfig.VCD.Org),
+					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.connector_type", "OPEN_LDAP"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.object_class", "inetOrgPerson"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.group_attributes.0.object_class", "group"),
 				),
 			},
 			{
-				// Step 1 - the configureLdapFunc has all required variables stored to perform LDAP
-				// configuration on Org defined in testing config after testing LDAP server was
-				// configured in Step0. `Config` is the same as for step 0
-				PreConfig: configureLdapFunc,
-				// ldapSetupConfig is still used in Config so that Terraform does not destroy LDAP
-				// server built in Step 0
-				Config: ldapSetupConfig + groupConfigText,
+				// Step 1 - tests org group and users
+				Config: groupConfigText,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_org_group.group1", "id", groupIdRegex),
 					resource.TestCheckResourceAttr("vcd_org_group.group1", "name", "ship_crew"),
@@ -165,9 +110,8 @@ func TestAccVcdOrgGroup(t *testing.T) {
 				),
 			},
 			{
-				// ldapSetupConfig is still used in Config so that Terraform does not destroy LDAP
-				// server built in Step 0
-				Config: ldapSetupConfig + groupConfigText2,
+				// Step 2 - tests org group and users
+				Config: groupConfigText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_org_group.group1", "id", groupIdRegex),
 					resource.TestCheckResourceAttr("vcd_org_group.group1", "name", "ship_crew"),
@@ -183,7 +127,7 @@ func TestAccVcdOrgGroup(t *testing.T) {
 				),
 			},
 			{
-				Config: ldapSetupConfig + groupConfigText2 + testAccVcdOrgGroupDS, // Datasource check
+				Config: groupConfigText2 + testAccVcdOrgGroupDS, // Datasource check
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual("data.vcd_org_group.sourced_group1", "vcd_org_group.group1", nil),
 					resourceFieldsEqual("data.vcd_org_group.sourced_group2", "vcd_org_group.group2", nil),
@@ -226,6 +170,9 @@ resource "vcd_org_group" "group1" {
   name          = "ship_crew"
   role          = "{{.RoleName}}"
   description   = "{{.Description}}"
+  depends_on = [
+    vcd_org_ldap.{{.OrgName}}
+  ]
 }
 
 resource "vcd_org_group" "group2" {
@@ -233,6 +180,9 @@ resource "vcd_org_group" "group2" {
   name          = "admin_staff"
   role          = "{{.RoleName}}"
   description   = "{{.Description}}"
+  depends_on = [
+    vcd_org_ldap.{{.OrgName}}
+  ]
 }
 
 resource "vcd_org_user" "user1" {
@@ -244,53 +194,6 @@ resource "vcd_org_user" "user1" {
   depends_on = [
     vcd_org_group.group1,
   ]
-}
-`
-
-const ldapSetup = `
-resource "vcd_network_direct" "net" {
-  name             = "TestAccVcdOrgGroup"
-  external_network = "{{.ExternalNetwork}}"
-}
-
-resource "vcd_vapp" "ldap-server" {
-  name = "ldap-server"
-}
-
-resource "vcd_vapp_org_network" "direct-net" {
-  vapp_name        = vcd_vapp.ldap-server.name
-  org_network_name = vcd_network_direct.net.name
-}
-
-resource "vcd_vapp_vm" "ldap-container" {
-  vapp_name     = vcd_vapp.ldap-server.name
-  name          = "ldap-host"
-  catalog_name  = "{{.CatalogName}}"
-  template_name = "{{.GuestImage}}"
-  memory        = 1024
-  cpus          = 2
-  cpu_cores     = 1
-
-  customization {
-    initscript = <<-EOT
-		{
-			until ip a show eth0 | grep "inet "
-			do
-				sleep 1
-			done
-			systemctl enable docker
-			systemctl start docker
-			docker run --name ldap-server --restart=always -d -p 389:10389 rroemhild/test-openldap
-		} &
-		EOT
-  }
-
-  network {
-    type               = "org"
-    name               = vcd_vapp_org_network.direct-net.org_network_name
-    ip_allocation_mode = "POOL"
-    is_primary         = true
-  }
 }
 `
 
@@ -309,129 +212,3 @@ data "vcd_org_user" "sourced_user1" {
   name = "fry"
 }
 `
-
-// getLdapSetupTemplate
-func getLdapSetupTemplate(templateText string, params interface{}) (string, error) {
-	var ldapSetupCfg bytes.Buffer
-	tmpl, err := template.New("test").Parse(templateText)
-	if err != nil {
-		panic(err)
-	}
-	err = tmpl.Execute(&ldapSetupCfg, params)
-	if err != nil {
-		return "", err
-	}
-
-	return ldapSetupCfg.String(), nil
-}
-
-// isTcpPortOpen checks if remote TCP port is open or closed every 8 seconds until timeout is
-// reached
-func isTcpPortOpen(host, port string, timeout int) bool {
-	retryTimeout := timeout
-	// due to the VMs taking long time to boot it needs to be at least 5 minutes
-	// may be even more in slower environments
-	if timeout < 5*60 { // 5 minutes
-		retryTimeout = 5 * 60 // 5 minutes
-	}
-	timeOutAfterInterval := time.Duration(retryTimeout) * time.Second
-	timeoutAfter := time.After(timeOutAfterInterval)
-	tick := time.NewTicker(time.Duration(8) * time.Second)
-
-	for {
-		select {
-		case <-timeoutAfter:
-			fmt.Printf(" Failed\n")
-			return false
-		case <-tick.C:
-			timeout := time.Second * 3
-			conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), timeout)
-			if err != nil {
-				fmt.Printf(".")
-			}
-			// Connection established - the port is open
-			if conn != nil {
-				defer conn.Close()
-				fmt.Printf(" Done\n")
-				return true
-			}
-		}
-	}
-}
-
-// ldapConfigurator is a struct holding required data to ease go-vcloud-director SDK operation
-// integration with Terraform acceptance test framework. It allows to use *testing.T inside some
-// Terraform acceptance functions which accept only functions with no parameters (such as
-// "PreConfig)
-type ldapConfigurator struct {
-	t         *testing.T
-	vcdClient *VCDClient
-	org       *govcd.AdminOrg
-	nic0Ip    *testCachedFieldValue
-}
-
-// configureOrgLdap checks that LDAP TCP port 389 is open for ldapConfigurator.nic0Ip and then
-// configures vCD Org to use that LDAP server
-func (l *ldapConfigurator) configureOrgLdap() {
-	var err error
-	// Step 0 - collect needed connections
-	l.vcdClient = createTemporaryVCDConnection(false)
-	l.org, err = l.vcdClient.GetAdminOrgByName(testConfig.VCD.Org)
-	if err != nil {
-		l.t.Errorf("could not get Org '%s': %s", testConfig.VCD.Org, err)
-	}
-
-	// Step 1 - ensure LDAP is already UP and serving connections on TCP 389
-	fmt.Printf("# Waiting until LDAP responds on %s:389 :", l.nic0Ip.fieldValue)
-	isPortOpen := isTcpPortOpen(l.nic0Ip.fieldValue, "389", testConfig.Provider.MaxRetryTimeout)
-	if !isPortOpen {
-		l.t.Error("error waiting for LDAP to respond")
-	}
-
-	// Step 2 - configure LDAP
-	l.orgConfigureLdap(l.nic0Ip.fieldValue)
-}
-
-func (l *ldapConfigurator) orgConfigureLdap(ldapServerIp string) {
-	fmt.Printf("# Configuring LDAP settings for Org '%s'", l.org.AdminOrg.Name)
-
-	// The below settings are tailored for LDAP docker testing image
-	// https://github.com/rroemhild/docker-test-openldap
-	ldapSettings := &types.OrgLdapSettingsType{
-		OrgLdapMode: types.LdapModeCustom,
-		CustomOrgLdapSettings: &types.CustomOrgLdapSettings{
-			HostName:                ldapServerIp,
-			Port:                    389,
-			SearchBase:              "dc=planetexpress,dc=com",
-			AuthenticationMechanism: "SIMPLE",
-			ConnectorType:           "OPEN_LDAP",
-			Username:                "cn=admin,dc=planetexpress,dc=com",
-			Password:                "GoodNewsEveryone",
-			UserAttributes: &types.OrgLdapUserAttributes{
-				ObjectClass:               "inetOrgPerson",
-				ObjectIdentifier:          "uid",
-				Username:                  "uid",
-				Email:                     "mail",
-				FullName:                  "cn",
-				GivenName:                 "givenName",
-				Surname:                   "sn",
-				Telephone:                 "telephoneNumber",
-				GroupMembershipIdentifier: "dn",
-			},
-			GroupAttributes: &types.OrgLdapGroupAttributes{
-				ObjectClass:          "group",
-				ObjectIdentifier:     "cn",
-				GroupName:            "cn",
-				Membership:           "member",
-				MembershipIdentifier: "dn",
-			},
-		},
-	}
-
-	_, err := l.org.LdapConfigure(ldapSettings)
-	if err != nil {
-		fmt.Println(" Failed")
-		l.t.Errorf("failed configuring LDAP for Org '%s': %s", testConfig.VCD.Org, err)
-	}
-	fmt.Println(" Done")
-}

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -87,7 +87,7 @@ func TestAccVcdOrgGroup(t *testing.T) {
 				Config: ldapSetupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrgLdapExists(ldapResourceDef),
-					resource.TestCheckResourceAttr(ldapResourceDef, "name", testConfig.VCD.Org),
+					resource.TestCheckResourceAttr(ldapResourceDef, "org_name", testConfig.VCD.Org),
 					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -25,7 +25,6 @@ func TestAccVcdOrgGroup(t *testing.T) {
 		return
 	}
 	skipTestForApiToken(t)
-	// LDAP is being configured using go-vcloud-director - binary test cannot be run
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -65,6 +64,10 @@ func TestAccVcdOrgGroup(t *testing.T) {
 	params["Description"] = "Description2"
 	groupConfigText2 := templateFill(testAccOrgLdap+testAccOrgGroup, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", groupConfigText2)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	// groupIdRegex is reused a few times in tests to match IDs
 	groupIdRegex := regexp.MustCompile(`^urn:vcloud:group:`)

--- a/vcd/resource_vcd_org_ldap.go
+++ b/vcd/resource_vcd_org_ldap.go
@@ -1,0 +1,312 @@
+package vcd
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+// resourceLdapUserAttributes defines the elements of types.OrgLdapUserAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+var resourceLdapUserAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "Custom user settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP objectClass of which imported users are members. For example, user or person",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use as the unique identifier for a user. For example, objectGuid",
+			},
+			"user_name": { // Username
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName",
+			},
+			"email": { // Email
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's email address. For example, mail",
+			},
+			"full_name": { // FullName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's full name. For example, displayName",
+			},
+			"given_name": { // GivenName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's given name. For example, givenName",
+			},
+			"surname": { // Surname
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's surname. For example, sn",
+			},
+			"telephone": { // Telephone
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the user's telephone number. For example, telephoneNumber",
+			},
+			"group_membership_identifier": { // GroupMembershipIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute that identifies a user as a member of a group. For example, dn",
+			},
+			"group_back_link_identifier": { // GroupBackLinkIdentifier
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "LDAP attribute that returns the identifiers of all the groups of which the user is a member",
+			},
+		},
+	},
+}
+
+// resourceLdapGroupAttributes defines the elements of types.OrgLdapGroupAttributes
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+var resourceLdapGroupAttributes = &schema.Schema{
+	Type:        schema.TypeList,
+	Required:    true,
+	MaxItems:    1,
+	Description: "Custom group settings when `ldap_mode` is CUSTOM",
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"object_class": { // ObjectClass
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP objectClass of which imported groups are members. For example, group",
+			},
+			"unique_identifier": { // ObjectIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use as the unique identifier for a group. For example, objectGuid",
+			},
+			"name": { // GroupName
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use for the group name. For example, cn",
+			},
+			"membership": { // Membership
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute to use when getting the members of a group. For example, member",
+			},
+			"group_membership_identifier": { // MembershipIdentifier
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "LDAP attribute that identifies a group as a member of another group. For example, dn",
+			},
+			"group_back_link_identifier": { // BackLinkIdentifier
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "LDAP group attribute used to identify a group member",
+			},
+		},
+	},
+}
+
+// resourceVcdOrgLdap defines types.OrgLdapSettingsType
+// The field names are the ones used in the GUI, with a comment to indicate which API field each one corresponds to
+func resourceVcdOrgLdap() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   resourceVcdOrgLdapRead,
+		CreateContext: resourceVcdOrgLdapCreate,
+		UpdateContext: resourceVcdOrgLdapUpdate,
+		DeleteContext: resourceVcdOrgLdapDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Organization name",
+			},
+			"ldap_mode": { // OrgLdapMode
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
+				ValidateFunc: validation.StringInSlice([]string{types.LdapModeNone, types.LdapModeSystem, types.LdapModeCustom}, false),
+			},
+			"custom_settings": { // CustomOrgLdapSettings
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Custom settings when `ldap_mode` is CUSTOM",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server": { // HostName
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "host name or IP of the LDAP server",
+						},
+						"port": { // Port
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: "Port number for LDAP service",
+						},
+						"authentication_method": { // AuthenticationMechanism
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "authentication method: one of SIMPLE, MD5DIGEST, NTLM",
+							ValidateFunc: validation.StringInSlice([]string{"SIMPLE", "MD5DIGEST", "NTLM"}, false),
+						},
+						"connector_type": { // ConnectorType
+							Type:         schema.TypeString,
+							Required:     true,
+							Description:  "type of connector: one of OPEN_LDAP, ACTIVE_DIRECTORY",
+							ValidateFunc: validation.StringInSlice([]string{"OPEN_LDAP", "ACTIVE_DIRECTORY"}, false),
+						},
+						"base_distinguished_name": { //SearchBase
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "LDAP search base",
+						},
+						"is_ssl": { // IsSsl
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "True if the LDAP service requires an SSL connection",
+						},
+						"username": { // Username
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Username to use when logging in to LDAP, specified using LDAP attribute=value pairs (for example: cn="ldap-admin", c="example", dc="com")`,
+						},
+						"password": { // Password
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `Password for the user identified by UserName. This value is never returned by GET. It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed`,
+						},
+						"user_attributes":  resourceLdapUserAttributes,  // CustomOrgLdapSettings.UserAttributes
+						"group_attributes": resourceLdapGroupAttributes, // CustomOrgLdapSettings.GroupAttributes
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceVcdOrgLdapCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("name").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
+	if err != nil {
+		return diag.Errorf("[Org LDAP read] error searching for Org %s: %s", orgName, err)
+	}
+
+	var settings types.OrgLdapSettingsType
+	newSettings, err := adminOrg.LdapConfigure(&settings)
+	if err != nil {
+		return diag.Errorf("[Org LDAP create] error setting org '%s' LDAP configuration: %s", orgName, err)
+	}
+	err = validateLdapSettings(&settings, newSettings)
+	if err != nil {
+		return diag.Errorf("[Org LDAP create] error validating LDAP settings: %s", err)
+	}
+	return resourceVcdOrgLdapRead(ctx, d, meta)
+}
+
+func resourceVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcdOrgLdapRead(ctx, d, meta, "resource")
+}
+
+func genericVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("name").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
+	if govcd.IsNotFound(err) && origin == "resource" {
+		log.Printf("[INFO] unable to find Organization %s LDAP settings: %s. Removing from state", orgName, err)
+		d.SetId("")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("unable to find organization %s: %s", orgName, err)
+	}
+
+	config, err := adminOrg.GetLdapConfiguration()
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("[Org LDAP read] error getting LDAP settings for Org %s: %s", orgName, err)
+	}
+
+	dSet(d, "name", orgName)
+	dSet(d, "ldap_mode", config.OrgLdapMode)
+	d.SetId(adminOrg.AdminOrg.ID)
+
+	if config.OrgLdapMode == "CUSTOM" {
+		customSettings := map[string]interface{}{
+			"server":                  config.CustomOrgLdapSettings.HostName,
+			"port":                    config.CustomOrgLdapSettings.Port,
+			"authentication_method":   config.CustomOrgLdapSettings.AuthenticationMechanism,
+			"connector_type":          config.CustomOrgLdapSettings.ConnectorType,
+			"base_distinguished_name": config.CustomOrgLdapSettings.SearchBase,
+			"is_ssl":                  config.CustomOrgLdapSettings.IsSsl,
+			"username":                config.CustomOrgLdapSettings.Username,
+			"password":                config.CustomOrgLdapSettings.Password,
+			"user_attributes": []map[string]interface{}{
+				{
+					"object_class":                config.CustomOrgLdapSettings.UserAttributes.ObjectClass,
+					"unique_identifier":           config.CustomOrgLdapSettings.UserAttributes.ObjectIdentifier,
+					"user_name":                   config.CustomOrgLdapSettings.UserAttributes.Username,
+					"email":                       config.CustomOrgLdapSettings.UserAttributes.Email,
+					"full_name":                   config.CustomOrgLdapSettings.UserAttributes.FullName,
+					"given_name":                  config.CustomOrgLdapSettings.UserAttributes.GivenName,
+					"surname":                     config.CustomOrgLdapSettings.UserAttributes.Surname,
+					"telephone":                   config.CustomOrgLdapSettings.UserAttributes.Telephone,
+					"group_membership_identifier": config.CustomOrgLdapSettings.UserAttributes.GroupMembershipIdentifier,
+					"group_back_link_identifier":  config.CustomOrgLdapSettings.UserAttributes.GroupBackLinkIdentifier,
+				},
+			},
+			"group_attributes": []map[string]interface{}{
+				{
+					"object_class":                config.CustomOrgLdapSettings.GroupAttributes.ObjectClass,
+					"unique_identifier":           config.CustomOrgLdapSettings.GroupAttributes.ObjectIdentifier,
+					"name":                        config.CustomOrgLdapSettings.GroupAttributes.GroupName,
+					"membership":                  config.CustomOrgLdapSettings.GroupAttributes.Membership,
+					"group_membership_identifier": config.CustomOrgLdapSettings.GroupAttributes.MembershipIdentifier,
+					"group_back_link_identifier":  config.CustomOrgLdapSettings.GroupAttributes.BackLinkIdentifier,
+				},
+			},
+		}
+		err = d.Set("custom_settings", []map[string]interface{}{customSettings})
+		if err != nil {
+			return diag.Errorf("[Org LDAP read] error setting 'user_attributes' field: %s", err)
+		}
+	}
+	return nil
+}
+
+func resourceVcdOrgLdapUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return diag.Errorf("[Org LDAP update] function not yet implemented")
+}
+
+func resourceVcdOrgLdapDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("name").(string)
+
+	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
+	if err != nil {
+		return diag.Errorf("[Org LDAP delete] error searching for Org %s: %s", orgName, err)
+	}
+	return diag.FromErr(adminOrg.LdapDisable())
+}
+
+func validateLdapSettings(wantedSettings, retrievedSettings *types.OrgLdapSettingsType) error {
+
+	return nil
+}

--- a/vcd/resource_vcd_org_ldap.go
+++ b/vcd/resource_vcd_org_ldap.go
@@ -130,7 +130,7 @@ func resourceVcdOrgLdap() *schema.Resource {
 			StateContext: resourceVcdOrgLdapImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": {
+			"org_name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -209,7 +209,7 @@ func resourceVcdOrgLdapCreateOrUpdate(ctx context.Context, d *schema.ResourceDat
 	if !vcdClient.Client.IsSysAdmin {
 		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
 	}
-	orgName := d.Get("name").(string)
+	orgName := d.Get("org_name").(string)
 
 	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
 	if err != nil {
@@ -240,7 +240,7 @@ func genericVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta int
 	if !vcdClient.Client.IsSysAdmin {
 		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
 	}
-	orgName := d.Get("name").(string)
+	orgName := d.Get("org_name").(string)
 
 	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
 	if govcd.IsNotFound(err) && origin == "resource" {
@@ -259,7 +259,7 @@ func genericVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.Errorf("[Org LDAP read %s] error getting LDAP settings for Org %s: %s", origin, orgName, err)
 	}
 
-	dSet(d, "name", orgName)
+	dSet(d, "org_name", orgName)
 	dSet(d, "ldap_mode", config.OrgLdapMode)
 	d.SetId(adminOrg.AdminOrg.ID)
 
@@ -316,7 +316,7 @@ func resourceVcdOrgLdapDelete(ctx context.Context, d *schema.ResourceData, meta 
 	if !vcdClient.Client.IsSysAdmin {
 		return diag.Errorf("resource vcd_org_ldap requires System administrator privileges")
 	}
-	orgName := d.Get("name").(string)
+	orgName := d.Get("org_name").(string)
 
 	adminOrg, err := vcdClient.GetAdminOrgByName(orgName)
 	if err != nil {
@@ -413,7 +413,7 @@ func resourceVcdOrgLdapImport(_ context.Context, d *schema.ResourceData, meta in
 		return nil, fmt.Errorf(errorRetrievingOrg, err)
 	}
 
-	dSet(d, "name", adminOrg.AdminOrg.Name)
+	dSet(d, "org_name", adminOrg.AdminOrg.Name)
 
 	d.SetId(adminOrg.AdminOrg.ID)
 	return []*schema.ResourceData{d}, nil

--- a/vcd/resource_vcd_org_ldap.go
+++ b/vcd/resource_vcd_org_ldap.go
@@ -41,7 +41,7 @@ var resourceLdapUserAttributes = &schema.Schema{
 				Required:    true,
 				Description: "LDAP attribute to use for the user's email address. For example, mail",
 			},
-			"full_name": { // FullName
+			"display_name": { // FullName
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "LDAP attribute to use for the user's full name. For example, displayName",
@@ -280,7 +280,7 @@ func genericVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta int
 					"unique_identifier":           config.CustomOrgLdapSettings.UserAttributes.ObjectIdentifier,
 					"username":                    config.CustomOrgLdapSettings.UserAttributes.Username,
 					"email":                       config.CustomOrgLdapSettings.UserAttributes.Email,
-					"full_name":                   config.CustomOrgLdapSettings.UserAttributes.FullName,
+					"display_name":                config.CustomOrgLdapSettings.UserAttributes.FullName,
 					"given_name":                  config.CustomOrgLdapSettings.UserAttributes.GivenName,
 					"surname":                     config.CustomOrgLdapSettings.UserAttributes.Surname,
 					"telephone":                   config.CustomOrgLdapSettings.UserAttributes.Telephone,
@@ -378,7 +378,7 @@ func fillLdapSettings(d *schema.ResourceData) (*types.OrgLdapSettingsType, error
 		ObjectIdentifier:          userAttributesMap["unique_identifier"].(string),
 		Username:                  userAttributesMap["username"].(string),
 		Email:                     userAttributesMap["email"].(string),
-		FullName:                  userAttributesMap["full_name"].(string),
+		FullName:                  userAttributesMap["display_name"].(string),
 		GivenName:                 userAttributesMap["given_name"].(string),
 		Surname:                   userAttributesMap["surname"].(string),
 		Telephone:                 userAttributesMap["telephone"].(string),

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -1,0 +1,169 @@
+//go:build ldap || org || ALL || functional
+// +build ldap org ALL functional
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func init() {
+	testingTags["ldap"] = "resource_vcd_org_ldap_test.go"
+}
+
+func TestAccVcdOrgLdap(t *testing.T) {
+	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skip("TestAccVcdOrgLdap requires system admin privileges")
+		return
+	}
+	if testConfig.Networking.LdapServer == "" {
+		t.Skip("TestAccVcdOrgLdap requires a working LDAP server (set the IP in testConfig.Networking.LdapServer)")
+		return
+	}
+	var orgName = testConfig.VCD.Org
+
+	var params = StringMap{
+		"OrgName":      orgName,
+		"LdapServerIp": testConfig.Networking.LdapServer,
+		"Tags":         "ldap org",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccOrgLdap, params)
+
+	params["FuncName"] = t.Name()
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+
+	resourceDef := "vcd_org_ldap." + orgName
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckOrgLdapDestroy(resourceDef),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckOrgLdapExists(resourceDef),
+					resource.TestCheckResourceAttr(resourceDef, "name", orgName),
+					resource.TestCheckResourceAttr(resourceDef, "ldap_mode", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
+					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
+					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.connector_type", "OPEN_LDAP"),
+					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.user_attributes.0.object_class", "inetOrgPerson"),
+					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.group_attributes.0.object_class", "group"),
+				),
+			},
+			{
+				ResourceName:      resourceDef,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdTopHierarchy(orgName),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+func testAccCheckOrgLdapExists(identifier string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[identifier]
+		if !ok {
+			return fmt.Errorf("not found: %s", identifier)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Org ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		adminOrg, err := conn.GetAdminOrgById(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		config, err := adminOrg.GetLdapConfiguration()
+		if err != nil {
+			return err
+		}
+		if config.OrgLdapMode == "NONE" {
+			return fmt.Errorf("resource %s not configured", identifier)
+		}
+		return nil
+	}
+}
+
+func testAccCheckOrgLdapDestroy(identifier string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[identifier]
+		if !ok {
+			return fmt.Errorf("not found: %s", identifier)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no Org ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		adminOrg, err := conn.GetAdminOrgById(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		config, err := adminOrg.GetLdapConfiguration()
+		if err != nil {
+			return err
+		}
+		if config.OrgLdapMode != "NONE" {
+			return fmt.Errorf("resource %s still configured", identifier)
+		}
+		return nil
+
+	}
+}
+
+const testAccOrgLdap = `
+resource "vcd_org_ldap" "{{.OrgName}}" {
+  name      = "{{.OrgName}}"
+  ldap_mode = "CUSTOM"
+  custom_settings {
+    server                  = "{{.LdapServerIp}}"
+    port                    = 389
+    is_ssl                  = false
+    username                = "cn=admin,dc=planetexpress,dc=com"
+    password                = "GoodNewsEveryone"
+    authentication_method   = "SIMPLE"
+    base_distinguished_name = "dc=planetexpress,dc=com"
+    connector_type          = "OPEN_LDAP"
+    user_attributes {
+      object_class                = "inetOrgPerson"
+      unique_identifier           = "uid"
+      full_name                   = "cn"
+      username                    = "uid"
+      given_name                  = "givenName"
+      surname                     = "sn"
+      telephone                   = "telephoneNumber"
+      group_membership_identifier = "dn"
+      email                       = "mail"
+    }
+    group_attributes {
+      name                        = "cn"
+      object_class                = "group"
+      membership                  = "member"
+      unique_identifier           = "cn"
+      group_membership_identifier = "dn"
+    }
+  }
+  lifecycle {
+    # password value does not get returned by GET
+    ignore_changes = [custom_settings[0].password]
+  }
+}
+`

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -57,7 +57,7 @@ func TestAccVcdOrgLdap(t *testing.T) {
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrgLdapExists(ldapResourceDef),
-					resource.TestCheckResourceAttr(ldapResourceDef, "name", orgName),
+					resource.TestCheckResourceAttr(ldapResourceDef, "org_name", orgName),
 					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
 					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
@@ -70,7 +70,7 @@ func TestAccVcdOrgLdap(t *testing.T) {
 				Config: configTextDS,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckOrgLdapExists(ldapResourceDef),
-					resource.TestCheckResourceAttrPair(ldapResourceDef, "name", ldapDatasourceDef, "name"),
+					resource.TestCheckResourceAttrPair(ldapResourceDef, "org_name", ldapDatasourceDef, "org_name"),
 					resource.TestCheckResourceAttrPair(ldapResourceDef, "ldap_mode", ldapDatasourceDef, "ldap_mode"),
 					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.server", ldapDatasourceDef, "custom_settings.0.server"),
 					resource.TestCheckResourceAttrPair(ldapResourceDef, "custom_settings.0.authentication_method", ldapDatasourceDef, "custom_settings.0.authentication_method"),
@@ -149,7 +149,7 @@ func testAccCheckOrgLdapDestroy(identifier string) resource.TestCheckFunc {
 
 const testAccOrgLdap = `
 resource "vcd_org_ldap" "{{.OrgName}}" {
-  name      = "{{.OrgName}}"
+  org_name      = "{{.OrgName}}"
   ldap_mode = "CUSTOM"
   custom_settings {
     server                  = "{{.LdapServerIp}}"
@@ -189,6 +189,6 @@ resource "vcd_org_ldap" "{{.OrgName}}" {
 const testAccOrgLdapDS = `
 # skip-binary-test: Terraform resource cannot have resource and datasource in the same file
 data "vcd_org_ldap" "{{.OrgName}}-DS" {
-  name = "{{.OrgName}}"
+  org_name = "{{.OrgName}}"
 }
 `

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -43,26 +43,27 @@ func TestAccVcdOrgLdap(t *testing.T) {
 	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 
-	resourceDef := "vcd_org_ldap." + orgName
+	ldapResourceDef := "vcd_org_ldap." + orgName
+	// Note: don't run this test in parallel, as it would clash with TestAccVcdOrgGroup
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckOrgLdapDestroy(resourceDef),
+		CheckDestroy:      testAccCheckOrgLdapDestroy(ldapResourceDef),
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckOrgLdapExists(resourceDef),
-					resource.TestCheckResourceAttr(resourceDef, "name", orgName),
-					resource.TestCheckResourceAttr(resourceDef, "ldap_mode", "CUSTOM"),
-					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
-					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
-					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.connector_type", "OPEN_LDAP"),
-					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.user_attributes.0.object_class", "inetOrgPerson"),
-					resource.TestCheckResourceAttr(resourceDef, "custom_settings.0.group_attributes.0.object_class", "group"),
+					testAccCheckOrgLdapExists(ldapResourceDef),
+					resource.TestCheckResourceAttr(ldapResourceDef, "name", orgName),
+					resource.TestCheckResourceAttr(ldapResourceDef, "ldap_mode", "CUSTOM"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.server", testConfig.Networking.LdapServer),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.authentication_method", "SIMPLE"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.connector_type", "OPEN_LDAP"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.user_attributes.0.object_class", "inetOrgPerson"),
+					resource.TestCheckResourceAttr(ldapResourceDef, "custom_settings.0.group_attributes.0.object_class", "group"),
 				),
 			},
 			{
-				ResourceName:      resourceDef,
+				ResourceName:      ldapResourceDef,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: importStateIdTopHierarchy(orgName),

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -163,7 +163,7 @@ resource "vcd_org_ldap" "{{.OrgName}}" {
     user_attributes {
       object_class                = "inetOrgPerson"
       unique_identifier           = "uid"
-      full_name                   = "cn"
+      display_name                = "cn"
       username                    = "uid"
       given_name                  = "givenName"
       surname                     = "sn"

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -1,5 +1,5 @@
-//go:build ldap || org || ALL || functional
-// +build ldap org ALL functional
+//go:build ldap || user || org || ALL || functional
+// +build ldap user org ALL functional
 
 package vcd
 

--- a/vcd/resource_vcd_org_user_test.go
+++ b/vcd/resource_vcd_org_user_test.go
@@ -1,5 +1,5 @@
-//go:build user || functional || ALL
-// +build user functional ALL
+//go:build user || ldap || functional || ALL
+// +build user ldap functional ALL
 
 package vcd
 

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -96,7 +96,7 @@
     "externalNetworkPortGroupType": "DV_PORTGROUP",
     "//": "This should be a LDAP server",
     "//": "configured according to docker testing image https://github.com/rroemhild/docker-test-openldap",
-    "ldap_server": "IP-of-test-LDAP-server"
+    "ldapServer": "IP-of-test-LDAP-server"
   },
   "nsxt": {
     "//": "NSX-T manager name to be used as defined in VCD",

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -93,7 +93,10 @@
     },
     "vcenter" : "vC1",
     "externalNetworkPortGroup": "ForTestingPG",
-    "externalNetworkPortGroupType": "DV_PORTGROUP"
+    "externalNetworkPortGroupType": "DV_PORTGROUP",
+    "//": "This should be a LDAP server",
+    "//": "configured according to docker testing image https://github.com/rroemhild/docker-test-openldap",
+    "ldap_server": "IP-of-test-LDAP-server"
   },
   "nsxt": {
     "//": "NSX-T manager name to be used as defined in VCD",

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -146,11 +146,6 @@
     "//": "'mediaName' media is stored in NSX-V VDC backed storage profile while 'nsxtBackedMediaName' is stored in NSX-T VDC Backed storage profile",
     "nsxtBackedMediaName": "media-name-in-nsxt-backed-catalog"
   },
-  "misc": {
-    "//": "ldapContainer can be used to pull default LDAP testing container 'rroemhild/test-openldap' from a local",
-    "//": "Docker registry. This can help to overcome Docker registry throttling",
-    "ldapContainer": ""
-  },
   "certificates": {
     "//": "relative path to pem file",
     "certificate1Path": "../test-resources/cert.pem",

--- a/vcd/testcheck_funcs_test.go
+++ b/vcd/testcheck_funcs_test.go
@@ -1,5 +1,5 @@
-//go:build vapp || vm || user || nsxt || extnetwork || network || gateway || catalog || standaloneVm || alb || vdcGroup || ALL || functional
-// +build vapp vm user nsxt extnetwork network gateway catalog standaloneVm alb vdcGroup ALL functional
+//go:build vapp || vm || user || nsxt || extnetwork || network || gateway || catalog || standaloneVm || alb || vdcGroup || ldap || ALL || functional
+// +build vapp vm user nsxt extnetwork network gateway catalog standaloneVm alb vdcGroup ldap ALL functional
 
 package vcd
 

--- a/website/docs/d/org_ldap.html.markdown
+++ b/website/docs/d/org_ldap.html.markdown
@@ -16,7 +16,7 @@ Provides a data source to read LDAP configuration for an organization.
 
 ```hcl
 data "vcd_org_ldap" "first" {
-  name = "my-org"
+  org_name = "my-org"
 }
 ```
 
@@ -24,7 +24,7 @@ data "vcd_org_ldap" "first" {
 
 The following arguments are supported:
 
-* `name` - (Required)  - Name of the organization containing the LDAP settings
+* `org_name` - (Required)  - Name of the organization containing the LDAP settings
 
 ## Attribute Reference
 

--- a/website/docs/d/org_ldap.html.markdown
+++ b/website/docs/d/org_ldap.html.markdown
@@ -15,8 +15,12 @@ Provides a data source to read LDAP configuration for an organization.
 ## Example Usage
 
 ```hcl
+data "vcd_org" "my-org" {
+  name = "my-org"
+}
+
 data "vcd_org_ldap" "first" {
-  org_name = "my-org"
+  org_id = data.vcd_org.my-org.id
 }
 ```
 

--- a/website/docs/d/org_ldap.html.markdown
+++ b/website/docs/d/org_ldap.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "vcd"
 page_title: "VMware Cloud Director: vcd_org_ldap"
-sidebar_current: "docs-vcd-datasource-org-ldap"
+sidebar_current: "docs-vcd-data-source-org-ldap"
 description: |-
   Provides a data source to read LDAP configuration for an organization.
 ---

--- a/website/docs/d/org_ldap.html.markdown
+++ b/website/docs/d/org_ldap.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_org_ldap"
+sidebar_current: "docs-vcd-datasource-org-ldap"
+description: |-
+  Provides a data source to read LDAP configuration for an organization.
+---
+
+# vcd\_org\_ldap
+
+Supported in provider *v3.8+*.
+
+Provides a data source to read LDAP configuration for an organization.
+
+## Example Usage
+
+```hcl
+data "vcd_org_ldap" "first" {
+  name = "my-org"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required)  - Name of the organization containing the LDAP settings
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_org_ldap`](/providers/vmware/vcd/latest/docs/resources/org_ldap) resource are available.

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -12,6 +12,8 @@ Provides a VMware Cloud Director Org LDAP resource. This can be used to create, 
 
 Supported in provider *v3.8+*
 
+-> **Note:** This resource requires system administrator privileges.
+
 ## Example Usage
 
 ```hcl
@@ -117,7 +119,7 @@ For example, using this structure, representing an existing LDAP configuration t
 
 ```hcl
 resource "vcd_org_ldap" "my-org-ldap" {
-  name             = "my-org"
+  name = "my-org"
 }
 ```
 

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -66,14 +66,18 @@ resource "vcd_org_ldap" "my-org-ldap" {
 
 -> **Note** 
 The password value never gets returned by GET. Therefore, if we want `terraform plan` to return a clean state, we need
-to add the following `lifecycle` block at the end of the resource definition, after creating or updating it.
+to add a `lifecycle` block at the end of the resource definition, after creating or updating it.
 And we need to remove the `lifecycle` block _if we want to change the password_.
 
 ```hcl
+resource "vcd_org_ldap" "my-org-ldap" {
+  # all other fields
+  # ...
   lifecycle {
     # password value does not get returned by GET
     ignore_changes = [custom_settings[0].password]
   }
+}
 ```
 
 ## Argument Reference

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -108,6 +108,13 @@ The `custom_settings` section contains the configuration for the LDAP server
 <a id="group-attributes"></a>
 ### Group Attributes
 
+* `object_class` - (Required) LDAP objectClass of which imported groups are members. For example, group
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a group. For example, objectGuid
+* `name` - (Required) LDAP attribute to use for the group name. For example, cn
+* `membership` - (Required) LDAP attribute to use when getting the members of a group. For example, member
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a group as a member of another group. For example, dn
+* `group_back_link_identifier` - (Optional) LDAP group attribute used to identify a group member
+
 ## Importing
 
 ~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -57,11 +57,19 @@ resource "vcd_org_ldap" "my-org-ldap" {
       group_membership_identifier = "dn"
     }
   }
+}
+```
+
+-> **Note** 
+The password value never gets returned by GET. Therefore, if we want `terraform plan` to return a clean state, we need
+to add the following `lifecycle` block at the end of the resource definition, after creating or updating it.
+And we need to remove the `lifecycle` block _if we want to change the password_.
+
+```hcl
   lifecycle {
     # password value does not get returned by GET
     ignore_changes = [custom_settings[0].password]
   }
-}
 ```
 
 ## Argument Reference

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -95,40 +95,40 @@ The `custom_settings` section contains the configuration for the LDAP server
 
 * `server` - (Required) The IP address or host name of the server providing the LDAP service
 * `port` - (Required) Port number of the LDAP server (usually 389 for LDAP, 636 for LDAPS)
-* `authentication_method` - (Required) authentication method: one of `SIMPLE`, `MD5DIGEST`, `NTLM`
-* `connector_type` - (Required) type of connector: one of `OPEN_LDAP`, `ACTIVE_DIRECTORY`
+* `authentication_method` - (Required) Authentication method: one of `SIMPLE`, `MD5DIGEST`, `NTLM`
+* `connector_type` - (Required) Type of connector: one of `OPEN_LDAP`, `ACTIVE_DIRECTORY`
 * `base_distinguished_name` - (Required) LDAP search base
 * `is_ssl` - (Optional) True if the LDAP service requires an SSL connection
-* `username` - (Optional) Username to use when logging in to LDAP, specified using LDAP attribute=value pairs 
+* `username` - (Optional) _Username_ to use when logging in to LDAP, specified using LDAP attribute=value pairs 
   (for example: cn="ldap-admin", c="example", dc="com")
-* `password` - (Optional) Password for the user identified by UserName. This value is never returned by GET. 
+* `password` - (Optional) _Password_ for the user identified by UserName. This value is never returned by GET. 
    It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed
 
 * `user_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [User Attributes](#user-attributes) below for details
-* `group_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [Group Attributes](#group-attributes) below for details
+* `group_attributes` - (Required) Group settings when `ldap_mode` is `CUSTOM` See [Group Attributes](#group-attributes) below for details
 
 <a id="user-attributes"></a>
 ### User Attributes
 
-* `object_class` - (Required)  LDAP objectClass of which imported users are members. For example, user or person
-* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a user. For example, objectGuid
-* `username` - (Required) LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName
-* `email` - (Required) LDAP attribute to use for the user's email address. For example, mail
-* `display_name` - (Required) LDAP attribute to use for the user's full name. For example, displayName
-* `given_name` - (Required) LDAP attribute to use for the user's given name. For example, givenName
-* `surname` - (Required) LDAP attribute to use for the user's surname. For example, sn
-* `telephone` - (Required) LDAP attribute to use for the user's telephone number. For example, telephoneNumber
-* `group_membership_identifier` - (Required) LDAP attribute that identifies a user as a member of a group. For example, dn
+* `object_class` - (Required)  LDAP _objectClass_ of which imported users are members. For example, _user_ or _person_
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a user. For example, _objectGuid_
+* `username` - (Required) LDAP attribute to use when looking up a username to import. For example, _userPrincipalName_ or _samAccountName_
+* `email` - (Required) LDAP attribute to use for the user's email address. For example, _mail_
+* `display_name` - (Required) LDAP attribute to use for the user's full name. For example, _displayName_
+* `given_name` - (Required) LDAP attribute to use for the user's given name. For example, _givenName_
+* `surname` - (Required) LDAP attribute to use for the user's surname. For example, _sn_
+* `telephone` - (Required) LDAP attribute to use for the user's telephone number. For example, _telephoneNumber_
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a user as a member of a group. For example, _dn_
 * `group_back_link_identifier` - (Optional) LDAP attribute that returns the identifiers of all the groups of which the user is a member
 
 <a id="group-attributes"></a>
 ### Group Attributes
 
-* `object_class` - (Required) LDAP objectClass of which imported groups are members. For example, group
-* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a group. For example, objectGuid
-* `name` - (Required) LDAP attribute to use for the group name. For example, cn
-* `membership` - (Required) LDAP attribute to use when getting the members of a group. For example, member
-* `group_membership_identifier` - (Required) LDAP attribute that identifies a group as a member of another group. For example, dn
+* `object_class` - (Required) LDAP _objectClass_ of which imported groups are members. For example, _group_
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a group. For example, _objectGuid_
+* `name` - (Required) LDAP attribute to use for the group name. For example, _cn_
+* `membership` - (Required) LDAP attribute to use when getting the members of a group. For example, _member_
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a group as a member of another group. For example, _dn_
 * `group_back_link_identifier` - (Optional) LDAP group attribute used to identify a group member
 
 ## Importing

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -24,10 +24,14 @@ provider "vcd" {
   url      = "https://AcmeVcd/api"
 }
 
+data "vcd_org" "my-org" {
+  name = "my-org"
+}
+
 # The settings below (except the server IP) are taken from the LDAP docker testing image
 # https://github.com/rroemhild/docker-test-openldap
 resource "vcd_org_ldap" "my-org-ldap" {
-  org_name  = "my-org"
+  org_id    = data.vcd_org.my-org.id
   ldap_mode = "CUSTOM"
   custom_settings {
     server                  = "192.168.1.172"
@@ -76,7 +80,7 @@ And we need to remove the `lifecycle` block _if we want to change the password_.
 
 The following arguments are supported:
 
-* `org_name` - (Required) Org name: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
+* `org_id` - (Required) Org ID: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
 * `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
 * `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
 
@@ -133,15 +137,22 @@ at the top of the vCD hierarchy, the path corresponds to the Org name.
 For example, using this structure, representing an existing LDAP configuration that was **not** created using Terraform:
 
 ```hcl
+data "vcd_org" "my-org" {
+  name = "my-org"
+}
+
 resource "vcd_org_ldap" "my-org-ldap" {
-  org_name = "my-org"
+  org_id = data.vcd_org.my-org.id
 }
 ```
 
-You can import such LDAP configuration into terraform state using this command
+You can import such LDAP configuration into terraform state using one of the following commands
 
 ```
-terraform import vcd_org_ldap.my-org my-org
+# EITHER
+terraform import vcd_org_ldap.my-org-ldap organization_name
+# OR
+terraform import vcd_org_ldap.my-org-ldap organization_id
 ```
 
 After that, you must expand the configuration file before you can either update or delete the LDAP configuration. Running `terraform plan`

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a VMware Cloud Director Organization LDAP resource. This can be used to create, delete, and update LDAP configuration for an organization .
 ---
 
-# vcd\_org_ldap
+# vcd\_org\_ldap
 
 Provides a VMware Cloud Director Org LDAP resource. This can be used to create, update, and delete LDAP configuration for an organization.
 
@@ -27,7 +27,7 @@ provider "vcd" {
 # The settings below (except the server IP) are taken from the LDAP docker testing image
 # https://github.com/rroemhild/docker-test-openldap
 resource "vcd_org_ldap" "my-org-ldap" {
-  name      = "my-org"
+  org_name  = "my-org"
   ldap_mode = "CUSTOM"
   custom_settings {
     server                  = "192.168.1.172"
@@ -68,7 +68,7 @@ resource "vcd_org_ldap" "my-org-ldap" {
 
 The following arguments are supported:
 
-* `name` - (Required) Org name: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
+* `org_name` - (Required) Org name: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
 * `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
 * `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
 
@@ -119,7 +119,7 @@ For example, using this structure, representing an existing LDAP configuration t
 
 ```hcl
 resource "vcd_org_ldap" "my-org-ldap" {
-  name = "my-org"
+  org_name = "my-org"
 }
 ```
 

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -41,7 +41,7 @@ resource "vcd_org_ldap" "my-org-ldap" {
     user_attributes {
       object_class                = "inetOrgPerson"
       unique_identifier           = "uid"
-      full_name                   = "cn"
+      display_name                = "cn"
       username                    = "uid"
       given_name                  = "givenName"
       surname                     = "sn"
@@ -106,7 +106,7 @@ The `custom_settings` section contains the configuration for the LDAP server
 * `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a user. For example, objectGuid
 * `username` - (Required) LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName
 * `email` - (Required) LDAP attribute to use for the user's email address. For example, mail
-* `full_name` - (Required) LDAP attribute to use for the user's full name. For example, displayName
+* `display_name` - (Required) LDAP attribute to use for the user's full name. For example, displayName
 * `given_name` - (Required) LDAP attribute to use for the user's given name. For example, givenName
 * `surname` - (Required) LDAP attribute to use for the user's surname. For example, sn
 * `telephone` - (Required) LDAP attribute to use for the user's telephone number. For example, telephoneNumber

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -1,0 +1,131 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_org_ldap"
+sidebar_current: "docs-vcd-resource-org-ldap"
+description: |-
+  Provides a VMware Cloud Director Organization LDAP resource. This can be used to create, delete, and update LDAP configuration for an organization .
+---
+
+# vcd\_org_ldap
+
+Provides a VMware Cloud Director Org LDAP resource. This can be used to create, update, and delete LDAP configuration for an organization.
+
+Supported in provider *v3.8+*
+
+## Example Usage
+
+```hcl
+provider "vcd" {
+  user     = var.admin_user
+  password = var.admin_password
+  org      = "System"
+  url      = "https://AcmeVcd/api"
+}
+
+# The settings below (except the server IP) are taken from the LDAP docker testing image
+# https://github.com/rroemhild/docker-test-openldap
+resource "vcd_org_ldap" "my-org-ldap" {
+  name      = "my-org"
+  ldap_mode = "CUSTOM"
+  custom_settings {
+    server                  = "192.168.1.172"
+    port                    = 389
+    is_ssl                  = false
+    username                = "cn=admin,dc=planetexpress,dc=com"
+    password                = "GoodNewsEveryone"
+    authentication_method   = "SIMPLE"
+    base_distinguished_name = "dc=planetexpress,dc=com"
+    connector_type          = "OPEN_LDAP"
+    user_attributes {
+      object_class                = "inetOrgPerson"
+      unique_identifier           = "uid"
+      full_name                   = "cn"
+      username                    = "uid"
+      given_name                  = "givenName"
+      surname                     = "sn"
+      telephone                   = "telephoneNumber"
+      group_membership_identifier = "dn"
+      email                       = "mail"
+    }
+    group_attributes {
+      name                        = "cn"
+      object_class                = "group"
+      membership                  = "member"
+      unique_identifier           = "cn"
+      group_membership_identifier = "dn"
+    }
+  }
+  lifecycle {
+    # password value does not get returned by GET
+    ignore_changes = [custom_settings[0].password]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Org name: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
+* `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
+* `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
+
+<a id="custom-settings"></a>
+## Custom Settings
+
+The `custom_settings` section contains the configuration for the LDAP server
+
+* `server` - (Required) The IP address or host name of the server providing the LDAP service
+* `port` - (Required) Port number of the LDAP server (usually 389 for LDAP, 636 for LDAPS)
+* `authentication_method` - (Required) authentication method: one of `SIMPLE`, `MD5DIGEST`, `NTLM`
+* `connector_type` - (Required) type of connector: one of `OPEN_LDAP`, `ACTIVE_DIRECTORY`
+* `base_distinguished_name` - (Required) LDAP search base
+* `is_ssl` - (Optional) True if the LDAP service requires an SSL connection
+* `username` - (Optional) Username to use when logging in to LDAP, specified using LDAP attribute=value pairs 
+  (for example: cn="ldap-admin", c="example", dc="com")
+* `password` - (Optional) Password for the user identified by UserName. This value is never returned by GET. 
+   It is inspected on create and modify. On modify, the absence of this element indicates that the password should not be changed
+
+* `user_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [User Attributes](#user-attributes) below for details
+* `group_attributes` - (Required) User settings when `ldap_mode` is `CUSTOM` See [Group Attributes](#group-attributes) below for details
+
+<a id="user-attributes"></a>
+### User Attributes
+
+* `object_class` - (Required)  LDAP objectClass of which imported users are members. For example, user or person
+* `unique_identifier` - (Required) LDAP attribute to use as the unique identifier for a user. For example, objectGuid
+* `username` - (Required) LDAP attribute to use when looking up a user name to import. For example, userPrincipalName or samAccountName
+* `email` - (Required) LDAP attribute to use for the user's email address. For example, mail
+* `full_name` - (Required) LDAP attribute to use for the user's full name. For example, displayName
+* `given_name` - (Required) LDAP attribute to use for the user's given name. For example, givenName
+* `surname` - (Required) LDAP attribute to use for the user's surname. For example, sn
+* `telephone` - (Required) LDAP attribute to use for the user's telephone number. For example, telephoneNumber
+* `group_membership_identifier` - (Required) LDAP attribute that identifies a user as a member of a group. For example, dn
+* `group_back_link_identifier` - (Optional) LDAP attribute that returns the identifiers of all the groups of which the user is a member
+
+<a id="group-attributes"></a>
+### Group Attributes
+
+## Importing
+
+~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate
+configuration. [More information.][docs-import]
+
+An existing LDAP configuration for an Org can be [imported][docs-import] into this resource via supplying the path for an Org. Since the Org is
+at the top of the vCD hierarchy, the path corresponds to the Org name.
+For example, using this structure, representing an existing LDAP configuration that was **not** created using Terraform:
+
+```hcl
+resource "vcd_org_ldap" "my-org-ldap" {
+  name             = "my-org"
+}
+```
+
+You can import such LDAP configuration into terraform state using this command
+
+```
+terraform import vcd_org_ldap.my-org my-org
+```
+
+After that, you must expand the configuration file before you can either update or delete the LDAP configuration. Running `terraform plan`
+at this stage will show the difference between the minimal configuration file and the stored properties.

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -250,6 +250,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-edgegateway-bgp-configuration") %>>
               <a href="/docs/providers/vcd/d/nsxt_edgegateway_bgp_configuration.html">vcd_nsxt_edgegateway_bgp_configuration</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-org-ldap") %>>
+              <a href="/docs/providers/vcd/d/org_ldap.html">vcd_org_ldap</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -455,6 +458,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-edgegateway-bgp-configuration") %>>
               <a href="/docs/providers/vcd/r/nsxt_edgegateway_bgp_configuration.html">vcd_nsxt_edgegateway_bgp_configuration</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-org-ldap") %>>
+              <a href="/docs/providers/vcd/r/org_ldap.html">vcd_org_ldap</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Add data source and resource for Org LDAP settings

This resource `vcd_org_ldap` allows to create, update, and delete a LDAP identity provider in an organization.

This PR also changes the test `TestAccVcdOrgGroup` to use the new resource rather than creating and configuring its own LDAP server.
For the tests `TestAccVcdOrgGroup` and `TestAccVcdOrgLdap` to work, a LDAP server must already exist, configured as defined in the LDAP docker testing image https://github.com/rroemhild/docker-test-openldap

