### PR TITLE
Fix TestAccDataSourceNotFound/vcd_org_ldap

### DIFF
--- a/vcd/datasource_not_found_test.go
+++ b/vcd/datasource_not_found_test.go
@@ -143,6 +143,12 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			return templateFields
 		}
 
+		if dataSourceName == "vcd_org_ldap" && mandatoryFields[fieldIndex] == "org_id" {
+			// injecting fake Org ID
+			templateFields = templateFields + `org_id = "urn:vcloud:org:784feb3d-87e4-4905-202a-bfe9faa5476f"` + "\n"
+			return templateFields
+		}
+
 		// vcd_portgroup requires portgroup  type
 		if dataSourceName == "vcd_portgroup" && mandatoryFields[fieldIndex] == "type" {
 			templateFields = templateFields + `type = "` + testConfig.Networking.ExternalNetworkPortGroupType + `"` + "\n"


### PR DESCRIPTION
When changing from `org_name` to `org_id` I neglected to check the data source test, which requires a special treatment