### PR TITLE
Prerelease test fixes

### DIFF
--- a/.changes/v3.8.0/932-bug-fixes.md
+++ b/.changes/v3.8.0/932-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fixed `resource/vcd_vapp` that would prevent to Power off vApp when previous state was
+  `power_on=true` [GH-932]

--- a/.changes/v3.8.0/932-bug-fixes.md
+++ b/.changes/v3.8.0/932-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fixed `resource/vcd_vapp` that would prevent to Power off vApp when previous state was
+* Fixed a bug in `resource/vcd_vapp` that would prevent to Power off vApp when previous state was
   `power_on=true` [GH-932]

--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,9 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.12.1 // indirect
 	golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 // indirect
+	golang.org/x/exp v0.0.0-20221114191408-850992195362
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
+	golang.org/x/sys v0.1.0 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167 h1:O8uGbHCqlTp2P6QJSLmCojM4mN6UemYv8K+dCnmHmu0=
 golang.org/x/crypto v0.0.0-20220517005047-85d78b3ac167/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
+golang.org/x/exp v0.0.0-20221114191408-850992195362 h1:NoHlPRbyl1VFI6FjwHtPQCN7wAMXI6cKcqrmXhOOfBQ=
+golang.org/x/exp v0.0.0-20221114191408-850992195362/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -235,8 +237,9 @@ golang.org/x/sys v0.0.0-20210502180810-71e4cd670f79/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/vcd/datasource_vcd_org_vdc.go
+++ b/vcd/datasource_vcd_org_vdc.go
@@ -2,11 +2,9 @@ package vcd
 
 import (
 	"context"
-	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -251,32 +249,10 @@ func datasourceVcdOrgVdcRead(_ context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	err = setDataSourceEdgeClusterData(d, adminVdc)
+	err = setEdgeClusterData(d, adminVdc, "data.vcd_org_vdc")
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	return nil
-}
-
-// setDataSourceEdgeClusterData is like setEdgeClusterData however it must handle the case where
-// user has insufficient rights to retrieve VDC Network Profile. Resource itself is not affected
-// by this problem because it requires provider user to create VDC.
-func setDataSourceEdgeClusterData(d *schema.ResourceData, adminVdc *govcd.AdminVdc) error {
-	vdcNetworkProfile, err := adminVdc.GetVdcNetworkProfile()
-	if err != nil {
-		// Conciously ignoring this error and loggin it to output as it will most probably be
-		// insufficient rights that the user has. It will work with System user but might not work
-		// for users that got lower privileges.
-		logForScreen("data.vcd_org_vdc", fmt.Sprintf("got error while attempting to retrieve Edge Cluster ID: %s", err))
-		dSet(d, "edge_cluster_id", "")
-		return nil
-	}
-
-	if vdcNetworkProfile != nil && vdcNetworkProfile.ServicesEdgeCluster != nil {
-		dSet(d, "edge_cluster_id", vdcNetworkProfile.ServicesEdgeCluster.BackingID)
-	} else {
-		dSet(d, "edge_cluster_id", "")
-	}
 	return nil
 }

--- a/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
@@ -807,7 +807,6 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
 	  name        = "rule1"
 	  action      = "REJECT"
 	  description = "description"
-	  comment     = "longer text comment field filled"
   
 	  source_ids = [vcd_nsxt_dynamic_security_group.group1.id]
 	}

--- a/vcd/resource_vcd_nsxt_vapp_raw_test.go
+++ b/vcd/resource_vcd_nsxt_vapp_raw_test.go
@@ -51,11 +51,8 @@ func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 	params["VappPowerOn"] = "false"
 	configText2 := templateFill(testAccCheckVcdNsxtVAppRaw_basic, params)
 
-	// params["FuncName"] = t.Name() + "-step3"
-	// configText3 := templateFill(testAccCheckVcdNsxtVAppRaw_basicCleanup, params)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText2)
-	// debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText3)
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,

--- a/vcd/resource_vcd_nsxv_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxv_firewall_rule_test.go
@@ -1131,7 +1131,6 @@ func TestAccVcdNsxvEdgeFirewallRuleVms(t *testing.T) {
 					}),
 				),
 			},
-
 			{
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1190,7 +1189,8 @@ resource "vcd_vapp" "fw-test" {
   org          = "{{.Org}}"
   vdc          = "{{.Vdc}}"
 
-  name = "fw-test"
+  name     = "fw-test"
+  power_on = false
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
@@ -1205,6 +1205,7 @@ resource "vcd_vapp_vm" "fw-vm" {
   vdc           = "{{.Vdc}}"
   vapp_name     = vcd_vapp.fw-test.name
   name          = "fw-test"
+  power_on      = false
   computer_name = "fw-test"
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -15,6 +15,11 @@ import (
 
 func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
+
 	var (
 		standaloneVmName        = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())
 		netVmName1              = standaloneVmName + "-1"

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -14,6 +14,10 @@ import (
 
 func TestAccVcdSubscribedCatalog(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
 
 	var (
 		publisherDescription  = "test publisher catalog"

--- a/vcd/resource_vcd_vapp_and_vm_with_compute_policies_test.go
+++ b/vcd/resource_vcd_vapp_and_vm_with_compute_policies_test.go
@@ -12,6 +12,10 @@ import (
 
 func TestAccVcdVAppAndVmWithComputePolicies(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
 
 	var params = StringMap{
 		"Name":                      t.Name(),

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -426,9 +426,6 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  # You cannot remove NICs from an active virtual machine on which no operating system is installed.
-  power_on = false
-
   vapp_name     = vcd_vapp.{{.VAppName}}.name
   name          = "{{.VMName}}"
   memory        = 512

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -32,8 +32,9 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 		"CatalogItem": testSuiteCatalogOVAItem,
 		"VAppName":    netVappName,
 		"VMName":      netVmName1,
-		"Tags":        "vapp vm",
 		"Media":       testConfig.Media.MediaName,
+		"VAppPower":   "true",
+		"Tags":        "vapp vm",
 	}
 	testParamsNotEmpty(t, params)
 
@@ -44,8 +45,9 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 
 	configTextVM := templateFill(testAccCheckVcdVAppEmptyVm, params)
 
-	params["FuncName"] = t.Name() + "-step1"
-	configTextVMUpdateStep1 := templateFill(testAccCheckVcdVAppEmptyVmStep1, params)
+	params["FuncName"] = t.Name() + "-step2"
+	params["VAppPower"] = "false"
+	configTextVMUpdateStep2 := templateFill(testAccCheckVcdVAppEmptyVmStep1, params)
 
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
@@ -57,7 +59,7 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckVcdVAppVmDestroy(netVappName),
 		Steps: []resource.TestStep{
-			// Step 0 - Create with variations of all possible NICs
+			// Step 1 - Create with variations of all possible NICs
 			{
 				Config: configTextVM,
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -160,9 +162,9 @@ func TestAccVcdVAppEmptyVm(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+netVmName1, "memory_hot_add_enabled", "true"),
 				),
 			},
-			// Step 1 - update
+			// Step 2 - update
 			{
-				Config: configTextVMUpdateStep1,
+				Config: configTextVMUpdateStep2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1, "vcd_vapp_vm."+netVmName1, &vapp, &vm),
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+netVmName1, "name", netVmName1),
@@ -228,6 +230,8 @@ const testAccCheckVcdVAppEmpty = `
 resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
+
+  power_on = {{.VAppPower}}
 
   name       = "{{.VAppName}}"
   depends_on = ["vcd_network_routed.net", "vcd_network_routed.net2"]
@@ -416,19 +420,14 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
  }
 `
 
-const testAccCheckVcdVAppEmptyVmStep1 = testAccCheckVcdVAppEmptyVmNetworkShared + `
+const testAccCheckVcdVAppEmptyVmStep1 = testAccCheckVcdVAppEmpty + testAccCheckVcdVAppEmptyVmNetworkShared + `
 # skip-binary-test: only for updates
-resource "vcd_vapp" "{{.VAppName}}" {
-	org = "{{.Org}}"
-	vdc = "{{.Vdc}}"
-
-	name       = "{{.VAppName}}"
-	depends_on = ["vcd_network_routed.net", "vcd_network_routed.net2"]
-}
-
 resource "vcd_vapp_vm" "{{.VMName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
+
+  # You cannot remove NICs from an active virtual machine on which no operating system is installed.
+  power_on = false
 
   vapp_name     = vcd_vapp.{{.VAppName}}.name
   name          = "{{.VMName}}"
@@ -489,7 +488,7 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
 
   network {
     type               = "org"
-    name              = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
+    name               = vcd_vapp_org_network.vappAttachedRoutedNet2.org_network_name
     ip_allocation_mode = "POOL"
   } 
 }

--- a/vcd/resource_vcd_vapp_empty_vm_test.go
+++ b/vcd/resource_vcd_vapp_empty_vm_test.go
@@ -426,6 +426,8 @@ resource "vcd_vapp_vm" "{{.VMName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
+  power_on = false
+
   vapp_name     = vcd_vapp.{{.VAppName}}.name
   name          = "{{.VMName}}"
   memory        = 512

--- a/vcd/resource_vcd_vapp_raw_test.go
+++ b/vcd/resource_vcd_vapp_raw_test.go
@@ -146,6 +146,7 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   name          = "{{.VmName}}"
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
+  power_on      = false
   memory        = 1024
   cpus          = 1
 

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -690,6 +690,10 @@ resource "vcd_vm" "empty-vm" {
 // (without any CPU/Memory values)
 func TestAccVcdVAppVm_4types_sizing_min(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
 
 	var params = StringMap{
 		"TestName":       t.Name(),
@@ -952,6 +956,10 @@ resource "vcd_vm" "empty-vm" {
 // sizing policy and no compute parameters specified in the VM resource itself
 func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
 
 	var params = StringMap{
 		"TestName":       t.Name(),
@@ -1131,6 +1139,10 @@ resource "vcd_vm" "empty-vm" {
 // works but memory is still required for empty VMs
 func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 	preTestChecks(t)
+	if !usingSysAdmin() {
+		t.Skipf("%s requires system admin privileges", t.Name())
+		return
+	}
 
 	var params = StringMap{
 		"TestName":       t.Name(),

--- a/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
+++ b/vcd/resource_vcd_vapp_vm_dhcp_wait_test.go
@@ -198,6 +198,7 @@ data "vcd_vapp_vm" "ds" {
 }
 `
 
+// #nosec G101 -- This doesn't contain any credential
 const testAccCheckVcdVAppVmDhcpWaitStep3 = `
 resource "vcd_vapp" "{{.VAppName}}" {
   org = "{{.Org}}"

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -262,7 +262,9 @@ resource "vcd_network_routed" "{{.NetworkName}}" {
 resource "vcd_vapp" "{{.VappName}}" {
   name = "{{.VappName}}"
   org  = "{{.Org}}"
-  vdc  = "{{.Vdc}}" 
+  vdc  = "{{.Vdc}}"
+
+  power_on = false
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
@@ -302,6 +304,7 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
   vdc           = "{{.Vdc}}"
   vapp_name     = vcd_vapp_vm.{{.VmName}}.vapp_name
   name          = "{{.VmName2}}"
+  power_on      = false
   computer_name = vcd_vapp_vm.{{.VmName}}.computer_name
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -67,7 +67,7 @@ func TestAccVcdVAppVm_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"vcd_vapp_vm."+vmName, "network.0.ip", "10.10.102.161"),
 					resource.TestCheckResourceAttr(
-						"vcd_vapp_vm."+vmName, "power_on", "true"),
+						"vcd_vapp_vm."+vmName, "power_on", "false"),
 					resource.TestCheckResourceAttr(
 						"vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
 					resource.TestCheckOutput("disk", diskName),
@@ -142,7 +142,7 @@ func TestAccVcdVAppVm_Clone(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						vm1, "network.0.ip", params["IP"].(string)),
 					resource.TestCheckResourceAttr(
-						vm1, "power_on", "true"),
+						vm1, "power_on", "false"),
 					resource.TestCheckResourceAttr(
 						vm1, "metadata.vm_metadata", "VM Metadata."),
 					resource.TestCheckResourceAttr(
@@ -189,9 +189,10 @@ resource "vcd_independent_disk" "{{.diskResourceName}}" {
 }
 
 resource "vcd_vapp" "{{.VappName}}" {
-  name = "{{.VappName}}"
-  org  = "{{.Org}}"
-  vdc  = "{{.Vdc}}"
+  name     = "{{.VappName}}"
+  org      = "{{.Org}}"
+  vdc      = "{{.Vdc}}"
+  power_on = false
 }
 
 resource "vcd_vapp_org_network" "vappNetwork1" {
@@ -209,6 +210,7 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   computer_name = "{{.ComputerName}}"
   catalog_name  = "{{.Catalog}}"
   template_name = "{{.CatalogItem}}"
+  power_on      = false
   memory        = 1024
   cpus          = 2
   cpu_cores     = 1
@@ -274,6 +276,7 @@ resource "vcd_vapp_vm" "{{.VmName}}" {
   org           = "{{.Org}}"
   vdc           = "{{.Vdc}}"
   vapp_name     = vcd_vapp.{{.VappName}}.name
+  power_on      = false
   name          = "{{.VmName}}"
   computer_name = "{{.ComputerName}}"
   catalog_name  = "{{.Catalog}}"


### PR DESCRIPTION
These are mainly test fixes, but there was one bug which is required to fix the tests:
`vcd_vapp` power handling had error in a scenario when one creates a powered on vApp and wants to power it down later on - this case was simply not covered.


Test fixed below:

* `TestAccVcdNsxtDynamicSecurityGroupIntegration` fails on VCD <10.3.2 because it uses earlier unsupported `comment` field. It has no purpose in this particular test so it is removed in file `resource_vcd_nsxt_dynamic_security_group_test.go`
* VCD 10.3.0 `TestAccVcdVAppVm_4types_PowerState` reports `POWERED_OFF` state for vApp instead of `MIXED` when a child VM is in vApp is powered off. Fix is to check for both cases.
* `TestAccVcdVdcGroupResourceAsOrgUser` failed on newly introduced `edge_cluster_id` field read. Normally, a `vcd_org_vdc` resource is created by sysadmin, but in this case the test jugles and switches to Org user mode after the resources are created, therefore it failed. 

The following tests are amended to power off vApp before removing vApp networks as it is not allowed. This has been done in a few ways - somewhere it is keep the vApp powered off (after bug fixed), in some cases it is powering of the VM, because a VM cannot be powered on in a powered off vApp.
* `TestAccVcdVAppEmptyVm` ensure that vApp is powered off before destroy phase to avoid triggering an error when removing vApp network from a powered on vApp.
* `TestAccVcdVAppMultiVmInTemplate`
* `TestAccVcdNsxtVAppRawAllNsxtNetworks`
* `TestAccVcdVAppVmCreateCustomizationFalse`
* `TestAccVcdVAppVmCreateCustomization`
* `TestAccVcdVAppVmUpdateCustomization`
* `TestAccVcdNsxvEdgeFirewallRuleVms`
* `TestAccVcdVAppVmDhcpWait`
* `TestAccVcdVAppRaw_Basic`
* `TestAccVcdVAppHotUpdateVm`
* `TestAccVcdVAppVmMultiNIC`
* `TestAccVcdVAppVm_Basic`
* `TestAccVcdVAppVm_Clone`

These tests are patched to be skipped when running in Org user mode:
* `TestAccVcdStandaloneVmWithVmSizing`
* `TestAccVcdSubscribedCatalog`
* `TestAccVcdVAppVm_4types_sizing_min`
* `TestAccVcdVAppVm_4types_sizing_max`
* `TestAccVcdVAppVm_4types_sizing_cpu_only`
* `TestAccVcdVAppAndVmWithComputePolicies`
