### PR TITLE
fix org user tests

### DIFF
--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -321,9 +321,16 @@ func testDistributedNetworksEnabled() bool {
 	return testDistributedNetworks || os.Getenv("VCD_TEST_DISTRIBUTED_NETWORK") != ""
 }
 
-// Returns true if the current configuration uses a system administrator for connections
+// usingSysAdmin returns true if the current configuration uses a system administrator for connections
 func usingSysAdmin() bool {
 	return strings.ToLower(testConfig.Provider.SysOrg) == "system"
+}
+
+// skipIfNotSysAdmin skips the calling test if the client is not a system administrator
+func skipIfNotSysAdmin(t *testing.T) {
+	if !usingSysAdmin() {
+		t.Skip(t.Name() + " requires system admin privileges")
+	}
 }
 
 // Gets a list of all variables mentioned in a template

--- a/vcd/datasource_not_found_test.go
+++ b/vcd/datasource_not_found_test.go
@@ -36,25 +36,45 @@ func TestAccDataSourceNotFound(t *testing.T) {
 
 func testSpecificDataSourceNotFound(dataSourceName string, vcdClient *VCDClient) func(*testing.T) {
 	return func(t *testing.T) {
-
 		// Skip sub-test if conditions are not met
+		dataSourcesRequiringSysAdmin := []string{
+			"vcd_external_network",
+			"vcd_global_role",
+			"vcd_nsxt_edgegateway_bgp_ip_prefix_list",
+			"vcd_nsxt_edgegateway_bgp_neighbor",
+			"vcd_org_ldap",
+			"vcd_portgroup",
+			"vcd_provider_vdc",
+			"vcd_rights_bundle",
+			"vcd_vcenter",
+			"vcd_vdc_group",
+			"vcd_vm_group",
+		}
+		dataSourcesRequiringAlbConfig := []string{
+			"vcd_nsxt_alb_cloud",
+			"vcd_nsxt_alb_controller",
+			"vcd_nsxt_alb_edgegateway_service_engine_group",
+			"vcd_nsxt_alb_importable_cloud",
+			"vcd_nsxt_alb_pool",
+			"vcd_nsxt_alb_service_engine_group",
+			"vcd_nsxt_alb_settings",
+			"vcd_nsxt_alb_virtual_service",
+			"vcd_nsxt_distributed_firewall",
+		}
+		dataSourcesRequiringNsxtConfig := []string{
+			"vcd_external_network_v2",
+			"vcd_nsxt_edge_cluster",
+			"vcd_nsxt_manager",
+			"vcd_nsxt_tier0_router",
+		}
+
 		switch {
-		case (dataSourceName == "vcd_external_network" || dataSourceName == "vcd_vcenter" ||
-			dataSourceName == "vcd_portgroup" || dataSourceName == "vcd_global_role" ||
-			dataSourceName == "vcd_rights_bundle" || dataSourceName == "vcd_vdc_group") &&
-			!usingSysAdmin():
+		case contains(dataSourcesRequiringSysAdmin, dataSourceName) && !usingSysAdmin():
 			t.Skip(`Works only with system admin privileges`)
-		case (dataSourceName == "vcd_nsxt_edgegateway_bgp_ip_prefix_list" || dataSourceName == "vcd_nsxt_edgegateway_bgp_neighbor") && !usingSysAdmin():
-			t.Skip(`Works only with system admin privileges`)
-		case (dataSourceName == "vcd_nsxt_tier0_router" || dataSourceName == "vcd_external_network_v2" ||
-			dataSourceName == "vcd_nsxt_manager" || dataSourceName == "vcd_nsxt_edge_cluster") &&
+		case contains(dataSourcesRequiringNsxtConfig, dataSourceName) &&
 			(testConfig.Nsxt.Manager == "" || testConfig.Nsxt.Tier0router == "" || !usingSysAdmin()):
 			t.Skip(`Nsxt.Manager, Nsxt.Tier0route is missing in configuration or not running as System user`)
-		case dataSourceName == "vcd_nsxt_alb_controller" || dataSourceName == "vcd_nsxt_alb_cloud" ||
-			dataSourceName == "vcd_nsxt_alb_importable_cloud" || dataSourceName == "vcd_nsxt_alb_service_engine_group" ||
-			dataSourceName == "vcd_nsxt_alb_settings" || dataSourceName == "vcd_nsxt_alb_edgegateway_service_engine_group" ||
-			dataSourceName == "vcd_nsxt_alb_pool" || dataSourceName == "vcd_nsxt_alb_virtual_service" ||
-			dataSourceName == "vcd_nsxt_distributed_firewall":
+		case contains(dataSourcesRequiringAlbConfig, dataSourceName):
 			skipNoNsxtAlbConfiguration(t)
 			if !usingSysAdmin() {
 				t.Skip(`Works only with system admin privileges`)

--- a/vcd/datasource_nsxt_manager_test.go
+++ b/vcd/datasource_nsxt_manager_test.go
@@ -13,10 +13,7 @@ import (
 func TestAccVcdDatasourceNsxtManager(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"FuncName":    t.Name(),

--- a/vcd/datasource_nsxt_tier0_router_test.go
+++ b/vcd/datasource_nsxt_tier0_router_test.go
@@ -28,10 +28,7 @@ func TestAccVcdDatasourceNsxtTier0RouterVrf(t *testing.T) {
 
 func testAccVcdDatasourceNsxtTier0Router(t *testing.T, tier0RouterName string) {
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"FuncName":        t.Name(),

--- a/vcd/datasource_vcd_external_network_v2_test.go
+++ b/vcd/datasource_vcd_external_network_v2_test.go
@@ -12,10 +12,7 @@ import (
 
 func TestAccVcdExternalNetworkV2Datasource(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"ExistingExternalNetwork": testConfig.Nsxt.ExternalNetwork,

--- a/vcd/datasource_vcd_independent_disk_test.go
+++ b/vcd/datasource_vcd_independent_disk_test.go
@@ -17,9 +17,7 @@ import (
 // Using a disk data source we reference a disk data source
 func TestAccVcdDataSourceIndependentDisk(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdDataSourceIndependentDisk requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 	resourceName := "TestAccVcdDataSourceIndependentDisk_1"
 	datasourceName := "TestAccVcdDataSourceIndependentDisk_Data"
 	datasourceNameWithId := "TestAccVcdDataSourceIndependentDiskWithId_Data"

--- a/vcd/datasource_vcd_nsxt_alb_importable_cloud_test.go
+++ b/vcd/datasource_vcd_nsxt_alb_importable_cloud_test.go
@@ -13,11 +13,7 @@ import (
 func TestAccVcdNsxtAlbImportableCloudDS(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
-
+	skipIfNotSysAdmin(t)
 	skipNoNsxtAlbConfiguration(t)
 
 	// String map to fill the template

--- a/vcd/datasource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile_test.go
@@ -134,9 +134,7 @@ data "vcd_nsxt_app_port_profile" "custom" {
 // This test is done to replicate and fix https://github.com/vmware/terraform-provider-vcd/issues/778
 func TestAccVcdNsxtAppPortProfileMultiOrg(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("this test requires Sysadmin user to create Org")
-	}
+	skipIfNotSysAdmin(t)
 
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)

--- a/vcd/datasource_vcd_nsxt_edge_cluster_test.go
+++ b/vcd/datasource_vcd_nsxt_edge_cluster_test.go
@@ -13,10 +13,7 @@ import (
 func TestAccVcdNsxtEdgeCluster(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"NsxtVdc":             testConfig.Nsxt.Vdc,
@@ -64,10 +61,7 @@ data "vcd_nsxt_edge_cluster" "ec" {
 func TestAccVcdNsxtEdgeClusterVdcId(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":                 testConfig.VCD.Org,
@@ -121,10 +115,7 @@ data "vcd_nsxt_edge_cluster" "ec" {
 func TestAccVcdNsxtEdgeClusterVdcGroupId(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":                 testConfig.VCD.Org,
@@ -178,10 +169,7 @@ data "vcd_nsxt_edge_cluster" "ec" {
 func TestAccVcdNsxtEdgeClusterProviderVdcId(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"ProviderVdc":         testConfig.VCD.NsxtProviderVdc.Name,

--- a/vcd/datasource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_test.go
@@ -14,10 +14,7 @@ import (
 // gateway resource can correctly consume these multiple subnets
 func TestAccVcdNsxtEdgeGatewayMultipleSubnetsAndDS(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/datasource_vcd_nsxt_network_context_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_network_context_profile_test.go
@@ -57,9 +57,7 @@ data "vcd_nsxt_network_context_profile" "p" {
 
 func TestAccVcdNsxtNetworkContextProfileInNsxtManager(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("this test requires Sysadmin user to lookup NSX-T Manager")
-	}
+	skipIfNotSysAdmin(t) // This test requires Sysadmin user to lookup NSX-T Manager
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return

--- a/vcd/datasource_vcd_org_test.go
+++ b/vcd/datasource_vcd_org_test.go
@@ -13,10 +13,7 @@ import (
 func TestAccVcdDatasourceOrg(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdDatasourceOrg requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	orgName1 := testConfig.VCD.Org
 	orgName2 := orgName1 + "-clone"

--- a/vcd/datasource_vcd_provider_vdc_test.go
+++ b/vcd/datasource_vcd_provider_vdc_test.go
@@ -4,18 +4,16 @@
 package vcd
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccVcdDatasourceProviderVdc(t *testing.T) {
 	// Pre-checks
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// Test configuration
 	var params = StringMap{

--- a/vcd/datasource_vcd_rights_container_test.go
+++ b/vcd/datasource_vcd_rights_container_test.go
@@ -125,10 +125,7 @@ func getRightsContainerInfo() (map[string]containerInfo, error) {
 func TestAccVcdRightsContainers(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdRightsContainers requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test

--- a/vcd/datasource_vcd_vm_group_test.go
+++ b/vcd/datasource_vcd_vm_group_test.go
@@ -4,18 +4,16 @@
 package vcd
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"regexp"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccVcdDatasourceVmGroup(t *testing.T) {
 	// Pre-checks
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// Test configuration
 	var params = StringMap{

--- a/vcd/datasource_vcenter_test.go
+++ b/vcd/datasource_vcenter_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestAccVcdVcenter(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + "  requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Vcenter": testConfig.Networking.Vcenter,

--- a/vcd/org_vdc_common_test.go
+++ b/vcd/org_vdc_common_test.go
@@ -19,10 +19,7 @@ var TestAccVcdVdc = "TestAccVcdVdcBasic"
 
 func runOrgVdcTest(t *testing.T, params StringMap, allocationModel string) {
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	testParamsNotEmpty(t, params)
 
 	configText := templateFill(testAccCheckVcdVdc_basic, params)
@@ -420,6 +417,7 @@ const additionalStorageProfile = `
 
 // TestAccVcdVdcMetadata tests metadata CRUD on VDCs
 func TestAccVcdVdcMetadata(t *testing.T) {
+	skipIfNotSysAdmin(t)
 	testMetadataEntryCRUD(t,
 		testAccCheckVcdVdcMetadata, "vcd_org_vdc.test-vdc",
 		testAccCheckVcdVdcMetadataDatasource, "data.vcd_org_vdc.test-vdc-ds",

--- a/vcd/resource_vcd_catalog_access_control_test.go
+++ b/vcd/resource_vcd_catalog_access_control_test.go
@@ -18,10 +18,7 @@ func TestAccVcdCatalogAccessControl(t *testing.T) {
 
 	skipTestForApiToken(t)
 
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":                      testConfig.VCD.Org,

--- a/vcd/resource_vcd_edgegateway_children_test.go
+++ b/vcd/resource_vcd_edgegateway_children_test.go
@@ -16,10 +16,7 @@ import (
 // * vcd_nsxv_dhcp_relay
 func TestAccVcdEdgeGatewayChildrenResourceNotFound(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("Edge Gateway tests require system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	// This test invokes go-vcloud-director SDK directly
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)

--- a/vcd/resource_vcd_edgegateway_settings_test.go
+++ b/vcd/resource_vcd_edgegateway_settings_test.go
@@ -16,10 +16,7 @@ import (
 // NSX-V based test
 func TestAccVcdEdgeGatewaySettingsFull(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("Edge Gateway resource tests require system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	fmt.Println("*** This test doesn't run anything directly, but it creates an HCL script")
 	fmt.Println("*** (vcd.TestAccVcdEdgeGatewaySettingsFull.tf) that will then run with the binary tests.")

--- a/vcd/resource_vcd_edgegateway_test.go
+++ b/vcd/resource_vcd_edgegateway_test.go
@@ -52,10 +52,7 @@ func TestAccVcdEdgeGatewayBasic(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	if !usingSysAdmin() {
-		t.Skip("Edge Gateway tests require system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
@@ -109,10 +106,7 @@ func TestAccVcdEdgeGatewayComplex(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	if !usingSysAdmin() {
-		t.Skip("Edge gateway tests requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
@@ -201,10 +195,7 @@ func TestAccVcdEdgeGatewayExternalNetworks(t *testing.T) {
 		return
 	}
 
-	if !usingSysAdmin() {
-		t.Skip("Edge gateway tests requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
@@ -416,10 +407,7 @@ func TestAccVcdEdgeGatewayRateLimits(t *testing.T) {
 		return
 	}
 
-	if !usingSysAdmin() {
-		t.Skip("Edge gateway tests requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
@@ -531,10 +519,7 @@ func TestAccVcdEdgeGatewayParallelCreation(t *testing.T) {
 		return
 	}
 
-	if !usingSysAdmin() {
-		t.Skip("Edge gateway tests requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,

--- a/vcd/resource_vcd_external_network_test.go
+++ b/vcd/resource_vcd_external_network_test.go
@@ -23,10 +23,7 @@ var externalNetwork govcd.ExternalNetwork
 func TestAccVcdExternalNetworkBasic(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"
@@ -179,10 +176,7 @@ func TestAccVcdExternalNetworkResourceNotFound(t *testing.T) {
 		return
 	}
 
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdExternalNetworkBasic requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -34,10 +34,7 @@ func TestAccVcdExternalNetworkV2NsxtT0Router(t *testing.T) {
 
 func testAccVcdExternalNetworkV2Nsxt(t *testing.T, nsxtTier0Router string) {
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"
@@ -245,10 +242,7 @@ func TestAccVcdExternalNetworkV2Nsxv(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	description := "Test External Network"
 	var params = StringMap{
@@ -449,10 +443,7 @@ output "portgroup-id" {
 
 func TestAccVcdExternalNetworkV2NsxtSegment(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"
@@ -634,10 +625,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt" {
 
 func TestAccVcdExternalNetworkV2NsxtConfigError(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"
@@ -748,10 +736,7 @@ func testAccCheckExternalNetworkDestroyV2(name string) resource.TestCheckFunc {
 // Org direct network resource (the only possible while implementing this feature)
 func TestAccVcdExternalNetworkV2NsxtSegmentIntegration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	startAddress := "192.168.30.51"
 	endAddress := "192.168.30.62"

--- a/vcd/resource_vcd_global_role_test.go
+++ b/vcd/resource_vcd_global_role_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestAccVcdGlobalRole(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdGlobalRole requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	skipTestForApiToken(t)
 	var globalRoleName = t.Name()
 	var globalRoleUpdateName = t.Name() + "-update"

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -21,9 +21,7 @@ var name = "TestAccVcdIndependentDiskBasic"
 
 func TestAccVcdIndependentDiskBasic(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdIndependentDiskBasic requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	if testConfig.VCD.NsxtProviderVdc.StorageProfile == "" || testConfig.VCD.NsxtProviderVdc.StorageProfile2 == "" {
 		t.Skip("Both variables testConfig.VCD.ProviderVdc.StorageProfile and testConfig.VCD.ProviderVdc.StorageProfile2 must be set")

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -186,10 +186,7 @@ resource "vcd_network_isolated_v2" "net1" {
 // * Step 7 - checks out that import of network being in different VDC still works
 func TestAccVcdNetworkIsolatedV2NsxtMigration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges to create VDCs")
-		return
-	}
+	skipIfNotSysAdmin(t) // requires system admin privileges to create VDCs
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -331,10 +331,7 @@ data "vcd_network_routed_v2" "net1" {
 // together and reflects it
 func TestAccVcdNetworkRoutedV2NsxtMigration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges to create VDCs")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -678,10 +675,7 @@ resource "vcd_network_routed_v2" "net1" {
 // Note. It does not test `org` field inheritance because our import sets it by default.
 func TestAccVcdNetworkRoutedV2InheritedVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_network_test.go
+++ b/vcd/resource_vcd_network_test.go
@@ -5,12 +5,13 @@ package vcd
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"regexp"
 	"strconv"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 )
 
 func init() {
@@ -574,10 +575,7 @@ func TestAccVcdNetworkRoutedMixedSub(t *testing.T) {
 // NSX-V based test
 func TestAccVcdNetworkDirect(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdNetworkDirect requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var def = networkDef{
 		name:                  directNetwork,
@@ -1340,6 +1338,7 @@ resource "vcd_network_routed" "{{.ResourceName}}" {
 
 // TestAccVcdDirectNetworkMetadata tests metadata CRUD on a NSX-V direct network
 func TestAccVcdDirectNetworkMetadata(t *testing.T) {
+	skipIfNotSysAdmin(t)
 	testMetadataEntryCRUD(t,
 		testAccCheckVcdDirectNetworkMetadata, "vcd_network_direct.test-network-direct",
 		testAccCheckVcdDirectNetworkMetadataDatasource, "data.vcd_network_direct.test-network-direct-ds",

--- a/vcd/resource_vcd_nsxt_alb_cloud_test.go
+++ b/vcd/resource_vcd_nsxt_alb_cloud_test.go
@@ -16,10 +16,7 @@ import (
 func TestAccVcdNsxtAlbCloud(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_common_test.go
+++ b/vcd/resource_vcd_nsxt_alb_common_test.go
@@ -20,10 +20,7 @@ func TestAccVcdNsxtAlbVdcGroupIntegrationWithoutVdcField(t *testing.T) {
 	defer restoreDefaultVdcFunc()
 
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 
@@ -101,10 +98,7 @@ func TestAccVcdNsxtAlbVdcGroupIntegrationWithoutVdcField(t *testing.T) {
 
 func TestAccVcdNsxtAlbVdcGroupIntegration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_controller_test.go
+++ b/vcd/resource_vcd_nsxt_alb_controller_test.go
@@ -15,10 +15,7 @@ import (
 
 func TestAccVcdNsxtAlbController(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_edgegateway_service_engine_group_test.go
@@ -12,10 +12,7 @@ import (
 
 func TestAccVcdNsxtEdgeGatewayServiceEngineGroupDedicated(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 
@@ -114,10 +111,7 @@ data "vcd_nsxt_alb_edgegateway_service_engine_group" "test" {
 
 func TestAccVcdNsxtEdgeGatewayServiceEngineGroupShared(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 
@@ -275,10 +269,7 @@ resource "vcd_nsxt_alb_edgegateway_service_engine_group" "test" {
 // d.SetId("") instead of throwing error) outside of Terraform control.
 func TestAccVcdNsxtEdgeGatewayServiceEngineGroupResourceNotFound(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// This test invokes go-vcloud-director SDK directly
 	if vcdShortTest {

--- a/vcd/resource_vcd_nsxt_alb_pool_test.go
+++ b/vcd/resource_vcd_nsxt_alb_pool_test.go
@@ -17,10 +17,7 @@ import (
 
 func TestAccVcdNsxtAlbPool(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
+++ b/vcd/resource_vcd_nsxt_alb_service_engine_group_test.go
@@ -16,10 +16,7 @@ import (
 
 func TestAccVcdNsxtAlbServiceEngineGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/resource_vcd_nsxt_alb_settings_test.go
@@ -15,10 +15,7 @@ import (
 
 func TestAccVcdNsxtAlbSettings(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
@@ -16,10 +16,7 @@ import (
 
 func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoNsxtAlbConfiguration(t)
 

--- a/vcd/resource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/resource_vcd_nsxt_app_port_profile_test.go
@@ -526,9 +526,7 @@ func TestAccVcdNsxtAppPortProfileTenantContextVdcGroup(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	if !usingSysAdmin() {
-		t.Skip("this test must pre-create VDC Group and cannot run in Org user mode")
-	}
+	skipIfNotSysAdmin(t) // this test must pre-create VDC Group and cannot run in Org user mode
 
 	var params = StringMap{
 		"Org":                       testConfig.VCD.Org,
@@ -621,9 +619,7 @@ func TestAccVcdNsxtAppPortProfileConfigurationMigration(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 		return
 	}
-	if !usingSysAdmin() {
-		t.Skip("this test must pre-create VDC Group and cannot run in Org user mode")
-	}
+	skipIfNotSysAdmin(t) // This test must pre-create VDC Group and cannot run in Org user mode
 
 	var params = StringMap{
 		"Org":                       testConfig.VCD.Org,

--- a/vcd/resource_vcd_nsxt_distributed_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_test.go
@@ -15,10 +15,7 @@ import (
 // explicitly check new features introduced in newer VCD versions having versions in their names.
 func TestAccVcdDistributedFirewall(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -391,10 +388,7 @@ data "vcd_nsxt_distributed_firewall" "t1" {
 // * Firewall rule 'action' REJECT
 func TestAccVcdDistributedFirewallVCD10_2_2(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -470,10 +464,7 @@ resource "vcd_nsxt_distributed_firewall" "t1" {
 // * destination_groups_excluded (negates the values specified in destinations_ids)
 func TestAccVcdDistributedFirewallVCD10_3_2(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_configuration_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_configuration_test.go
@@ -16,10 +16,7 @@ import (
 // Tier-0 gateway
 func TestAccVcdNsxtEdgeBgpConfigTier0(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// Binary tests cannot be run for this test because it requires dedicated Tier-0 gateway which
 	// is enabled using custom SDK functions
@@ -306,10 +303,7 @@ resource "vcd_nsxt_edgegateway_bgp_configuration" "testing" {
 // fields are filled in with some values.
 func TestAccVcdNsxtEdgeBgpConfigVrf(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -529,10 +523,7 @@ func testAccCheckNsxtBgpConfigurationDisabled(edgeGatewayName string) resource.T
 // part of VDC Group
 func TestAccVcdNsxtEdgeBgpConfigVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -644,10 +635,7 @@ resource "vcd_nsxt_edgegateway_bgp_configuration" "testing" {
 // would do to achieve complete BGP configuration.
 func TestAccVcdNsxtEdgeBgpConfigIntegrationVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// Binary tests cannot be run for this test because it requires dedicated Tier-0 gateway which
 	// is enabled using custom SDK functions
@@ -782,10 +770,7 @@ resource "vcd_nsxt_edgegateway_bgp_neighbor" "testing" {
 // would do to achieve complete BGP configuration.
 func TestAccVcdNsxtEdgeBgpConfigIntegrationVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_neighbor_test.go
@@ -11,10 +11,7 @@ import (
 
 func TestAccVcdNsxtEdgeBgpNeighbor(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_prefix_list_test.go
@@ -11,10 +11,7 @@ import (
 
 func TestAccVcdNsxtEdgeBgpIpPrefixListVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -19,10 +19,7 @@ import (
 // testConfig.Nsxt.ExternalNetwork which is expected to be correctly configured.
 func TestAccVcdNsxtEdgeGateway(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	skipNoConfiguration(t, StringMap{"Nsxt.ExternalNetwork": testConfig.Nsxt.ExternalNetwork})
 	vcdClient := createTemporaryVCDConnection(false)
@@ -212,10 +209,7 @@ func testAccCheckVcdNsxtEdgeGatewayDestroy(edgeName string) resource.TestCheckFu
 
 func TestAccVcdNsxtEdgeGatewayVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -368,10 +362,7 @@ data "vcd_nsxt_edgegateway" "ds" {
 // Step 5 - migrates the Edge Gateway to a different VDC than the starting one
 func TestAccVcdNsxtEdgeGatewayVdcGroupMigration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	vcdClient := createTemporaryVCDConnection(false)
 
@@ -576,10 +567,7 @@ resource "vcd_nsxt_edgegateway" "nsxt-edge" {
 // After an expected failure it will just use the same VDC using `owner_id` instead of `vdc` field.
 func TestAccVcdNsxtEdgeGatewayVdcUpdateFails(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":                       testConfig.VCD.Org,
@@ -746,10 +734,7 @@ func lookupAvailableEdgeClusterId(t *testing.T, vcdClient *VCDClient) (string, e
 
 func TestAccVcdNsxtEdgeGatewayCreateInVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_ip_set_test.go
+++ b/vcd/resource_vcd_nsxt_ip_set_test.go
@@ -295,9 +295,7 @@ data "vcd_nsxt_ip_set" "ds" {
 // TestAccVcdNsxtIpSetOwnerVdcGroup starts with creating an IP Set with IP addresses defined in VDC Group and later on removes them all
 func TestAccVcdNsxtIpSetOwnerVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("this test requires Sysadmin user to create prerequisites")
-	}
+	skipIfNotSysAdmin(t) //This test requires Sysadmin user to create prerequisites
 
 	// String map to fill the template
 	var params = StringMap{
@@ -437,10 +435,7 @@ resource "vcd_nsxt_ip_set" "set1" {
 // together and reflects it
 func TestAccVcdNsxtIpSetMigration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges to create VDCs")
-		return
-	}
+	skipIfNotSysAdmin(t) // requires system admin privileges to create VDCs
 
 	// String map to fill the template
 	var params = StringMap{
@@ -699,10 +694,7 @@ resource "vcd_nsxt_ip_set" "set1" {
 // Note. It does not test `org` field inheritance because our import sets it by default.
 func TestAccVcdNsxtIpSetInheritedVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_network_imported_test.go
+++ b/vcd/resource_vcd_nsxt_network_imported_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestAccVcdNsxtNetworkImported(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -148,9 +146,7 @@ resource "vcd_nsxt_network_imported" "net1" {
 // on the first run
 func TestAccVcdNsxtNetworkImportedOwnerIsVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -296,9 +292,7 @@ resource "vcd_nsxt_network_imported" "net1" {
 func TestAccVcdNsxtNetworkImportedInVdcGroup(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{
@@ -406,10 +400,7 @@ resource "vcd_nsxt_network_imported" "net1" {
 // * Step 7 - checks out that import of network being in different VDC still works
 func TestAccVcdNetworkImportedNsxtMigration(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges to create VDCs")
-		return
-	}
+	skipIfNotSysAdmin(t) // requires system admin privileges to create VDCs
 
 	// String map to fill the template
 	var params = StringMap{
@@ -610,10 +601,7 @@ resource "vcd_nsxt_network_imported" "net1" {
 // Note. It does not test `org` field inheritance because our import sets it by default.
 func TestAccVcdNetworkImportedV2InheritedVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_nsxt_route_advertisement_test.go
+++ b/vcd/resource_vcd_nsxt_route_advertisement_test.go
@@ -15,10 +15,7 @@ import (
 
 func TestAccVcdNsxtRouteAdvertisement(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	isRouteAdvertisementEnable := true
 	subnet1 := "192.168.1.0/24"
@@ -184,10 +181,7 @@ resource "vcd_nsxt_route_advertisement" "testing" {
 
 func TestAccVcdNsxtRouteAdvertisementVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	isRouteAdvertisementEnable := true
 	subnet1 := "192.168.1.0/24"

--- a/vcd/resource_vcd_nsxt_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_security_group_test.go
@@ -491,9 +491,7 @@ func testAccCheckNsxtFirewallGroupDestroy(vdcName, firewalGroupName, firewallGro
 // TestAccVcdNsxtSecurityGroupOwnerVdcGroup starts with creating the Security group with defined in VDC Group and later on removes them all
 func TestAccVcdNsxtSecurityGroupOwnerVdcGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("this test requires Sysadmin user to create VDC Group")
-	}
+	skipIfNotSysAdmin(t) // requires SysAdmin user to create VDC Group
 
 	// String map to fill the template
 	var params = StringMap{
@@ -720,10 +718,7 @@ resource "vcd_nsxt_security_group" "group1" {
 // Note. It does not test `org` field inheritance because our import sets it by default.
 func TestAccVcdNsxtSecurityGroupInheritedVdc(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_org_group_test.go
+++ b/vcd/resource_vcd_org_group_test.go
@@ -20,10 +20,7 @@ import (
 // Note: This test requires an existing LDAP server and its IP set in testConfig.Networking.LdapServer
 func TestAccVcdOrgGroup(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdOrgGroup requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	skipTestForApiToken(t)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)

--- a/vcd/resource_vcd_org_ldap_test.go
+++ b/vcd/resource_vcd_org_ldap_test.go
@@ -17,10 +17,7 @@ func init() {
 
 func TestAccVcdOrgLdap(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdOrgLdap requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	if testConfig.Networking.LdapServer == "" {
 		t.Skip("TestAccVcdOrgLdap requires a working LDAP server (set the IP in testConfig.Networking.LdapServer)")
 		return

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -27,10 +27,7 @@ func TestAccVcdOrgBasic(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdOrgBasic requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	configText := templateFill(testAccCheckVcdOrgBasic, params)
 	if vcdShortTest {
@@ -67,10 +64,7 @@ func TestAccVcdOrgBasic(t *testing.T) {
 func TestAccVcdOrgFull(t *testing.T) {
 	preTestChecks(t)
 
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdOrgFull requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	type testOrgData struct {
 		name                         string
 		enabled                      bool
@@ -414,6 +408,7 @@ resource "vcd_org" "{{.OrgName}}" {
 
 // TestAccVcdOrgMetadata tests metadata CRUD on organizations
 func TestAccVcdOrgMetadata(t *testing.T) {
+	skipIfNotSysAdmin(t)
 	testMetadataEntryCRUD(t,
 		testAccCheckVcdOrgMetadata, "vcd_org.test-org",
 		testAccCheckVcdOrgMetadataDatasource, "data.vcd_org.test-org-ds",

--- a/vcd/resource_vcd_org_vdc_access_control_test.go
+++ b/vcd/resource_vcd_org_vdc_access_control_test.go
@@ -16,9 +16,7 @@ import (
 
 func TestAccVcdOrgVdcAccessControl(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	userName1 := strings.ToLower(t.Name())
 	userName2 := strings.ToLower(t.Name()) + "2"

--- a/vcd/resource_vcd_org_vdc_nsxt_edge_cluster_test.go
+++ b/vcd/resource_vcd_org_vdc_nsxt_edge_cluster_test.go
@@ -11,9 +11,7 @@ import (
 
 func TestAccVcdOrgVdcNsxtEdgeCluster(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"VdcName":                   t.Name(),

--- a/vcd/resource_vcd_org_vdc_nsxt_test.go
+++ b/vcd/resource_vcd_org_vdc_nsxt_test.go
@@ -7,9 +7,7 @@ import "testing"
 
 func TestAccVcdOrgVdcNsxt(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 	allocationModel := "ReservationPool"
 
 	var params = StringMap{

--- a/vcd/resource_vcd_org_vdc_test.go
+++ b/vcd/resource_vcd_org_vdc_test.go
@@ -15,9 +15,7 @@ func init() {
 
 func TestAccVcdOrgVdcReservationPool(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	allocationModel := "ReservationPool"
 
@@ -60,9 +58,7 @@ func TestAccVcdOrgVdcReservationPool(t *testing.T) {
 
 func TestAccVcdOrgVdcAllocationPool(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	allocationModel := "AllocationPool"
 
@@ -104,9 +100,7 @@ func TestAccVcdOrgVdcAllocationPool(t *testing.T) {
 
 func TestAccVcdOrgVdcAllocationVApp(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	allocationModel := "AllocationVApp"
 
@@ -148,9 +142,7 @@ func TestAccVcdOrgVdcAllocationVApp(t *testing.T) {
 
 func TestAccVcdOrgVdcAllocationFlex(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	allocationModel := "Flex"
 
@@ -194,9 +186,7 @@ func TestAccVcdOrgVdcAllocationFlex(t *testing.T) {
 // control.
 func TestAccVcdOrgVdcResourceNotFound(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	// This test invokes go-vcloud-director SDK directly
 	if vcdShortTest {

--- a/vcd/resource_vcd_org_vdc_with_all_compute_policies_test.go
+++ b/vcd/resource_vcd_org_vdc_with_all_compute_policies_test.go
@@ -11,9 +11,7 @@ import (
 
 func TestAccVcdOrgVdcWithAllComputePolicies(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"VmGroup":                   testConfig.VCD.NsxtProviderVdc.PlacementPolicyVmGroup,

--- a/vcd/resource_vcd_org_vdc_with_vm_placement_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_placement_policy_test.go
@@ -11,9 +11,7 @@ import (
 
 func TestAccVcdOrgVdcWithVmPlacementPolicy(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 	if testConfig.VCD.NsxtProviderVdc.Name == "" {
 		t.Skip("Variable nsxtProviderVdc.Name must be set to run VDC tests")
 	}

--- a/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_org_vdc_with_vm_sizing_policy_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestAccVcdOrgVdcWithVmSizingPolicy(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdOrgVdcWithVmSizingPolicy requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	allocationModel := "Flex"
 

--- a/vcd/resource_vcd_rights_bundle_test.go
+++ b/vcd/resource_vcd_rights_bundle_test.go
@@ -13,10 +13,7 @@ import (
 
 func TestAccVcdRightsBundle(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdRightsBundle requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 	skipTestForApiToken(t)
 	var rightsBundleName = t.Name()
 	var rightsBundleUpdateName = t.Name() + "-update"

--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -15,10 +15,7 @@ import (
 
 func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var (
 		standaloneVmName        = fmt.Sprintf("%s-%d", t.Name(), os.Getpid())

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -14,10 +14,7 @@ import (
 
 func TestAccVcdSubscribedCatalog(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var (
 		publisherDescription  = "test publisher catalog"

--- a/vcd/resource_vcd_vapp_and_vm_with_compute_policies_test.go
+++ b/vcd/resource_vcd_vapp_and_vm_with_compute_policies_test.go
@@ -12,10 +12,7 @@ import (
 
 func TestAccVcdVAppAndVmWithComputePolicies(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Name":                      t.Name(),

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -690,10 +690,7 @@ resource "vcd_vm" "empty-vm" {
 // (without any CPU/Memory values)
 func TestAccVcdVAppVm_4types_sizing_min(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"TestName":       t.Name(),
@@ -956,10 +953,7 @@ resource "vcd_vm" "empty-vm" {
 // sizing policy and no compute parameters specified in the VM resource itself
 func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"TestName":       t.Name(),
@@ -1139,10 +1133,7 @@ resource "vcd_vm" "empty-vm" {
 // works but memory is still required for empty VMs
 func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skipf("%s requires system admin privileges", t.Name())
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"TestName":       t.Name(),

--- a/vcd/resource_vcd_vm_internal_disk_test.go
+++ b/vcd/resource_vcd_vm_internal_disk_test.go
@@ -17,10 +17,7 @@ func TestAccVcdVmInternalDisk(t *testing.T) {
 	preTestChecks(t)
 
 	// In general VM internal disks works with Org users, but since we need to create VDC with disabled fast provisioning value, we have to be sys admins
-	if !usingSysAdmin() {
-		t.Skip("VM internal disks tests requires system admin privileges")
-		return
-	}
+	skipIfNotSysAdmin(t)
 
 	if testConfig.VCD.ProviderVdc.StorageProfile == "" || testConfig.VCD.ProviderVdc.StorageProfile2 == "" {
 		t.Skip("Both variables testConfig.VCD.ProviderVdc.StorageProfile and testConfig.VCD.ProviderVdc.StorageProfile2 must be set")

--- a/vcd/resource_vcd_vm_placement_policy_test.go
+++ b/vcd/resource_vcd_vm_placement_policy_test.go
@@ -12,9 +12,7 @@ import (
 
 func TestAccVcdVmPlacementPolicy(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 	if testConfig.VCD.ProviderVdc.Name == "" {
 		t.Skip("Variable providerVdc.Name must be set to run VDC tests")
 	}
@@ -136,9 +134,7 @@ data "vcd_vm_placement_policy" "data-{{.PolicyName}}" {
 // corresponds to a VM Placement Policy with an empty description in VCD.
 func TestAccVcdVmPlacementPolicyWithoutDescription(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip(t.Name() + " requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 	if testConfig.VCD.ProviderVdc.Name == "" {
 		t.Skip("Variable providerVdc.Name must be set to run VDC tests")
 	}

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -15,9 +15,7 @@ var TestVmPolicy = "TestVmPolicyBasic"
 
 func TestAccVcdVmSizingPolicy(t *testing.T) {
 	preTestChecks(t)
-	if !usingSysAdmin() {
-		t.Skip("TestAccVcdVmSizingPolicy requires system admin privileges")
-	}
+	skipIfNotSysAdmin(t)
 
 	if testConfig.VCD.ProviderVdc.Name == "" {
 		t.Skip("Variable providerVdc.Name must be set to run VDC tests")


### PR DESCRIPTION
This PR does three main things:

1. Skips specific tests that require system administrator when running as org-user
    *  `TestAccDataSourceNotFound/vcd_org_ldap`
    *  `TestAccDataSourceNotFound/vcd_provider_vdc`
    *  `TestAccDataSourceNotFound/vcd_vm_group`
    * `TestAccVcdVdcMetadata`
    * `TestAccVcdDirectNetworkMetadata`
    * `TestAccVcdOrgMetadata`
2. Refactor `testSpecificDataSourceNotFound` to make it easier to add new data sources
3. Uses function `skipIfNotSysAdmin` to replace the block below, which was used 100+ times

```
if !usingSysAdmin() {
    t.Skip(t.Name() + " requires system admin privileges")
}
```