### PR TITLE
Update Codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo. Unless a later match takes
 # precedence all these users will be requested for review when someone opens a pull request.
-*       @lvirbalas @Didainius @adambarreiro
+*       @lvirbalas @Didainius @adambarreiro @dataclouder


### PR DESCRIPTION
This PR restores @dataclouder to be present in the `codeowners` file so he is added automatically to review PRs.