### PR TITLE
Fix bug that causes Compute Policies to fail on VCD 10.3.0 and 10.3.1

### DIFF
--- a/.changes/v3.8.0/904-features.md
+++ b/.changes/v3.8.0/904-features.md
@@ -1,4 +1,4 @@
-* **New Resource:** `vcd_vm_placement_policy` that allows creating VM Placement Policies [GH-904]
-* **New Data Source:** `vcd_vm_placement_policy` that allows fetching existing VM Placement Policies [GH-904]
+* **New Resource:** `vcd_vm_placement_policy` that allows creating VM Placement Policies [GH-904], [GH-911]
+* **New Data Source:** `vcd_vm_placement_policy` that allows fetching existing VM Placement Policies [GH-904], [GH-911]
 * **New Data Source:** `vcd_provider_vdc` that allows fetching existing Provider VDCs [GH-904]
 * **New Data Source:** `vcd_vm_group` that allows fetching existing VM Groups, to be able to create VM Placement Policies [GH-904]

--- a/.changes/v3.8.0/904-improvements.md
+++ b/.changes/v3.8.0/904-improvements.md
@@ -1,4 +1,4 @@
 * Added `vm_placement_policy_ids` attribute to `vcd_org_vdc` resource and data source to assign existing
-  VM Placement Policies to VDCs [GH-904]
+  VM Placement Policies to VDCs [GH-904], [GH-911]
 * Added `default_compute_policy_id` attribute to `vcd_org_vdc` resource and data source to specify a default
-  VM Sizing Policy, VM Placement Policy or vGPU Policy for the VDC [GH-904]
+  VM Sizing Policy, VM Placement Policy or vGPU Policy for the VDC [GH-904], [GH-911]

--- a/go.mod
+++ b/go.mod
@@ -59,4 +59,4 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220906102404-20ad03790c56
+replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220928073049-f27fe7e7496a

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7 h1:YoJbenK9C6
 github.com/ProtonMail/go-crypto v0.0.0-20210428141323-04723f9f07d7/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
 github.com/acomagu/bufpipe v1.0.3 h1:fxAGrHZTgQ9w5QqVItgzwj235/uYZYgbXitB+dLupOk=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220906102404-20ad03790c56 h1:nDzQm8TXnuZ+GMUiSjiJ/tjOtivrxdr2CwhuqVhFIlc=
-github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220906102404-20ad03790c56/go.mod h1:VRA1ZLDf6CtL1atU1ceMj6/3h9HJg+zjBLaMNODF1qQ=
+github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220928073049-f27fe7e7496a h1:ZPYLW1zn8TDhBmP0AOyev4RNvBwocEha+MbhSvQVUbE=
+github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20220928073049-f27fe7e7496a/go.mod h1:VRA1ZLDf6CtL1atU1ceMj6/3h9HJg+zjBLaMNODF1qQ=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -440,7 +440,7 @@ func setOrgVdcData(d *schema.ResourceData, vcdClient *VCDClient, adminOrg *govcd
 	dSet(d, "default_compute_policy_id", adminVdc.AdminVdc.DefaultComputePolicy.ID)
 
 	assignedVmComputePolicies, err := adminVdc.GetAllAssignedVdcComputePoliciesV2(url.Values{
-		"filter": []string{fmt.Sprintf("%spolicyType==VdcVmPolicy", getVgpuFilterToPrepend(vcdClient,false))}, // Filtering out vGPU Policies as there's no attribute support yet.
+		"filter": []string{fmt.Sprintf("%spolicyType==VdcVmPolicy", getVgpuFilterToPrepend(vcdClient, false))}, // Filtering out vGPU Policies as there's no attribute support yet.
 	})
 	if err != nil {
 		log.Printf("[DEBUG] Unable to get assigned VM Compute policies")

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -976,7 +976,7 @@ func addAssignedComputePolicies(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf(errorRetrievingVdcFromOrg, d.Get("org").(string), d.Get("name").(string), err)
 	}
 
-	err = changeComputePoliciesAndDefaultId(d, nil, vcdComputePolicyHref.String(), vdc)
+	err = changeComputePoliciesAndDefaultId(d, vcdClient, vcdComputePolicyHref.String(), vdc)
 	if err != nil {
 		return err
 	}

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -453,8 +453,8 @@ func getVgpuFilterToPrepend(vcdClient *VCDClient, isVgpu bool) string {
 }
 
 // getFriendlyErrorIfVmPlacementPolicyAlreadyExists is intended to be used when a VM Placement Policy already exists and the provider
-// tries to create another one with the same name. When this happens, VCD discloses a lot of unnecessary information to the user,
-// so this function simplifies the message.
+// tries to create another one with the same name. When this happens, VCD discloses a lot of unnecessary information to the user that is
+// hard to read and understand, so this function simplifies the message.
 // Note: This function should not be needed anymore once VCD 10.4.0 is discontinued.
 func getFriendlyErrorIfVmPlacementPolicyAlreadyExists(vmPlacementPolicyName string, err error) error {
 	if err != nil && strings.Contains(err.Error(), "already exists") {

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -444,9 +444,10 @@ func setVmPlacementPolicy(_ context.Context, d *schema.ResourceData, vcdClient *
 // getVgpuFilterToPrepend gets a vGPU Policy filter set to `isVgpu` if API version of target VCD is greater than 36.2 (VCD 10.3.2).
 // The semicolon is placed to the right so the returned filter can be prepended to an existing one.
 // Returns an empty string otherwise.
+// Note: This function should be not used anymore once VCD 10.3.0 and 10.3.1 are discontinued.
 func getVgpuFilterToPrepend(vcdClient *VCDClient, isVgpu bool) string {
 	if vcdClient.Client.APIVCDMaxVersionIs(">= 36.2") {
-			return fmt.Sprintf("isVgpuPolicy==%s;", strconv.FormatBool(isVgpu))
+		return fmt.Sprintf("isVgpuPolicy==%s;", strconv.FormatBool(isVgpu))
 	}
 	return ""
 }

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -452,6 +452,18 @@ func getVgpuFilterToPrepend(vcdClient *VCDClient, isVgpu bool) string {
 	return ""
 }
 
+// getVgpuFilter gets a vGPU Policy filter set to `isVgpu` if API version of target VCD is greater than 36.2 (VCD 10.3.2).
+// The filter option is returned WITHOUT any semicolon.
+// Returns an empty string otherwise.
+// Note: This function should not be needed anymore once VCD 10.3.0 and 10.3.1 are discontinued.
+func getVgpuFilter(vcdClient *VCDClient, isVgpu bool) string {
+	vgpuFilterToPrepend := getVgpuFilterToPrepend(vcdClient, isVgpu)
+	if vgpuFilterToPrepend != "" {
+		return vgpuFilterToPrepend[:len(vgpuFilterToPrepend)-1] // Removes semicolon to the right
+	}
+	return ""
+}
+
 // getFriendlyErrorIfVmPlacementPolicyAlreadyExists is intended to be used when a VM Placement Policy already exists and the provider
 // tries to create another one with the same name. When this happens, VCD discloses a lot of unnecessary information to the user that is
 // hard to read and understand, so this function simplifies the message.

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -107,8 +107,8 @@ func resourceVmPlacementPolicyCreate(ctx context.Context, d *schema.ResourceData
 
 	createdVmSizingPolicy, err := vcdClient.CreateVdcComputePolicyV2(computePolicy)
 	if err != nil {
-		log.Printf("[DEBUG] Error creating VM Placement Policy: %s", getFriendlyErrorIfVmPlacementPolicyAlreadyExists(computePolicy.Name, err))
-		return diag.Errorf("error creating VM Placement Policy: %s", getFriendlyErrorIfVmPlacementPolicyAlreadyExists(computePolicy.Name, err))
+		log.Printf("[DEBUG] Error creating VM Placement Policy: %s", err)
+		return diag.Errorf("error creating VM Placement Policy: %s", err)
 	}
 
 	d.SetId(createdVmSizingPolicy.VdcComputePolicyV2.ID)
@@ -462,15 +462,4 @@ func getVgpuFilter(vcdClient *VCDClient, isVgpu bool) string {
 		return vgpuFilterToPrepend[:len(vgpuFilterToPrepend)-1] // Removes semicolon to the right
 	}
 	return ""
-}
-
-// getFriendlyErrorIfVmPlacementPolicyAlreadyExists is intended to be used when a VM Placement Policy already exists and the provider
-// tries to create another one with the same name. When this happens, VCD discloses a lot of unnecessary information to the user that is
-// hard to read and understand, so this function simplifies the message.
-// Note: This function should not be needed anymore once VCD 10.4.0 is discontinued.
-func getFriendlyErrorIfVmPlacementPolicyAlreadyExists(vmPlacementPolicyName string, err error) error {
-	if err != nil && strings.Contains(err.Error(), "already exists") {
-		return fmt.Errorf("VM Placement Policy with name '%s' already exists", vmPlacementPolicyName)
-	}
-	return err
 }

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -442,7 +442,7 @@ func setVmPlacementPolicy(_ context.Context, d *schema.ResourceData, vcdClient *
 }
 
 // getVgpuFilterToPrepend gets a vGPU Policy filter set to `isVgpu` if API version of target VCD is greater than 36.2 (VCD 10.3.2).
-// The semicolon is placed to the right so the returned filter can be prepended to an existing one.
+// The semicolon is placed to the right so the returned filter must be prepended to an existing one.
 // Returns an empty string otherwise.
 // Note: This function should not be needed anymore once VCD 10.3.0 and 10.3.1 are discontinued.
 func getVgpuFilterToPrepend(vcdClient *VCDClient, isVgpu bool) string {

--- a/vcd/resource_vcd_vm_placement_policy.go
+++ b/vcd/resource_vcd_vm_placement_policy.go
@@ -441,11 +441,11 @@ func setVmPlacementPolicy(_ context.Context, d *schema.ResourceData, vcdClient *
 	return nil
 }
 
-// getVgpuFilterToPrepend gets a vGPU Policy filter set to `isVgpu` if API version of target VCD is greater than 36.0.
+// getVgpuFilterToPrepend gets a vGPU Policy filter set to `isVgpu` if API version of target VCD is greater than 36.2 (VCD 10.3.2).
 // The semicolon is placed to the right so the returned filter can be prepended to an existing one.
 // Returns an empty string otherwise.
 func getVgpuFilterToPrepend(vcdClient *VCDClient, isVgpu bool) string {
-	if vcdClient.Client.APIVCDMaxVersionIs("> 36.0") {
+	if vcdClient.Client.APIVCDMaxVersionIs(">= 36.2") {
 			return fmt.Sprintf("isVgpuPolicy==%s;", strconv.FormatBool(isVgpu))
 	}
 	return ""

--- a/vcd/resource_vcd_vm_sizing_policy.go
+++ b/vcd/resource_vcd_vm_sizing_policy.go
@@ -574,10 +574,7 @@ func listComputePoliciesForImport(meta interface{}, origin, policyType string) (
 	case "placement":
 		filter += fmt.Sprintf("%sisSizingOnly==false", getVgpuFilterToPrepend(vcdClient, false))
 	case "vgpu":
-		vgpuFilterToPrepend := getVgpuFilterToPrepend(vcdClient, true)
-		if vgpuFilterToPrepend != "" {
-			filter += vgpuFilterToPrepend[:len(vgpuFilterToPrepend)-1] // Removes trailing semicolon to the right
-		}
+		filter += getVgpuFilter(vcdClient, true)
 	default:
 		return nil, fmt.Errorf("unrecognized type of policy to import: %s", policyType)
 	}

--- a/vcd/resource_vcd_vm_sizing_policy.go
+++ b/vcd/resource_vcd_vm_sizing_policy.go
@@ -572,9 +572,12 @@ func listComputePoliciesForImport(meta interface{}, origin, policyType string) (
 	case "sizing":
 		filter += "isSizingOnly==true"
 	case "placement":
-		filter += "isVgpuPolicy==false;isSizingOnly==false"
+		filter += fmt.Sprintf("%sisSizingOnly==false", getVgpuFilterToPrepend(vcdClient, false))
 	case "vgpu":
-		filter += "isVgpuPolicy==true"
+		vgpuFilterToPrepend := getVgpuFilterToPrepend(vcdClient, true)
+		if vgpuFilterToPrepend != "" {
+			filter += vgpuFilterToPrepend[:len(vgpuFilterToPrepend)-1] // Removes trailing semicolon to the right
+		}
 	default:
 		return nil, fmt.Errorf("unrecognized type of policy to import: %s", policyType)
 	}


### PR DESCRIPTION
## Description

This PR amends the code added in PR #904, where the VM Placement Policies were onboarded to the Provider.

The problem that this PR fixes is that in VCD 10.3.0 and 10.3.1, vGPU Policies do not exist, hence the filter `isVgpuPolicy` causes an error when fetching VM Placement Policies.

To fix this situation, I added two auxiliary functions, `getVgpuFilter`, that returns a `isVgpuPolicy` filter option only if API version is greater or equal than 36.2 (VCD 10.3.2). Second function is `getVgpuFilterToPrepend` which is similar to the first one but it adds a `;` to the right (The `;` acts as a logical AND). This second one is intended to be used to prepend this vGPU filtering to an existing filter string.

## RCA

The issue was identified when executing the acceptance tests in VCD 10.3.0.
PR #904 was tested with VCD 10.3.3 and 10.4.0, which already had vGPU Policy support (this was introduced in VCD 10.3.2), so this issue got undetected. 