### PR TITLE
Fix typos and other mistakes in the provider documentation

### DIFF
--- a/.changes/v3.8.0/917-features.md
+++ b/.changes/v3.8.0/917-features.md
@@ -1,12 +1,11 @@
 * Added attribute `metadata_entry` to the following data sources:
-  `vcd_catalog`, `vcd_catalog_media`, `vcd_catalog_vapp_template`, `vcd_independent_disk`, `vcd_network_direct`,
-  `vcd_network_isolated`, `vcd_network_isolated_v2`, `vcd_network_routed`, `vcd_network_routed_v2`, `vcd_org`,
-  `vcd_org_vdc`, `vcd_provider_vdc`, `vcd_storage_profile`, `vcd_vapp`, `vcd_vapp_vm`. This new attribute replaces `metadata`
+  `vcd_catalog`, `vcd_catalog_media`, `vcd_independent_disk`, `vcd_network_direct`, `vcd_network_isolated`,
+  `vcd_network_isolated_v2`, `vcd_network_routed`, `vcd_network_routed_v2`, `vcd_org`, `vcd_org_vdc`, `vcd_provider_vdc`,
+  `vcd_storage_profile`, `vcd_vapp`, `vcd_vapp_vm`. This new attribute replaces `metadata`
   to add support of metadata visibility (user access levels), all the available types and domains for every metadata
   entry. [GH-917]
 * Added attribute `metadata_entry` to the following resources:
-  `vcd_catalog`, `vcd_catalog_media`, `vcd_catalog_vapp_template`, `vcd_independent_disk`, `vcd_network_direct`,
-  `vcd_network_isolated`, `vcd_network_isolated_v2`, `vcd_network_routed`, `vcd_network_routed_v2`, `vcd_org`,
-  `vcd_org_vdc`, `vcd_vapp`, `vcd_vapp_vm`. This new attribute replaces `metadata`
-  to add support of metadata visibility (user access levels), all the available types and domains for every metadata
-  entry. [GH-917]
+  `vcd_catalog`, `vcd_catalog_media`, `vcd_independent_disk`, `vcd_network_direct`, `vcd_network_isolated`,
+  `vcd_network_isolated_v2`, `vcd_network_routed`, `vcd_network_routed_v2`, `vcd_org`, `vcd_org_vdc`, `vcd_vapp`,
+  `vcd_vapp_vm`. This new attribute replaces `metadata` to add support of metadata visibility (user access levels),
+  all the available types and domains for every metadata entry. [GH-917]

--- a/examples/subscribed_catalog/publisher/3.8-catalog_publisher.tf
+++ b/examples/subscribed_catalog/publisher/3.8-catalog_publisher.tf
@@ -41,11 +41,30 @@ resource "vcd_catalog" "test-publisher" {
   delete_force     = "true"
   delete_recursive = "true"
 
-  metadata = {
-    identity     = "published catalog"
-    origin       = var.org
-    host_version = "10.4.1"
+  metadata_entry {
+    key         = "identity"
+    value       = "published catalog"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
   }
+
+  metadata_entry {
+    key         = "origin"
+    value       = var.org
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "host_version"
+    value       = "10.4.1"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
   publish_enabled               = "true"
   cache_enabled                 = "true"
   preserve_identity_information = "false"
@@ -62,12 +81,44 @@ resource "vcd_catalog_vapp_template" "test_vt" {
   ova_path          = "${var.ova_path}/test_vapp_template.ova"
   upload_piece_size = 5
 
-  metadata = {
-    identity       = "published catalog item"
-    origin         = var.org
-    parent         = vcd_catalog.test-publisher.name
-    parent_created = vcd_catalog.test-publisher.created
-    host_version   = "10.4.1"
+  metadata_entry {
+    key         = "identity"
+    value       = "published catalog item"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "origin"
+    value       = var.org
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "parent"
+    value       = vcd_catalog.test-publisher.name
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "parent_created"
+    value       = vcd_catalog.test-publisher.created
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "host_version"
+    value       = "10.4.1"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
   }
 }
 
@@ -80,12 +131,45 @@ resource "vcd_catalog_media" "test_media" {
   description       = "test media item test-media-${count.index}"
   media_path        = "${var.ova_path}/test.iso"
   upload_piece_size = 5
-  metadata = {
-    identity       = "published catalog item"
-    origin         = var.org
-    parent         = vcd_catalog.test-publisher.name
-    parent_created = vcd_catalog.test-publisher.created
-    host_version   = "10.4.1"
+
+  metadata_entry {
+    key         = "identity"
+    value       = "published catalog item"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "origin"
+    value       = var.org
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "parent"
+    value       = vcd_catalog.test-publisher.name
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "parent_created"
+    value       = vcd_catalog.test-publisher.created
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
+  }
+
+  metadata_entry {
+    key         = "host_version"
+    value       = "10.4.1"
+    type        = "MetadataStringValue"
+    user_access = "READWRITE"
+    is_system   = false
   }
 }
 

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -47,7 +47,7 @@ The following arguments are supported:
 * `cache_enabled` - (*v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`.
 * `preserve_identity_information` - (*v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package and you should use it only when necessary. Default is `false`.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata.
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to this Catalog. See [Metadata](#metadata) section for details.
+* `metadata_entry` - A set of metadata entries assigned to this Catalog. See [Metadata](#metadata) section for details.
 * `catalog_version` - (*v3.6+*) Version number from this catalog.
 * `owner_name` - (*v3.6+*) Owner of the catalog.
 * `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.

--- a/website/docs/d/catalog.html.markdown
+++ b/website/docs/d/catalog.html.markdown
@@ -52,8 +52,8 @@ The following arguments are supported:
 * `owner_name` - (*v3.6+*) Owner of the catalog.
 * `number_of_vapp_templates` - (*v3.6+*) Number of vApp templates available in this catalog.
 * `number_of_media` - (*v3.6+*) Number of media items available in this catalog.
-* `vapp_template_list` (*v3.8+*) List of vApp template names in this catalog, in alphabetical order.
-* `media_item_list` (*v3.8+*) List of media item names in this catalog, in alphabetical order.
+* `vapp_template_list` - (*v3.8+*) List of vApp template names in this catalog, in alphabetical order.
+* `media_item_list` - (*v3.8+*) List of media item names in this catalog, in alphabetical order.
 * `is_shared` - (*v3.6+*) Indicates if the catalog is shared.
 * `is_published` - (*v3.6+*) Indicates if this catalog is shared to all organizations.
 * `created` - (*v3.6+*) Date and time of catalog creation

--- a/website/docs/d/catalog_item.html.markdown
+++ b/website/docs/d/catalog_item.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `description` - Catalog item description.
 * `metadata` - Key value map of metadata assigned to the associated vApp template.
 * `catalog_item_metadata` - (Deprecated) Use `metadata_entry` instead. Key value map of metadata assigned to the catalog item.
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to the catalog item. See [Metadata](#metadata) section for details.
+* `metadata_entry` - A set of metadata entries assigned to the catalog item. See [Metadata](#metadata) section for details.
 
 <a id="metadata"></a>
 ## Metadata

--- a/website/docs/d/catalog_item.html.markdown
+++ b/website/docs/d/catalog_item.html.markdown
@@ -75,17 +75,17 @@ The `metadata_entry` (*v3.8+*) is a set of metadata entries that have the follow
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `date` (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `date` - (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
   optional spaces in between. For example: `> 2020-02-01 12:35:00.523Z`
   The filter recognizes several formats, but one of `yyyy-mm-dd [hh:mm[:ss[.nnnZ]]]` or `dd-MMM-yyyy [hh:mm[:ss[.nnnZ]]]`
   is recommended.
   Comparison with equality operator (`==`) need to define the date to the microseconds.
-* `latest` (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
+* `latest` - (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the newest item.
-* `earliest` (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
+* `earliest` - (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the oldest item.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.
 

--- a/website/docs/d/catalog_media.html.markdown
+++ b/website/docs/d/catalog_media.html.markdown
@@ -50,17 +50,17 @@ All attributes defined in [catalog_media](/providers/vmware/vcd/latest/docs/reso
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `date` (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `date` - (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
   optional spaces in between. For example: `> 2020-02-01 12:35:00.523Z`
   The filter recognizes several formats, but one of `yyyy-mm-dd [hh:mm[:ss[.nnnZ]]]` or `dd-MMM-yyyy [hh:mm[:ss[.nnnZ]]]`
   is recommended.
   Comparison with equality operator (`==`) need to define the date to the microseconds.
-* `latest` (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
+* `latest` - (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the newest item.
-* `earliest` (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
+* `earliest` - (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the oldest item.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.
 

--- a/website/docs/d/catalog_vapp_template.html.markdown
+++ b/website/docs/d/catalog_vapp_template.html.markdown
@@ -42,7 +42,17 @@ resource "vcd_catalog_vapp_template" "my-second-vapp_template" {
   description       = "Belongs to ${data.vcd_catalog.my-catalog.name}"
   ova_path          = "/path/to/test_vapp_template.ova"
   upload_piece_size = 5
-  metadata          = data.vcd_catalog_vapp_template.my-first-vapp-template.metadata
+  
+  dynamic "metadata_entry" {
+    for_each = data.vcd_catalog_vapp_template.photon.metadata_entry
+    content {
+      key         = metadata_entry.value["key"]
+      value       = metadata_entry.value["value"]
+      type        = metadata_entry.value["type"]
+      is_system   = metadata_entry.value["is_system"]
+      user_access = metadata_entry.value["user_access"]
+    }
+  }
 }
 ```
 
@@ -75,7 +85,17 @@ resource "vcd_catalog_vapp_template" "my-second-vapp_template" {
   description       = "Belongs to ${data.vcd_org_vdc.my-vdc.name}"
   ova_path          = "/path/to/test_vapp_template.ova"
   upload_piece_size = 5
-  metadata          = data.vcd_catalog_vapp_template.my-first-vapp-template.metadata
+  
+  dynamic "metadata_entry" {
+    for_each = data.vcd_catalog_vapp_template.photon.metadata_entry
+    content {
+      key         = metadata_entry.value["key"]
+      value       = metadata_entry.value["value"]
+      type        = metadata_entry.value["type"]
+      is_system   = metadata_entry.value["is_system"]
+      user_access = metadata_entry.value["user_access"]
+    }
+  }
 }
 ```
 

--- a/website/docs/d/catalog_vapp_template.html.markdown
+++ b/website/docs/d/catalog_vapp_template.html.markdown
@@ -42,7 +42,8 @@ resource "vcd_catalog_vapp_template" "my-second-vapp_template" {
   description       = "Belongs to ${data.vcd_catalog.my-catalog.name}"
   ova_path          = "/path/to/test_vapp_template.ova"
   upload_piece_size = 5
-  
+
+  # Assign all the metadata from the vApp template to this new one.
   dynamic "metadata_entry" {
     for_each = data.vcd_catalog_vapp_template.photon.metadata_entry
     content {
@@ -86,6 +87,7 @@ resource "vcd_catalog_vapp_template" "my-second-vapp_template" {
   ova_path          = "/path/to/test_vapp_template.ova"
   upload_piece_size = 5
   
+  # Assign all the metadata from the vApp template to this new one.
   dynamic "metadata_entry" {
     for_each = data.vcd_catalog_vapp_template.photon.metadata_entry
     content {

--- a/website/docs/d/catalog_vapp_template.html.markdown
+++ b/website/docs/d/catalog_vapp_template.html.markdown
@@ -120,16 +120,16 @@ The following arguments are supported:
 
 ## Filter arguments
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `date` (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `date` - (Optional) is an expression starting with an operator (`>`, `<`, `>=`, `<=`, `==`), followed by a date, with
   optional spaces in between. For example: `> 2020-02-01 12:35:00.523Z`
   The filter recognizes several formats, but one of `yyyy-mm-dd [hh:mm[:ss[.nnnZ]]]` or `dd-MMM-yyyy [hh:mm[:ss[.nnnZ]]]`
   is recommended.
   Comparison with equality operator (`==`) need to define the date to the microseconds.
-* `latest` (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
+* `latest` - (Optional) If `true`, retrieve the latest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the newest item.
-* `earliest` (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
+* `earliest` - (Optional) If `true`, retrieve the earliest item among the ones matching other parameters. If no other parameters
   are set, it retrieves the oldest item.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -64,7 +64,7 @@ All attributes defined in [edge gateway resource](/providers/vmware/vcd/latest/d
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
+* `name_regex` - (Optional) matches the name using a regular expression.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.
 

--- a/website/docs/d/network_direct.html.markdown
+++ b/website/docs/d/network_direct.html.markdown
@@ -81,8 +81,8 @@ The following arguments are supported:
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/network_isolated.html.markdown
+++ b/website/docs/d/network_isolated.html.markdown
@@ -70,8 +70,8 @@ All attributes defined in [isolated network resource](/providers/vmware/vcd/late
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/network_isolated_v2.html.markdown
+++ b/website/docs/d/network_isolated_v2.html.markdown
@@ -47,7 +47,7 @@ data "vcd_network_isolated_v2" "net" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level
-* `owner_id` (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
+* `owner_id` - (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
 and inherited from provider configuration)
 * `vdc` - (Deprecated; Optional) The name of VDC to use. **Deprecated**  in favor of new field
   `owner_id` which supports VDC and VDC Group IDs.
@@ -61,7 +61,7 @@ All attributes defined in [isolated network resource](/providers/vmware/vcd/late
 
 ## Filter arguments
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/network_routed.html.markdown
+++ b/website/docs/d/network_routed.html.markdown
@@ -66,9 +66,9 @@ All attributes defined in [routed network resource](/providers/vmware/vcd/latest
 
 (Supported in provider *v2.9+*)
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
-* `metadata` (Optional) One or more parameters that will match metadata contents.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
+* `metadata` - (Optional) One or more parameters that will match metadata contents.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.
 

--- a/website/docs/d/network_routed_v2.html.markdown
+++ b/website/docs/d/network_routed_v2.html.markdown
@@ -52,7 +52,7 @@ supported.
 
 ## Filter arguments
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/nsxt_alb_service_engine_group.html.markdown
+++ b/website/docs/d/nsxt_alb_service_engine_group.html.markdown
@@ -34,7 +34,7 @@ data "vcd_nsxt_alb_service_engine_group" "demo" {
 The following arguments are supported:
 
 * `name` - (Required)  - Name of Service Engine Group.
-* `sync_on_refresh` (Optional) - A special argument that is not passed to VCD, but alters behaviour of this resource so
+* `sync_on_refresh` - (Optional) - A special argument that is not passed to VCD, but alters behaviour of this resource so
   that it performs a Sync operation on every Terraform refresh. *Note* this may impact refresh performance, but should
   ensure up-to-date information is read. Default is **false**.
 

--- a/website/docs/d/nsxt_network_imported.html.markdown
+++ b/website/docs/d/nsxt_network_imported.html.markdown
@@ -51,7 +51,7 @@ data "vcd_nsxt_network_imported" "net" {
 The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level
-* `owner_id` (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
+* `owner_id` - (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
 and inherited from provider configuration)
 * `vdc` - (Deprecated; Optional) The name of VDC to use. **Deprecated**  in favor of new field
   `owner_id` which supports VDC and VDC Group IDs.
@@ -64,7 +64,7 @@ All attributes defined in [imported network resource](/providers/vmware/vcd/late
 
 ## Filter arguments
 
-* `name_regex` (Optional) matches the name using a regular expression.
-* `ip` (Optional) matches the IP of the resource using a regular expression.
+* `name_regex` - (Optional) matches the name using a regular expression.
+* `ip` - (Optional) matches the IP of the resource using a regular expression.
 
 See [Filters reference](/providers/vmware/vcd/latest/docs/guides/data_source_filters) for details and examples.

--- a/website/docs/d/org.html.markdown
+++ b/website/docs/d/org.html.markdown
@@ -61,7 +61,7 @@ The following arguments are supported:
 * `can_subscribe_external_catalogs` - (*v3.6+*) True if this organization is allowed to subscribe to external catalogs.
 * `delay_after_power_on_seconds` - Specifies this organization's default for virtual machine boot delay after power on.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata assigned to this organization.
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to the organization. See [Metadata](#metadata) section for details.
+* `metadata_entry` - A set of metadata entries assigned to the organization. See [Metadata](#metadata) section for details.
 * `vapp_lease` - (*v2.7+*) Defines lease parameters for vApps created in this organization. See [vApp Lease](#vapp-lease) below for details. 
 * `vapp_template_lease` - (*v2.7+*) Defines lease parameters for vApp templates created in this organization. See [vApp Template Lease](#vapp-template-lease) below for details.
 

--- a/website/docs/d/provider_vdc.html.markdown
+++ b/website/docs/d/provider_vdc.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # vcd\_provider\_vdc
 
-Provides a VMware Cloud Director Provider VDC data source. A Provider VDC can be used to reference a Provider VDC and use its 
+Gives a VMware Cloud Director Provider VDC data source. This data source can be used to reference a Provider VDC and use its 
 data within other resources or data sources.
 
 Supported in provider *v3.8+*
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `host_ids` - Set with all the hosts which are connected to VC server.
 * `vcenter_id` - ID of the vCenter Server that provides the Resource Pools and Datastores.
 * `metadata` - (Deprecated) Use `metadata_entry` instead. Key and value pairs for Provider VDC Metadata.
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to the Provider VDC. See [Metadata](#metadata) section for details.
+* `metadata_entry` - A set of metadata entries assigned to the Provider VDC. See [Metadata](#metadata) section for details.
 
 <a id="compute-capacity"></a>
 ## Compute Capacity

--- a/website/docs/d/resource_schema.html.markdown
+++ b/website/docs/d/resource_schema.html.markdown
@@ -338,7 +338,7 @@ struct_network_isolated = {
 The following arguments are supported:
 
 * `name` - (Required) An unique name to identify the data source
-* `resource_type` (Required) Which resource we want to list. It needs to use the full name of the resource (i.e. "vcd_org",
+* `resource_type` - (Required) Which resource we want to list. It needs to use the full name of the resource (i.e. "vcd_org",
 not simply "org")
 
 ## Attribute Reference

--- a/website/docs/d/resource_schema.html.markdown
+++ b/website/docs/d/resource_schema.html.markdown
@@ -31,7 +31,7 @@ output:
 org_struct = [
   {
     "computed" = false
-    "description" = "When destroying use delete_force=True with delete_recursive=True to remove an org and any objects it contains, regardless of their state."
+    "description" = "When destroying use delete_force=true with delete_recursive=true to remove an org and any objects it contains, regardless of their state."
     "name" = "delete_force"
     "optional" = false
     "required" = true

--- a/website/docs/d/vapp.html.markdown
+++ b/website/docs/d/vapp.html.markdown
@@ -60,7 +60,7 @@ The following arguments are supported:
 * `guest_properties` -  Key value map of vApp guest properties.
 * `status` -  The vApp status as a numeric code
 * `status_text` -  The vApp status as text.
-* `lease` (*v3.5+*) - The information about the vApp lease. It includes the following fields:
+* `lease` - (*v3.5+*) - The information about the vApp lease. It includes the following fields:
   * `runtime_lease_in_sec` - How long any of the VMs in the vApp can run before the vApp is automatically powered off or suspended. 0 means never expires.
   * `storage_lease_in_sec` - How long the vApp is available before being automatically deleted or marked as expired. 0 means never expires.
 

--- a/website/docs/d/vapp.html.markdown
+++ b/website/docs/d/vapp.html.markdown
@@ -56,7 +56,7 @@ The following arguments are supported:
 * `description` An optional description for the vApp
 * `href` - The vApp Hyper Reference
 * `metadata` - (Deprecated) Use `metadata_entry` instead. Key value map of metadata assigned to this vApp. Key and value can be any string. 
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to this vApp. See [Metadata](#metadata) section for details.
+* `metadata_entry` - A set of metadata entries assigned to this vApp. See [Metadata](#metadata) section for details.
 * `guest_properties` -  Key value map of vApp guest properties.
 * `status` -  The vApp status as a numeric code
 * `status_text` -  The vApp status as text.

--- a/website/docs/d/vapp_vm.html.markdown
+++ b/website/docs/d/vapp_vm.html.markdown
@@ -104,7 +104,7 @@ The following arguments are supported:
 * `cpu_shares` - Custom priority for the resource in MHz
 * `cpu_limit` - The limit (in MHz) for how much of CPU can be consumed on the underlying virtualization infrastructure. `-1` value for unlimited.
 * `metadata` - (Deprecated) Use `metadata_entry` instead. Key value map of metadata assigned to this VM
-* `metadata_entry` - (*v3.8+*) A set of metadata entries assigned to this VM. See [Metadata](#metadata) section for details
+* `metadata_entry` - A set of metadata entries assigned to this VM. See [Metadata](#metadata) section for details
 * `disk` -  Independent disk attachment configuration.
 * `network` -  A block defining a network interface. Multiple can be used.
 * `guest_properties` -  Key value map of guest properties

--- a/website/docs/d/vapp_vm.html.markdown
+++ b/website/docs/d/vapp_vm.html.markdown
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 ## Attribute reference
 
-* `vm_type` (*3.2+*) - type of the VM (either `vcd_vapp_vm` or `vcd_vm`)
+* `vm_type` - (*3.2+*) - type of the VM (either `vcd_vapp_vm` or `vcd_vm`)
 * `computer_name` -  Computer name to assign to this virtual machine. 
 * `catalog_name` -  The catalog name in which to find the given vApp Template
 * `template_name` -  The name of the vApp Template to use
@@ -114,8 +114,8 @@ The following arguments are supported:
 * `internal_disk` - (*v2.7+*) A block providing internal disk of VM details
 * `os_type` - (*v2.9+*) Operating System type.
 * `hardware_version` - (*v2.9+*) Virtual Hardware Version (e.g.`vmx-14`, `vmx-13`, `vmx-12`, etc.).
-* `sizing_policy_id` (*v3.0+*, *vCD 10.0+*) VM sizing policy ID.
-* `placement_policy_id` (*v3.8+*) VM placement policy ID.
+* `sizing_policy_id` - (*v3.0+*, *vCD 10.0+*) VM sizing policy ID.
+* `placement_policy_id` - (*v3.8+*) VM placement policy ID.
 * `status` - (*v3.8+*) The vApp status as a numeric code.
 * `status_text` - (*v3.8+*) The vApp status as text.
 

--- a/website/docs/guides/catalog_subscription_and_sharing.html.markdown
+++ b/website/docs/guides/catalog_subscription_and_sharing.html.markdown
@@ -194,6 +194,8 @@ In **scenario 3**, the subscribing catalog will access all items immediately, al
 
 ### Subscription without automatic download 
 
+~> This option is only available to System administrators at the moment, we may extend this to tenant users in future releases.
+
 If we subscribe the catalog without automatic downloads (`make_local_copy = false`) there will be no immediate access to
 the catalog resources. The catalog and its items will need to be synchronised explicitly.
 When we are in this situation, adding `sync_catalog=true` to the creation script will only get general information about the

--- a/website/docs/guides/catalog_subscription_and_sharing.html.markdown
+++ b/website/docs/guides/catalog_subscription_and_sharing.html.markdown
@@ -194,7 +194,7 @@ In **scenario 3**, the subscribing catalog will access all items immediately, al
 
 ### Subscription without automatic download 
 
-~> This option is only available to System administrators at the moment, we may extend this to tenant users in future releases.
+~> This option is only available to System administrators.
 
 If we subscribe the catalog without automatic downloads (`make_local_copy = false`) there will be no immediate access to
 the catalog resources. The catalog and its items will need to be synchronised explicitly.

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `storage_profile_id` - (Optional, *v3.1+*) Allows to set specific storage profile to be used for catalog. **Note.** Data
 source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/storage_profile) can help to lookup storage profile ID.
 * `delete_recursive` - (Required) When destroying use delete_recursive=True to remove the catalog and any objects it contains that are in a state that normally allows removal
-* `delete_force` - (Required) When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state
+* `delete_force` - (Required) When destroying use `delete_force=true` with `delete_recursive=true` to remove a catalog and any objects it contains, regardless of their state
 * `publish_enabled` - (Optional, *v3.6+*) Enable allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation. Default is `false`. 
 * `cache_enabled` - (Optional, *v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`. It is recommended to set it to `true` when publishing the catalog.
 * `preserve_identity_information` - (Optional, *v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package, and you should use it only when necessary. Default is `false`.

--- a/website/docs/r/catalog.html.markdown
+++ b/website/docs/r/catalog.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `storage_profile_id` - (Optional, *v3.1+*) Allows to set specific storage profile to be used for catalog. **Note.** Data
 source [vcd_storage_profile](/providers/vmware/vcd/latest/docs/data-sources/storage_profile) can help to lookup storage profile ID.
 * `delete_recursive` - (Required) When destroying use delete_recursive=True to remove the catalog and any objects it contains that are in a state that normally allows removal
-* `delete_force` -(Required) When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state
+* `delete_force` - (Required) When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state
 * `publish_enabled` - (Optional, *v3.6+*) Enable allows to publish a catalog externally to make its vApp templates and media files available for subscription by organizations outside the Cloud Director installation. Default is `false`. 
 * `cache_enabled` - (Optional, *v3.6+*) Enable early catalog export to optimize synchronization. Default is `false`. It is recommended to set it to `true` when publishing the catalog.
 * `preserve_identity_information` - (Optional, *v3.6+*) Enable include BIOS UUIDs and MAC addresses in the downloaded OVF package. Preserving the identity information limits the portability of the package, and you should use it only when necessary. Default is `false`.

--- a/website/docs/r/edgegateway_settings.html.markdown
+++ b/website/docs/r/edgegateway_settings.html.markdown
@@ -66,7 +66,7 @@ The following arguments are supported:
 Default is `false`. Note: **only System administrators can change this property**. It is ignored by API for Org users.
 * `lb_loglevel` - (Optional) Choose the severity of events to be logged. One of `emergency`,
 `alert`, `critical`, `error`, `warning`, `notice`, `info`, `debug`. Note: **only System administrators can change this property**. It is ignored by API for Org users.
-* `fw_enabled` (Optional) Enable firewall. Default `true`.
+* `fw_enabled` - (Optional) Enable firewall. Default `true`.
 * `fw_default_rule_logging_enabled` (Optional) Enable default firewall rule (last in the processing 
 order) logging. Default `false`.
 * `fw_default_rule_action` (Optional) Default firewall rule (last in the processing order) action.

--- a/website/docs/r/external_network.html.markdown
+++ b/website/docs/r/external_network.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 * `netmask` - (Required) Network mask
 * `dns1` - (Optional) Primary DNS server
 * `dns2` - (Optional) Secondary DNS server
-* `dns_suffix` (Optional) A FQDN for the virtual machines on this network.
+* `dns_suffix` - (Optional) A FQDN for the virtual machines on this network.
 * `static_ip_pool` - (Required) IP ranges used for static pool allocation in the network.  See [IP Pool](#ip-pool) below for details.
 
 <a id="ip-pool"></a>

--- a/website/docs/r/external_network_v2.html.markdown
+++ b/website/docs/r/external_network_v2.html.markdown
@@ -181,7 +181,7 @@ The following arguments are supported:
 * `static_ip_pool` - (Required) IP ranges used for static pool allocation in the network.  See [IP Pool](#ip-pool) below for details.
 * `dns1` - (Optional) Primary DNS server. **Only valid** for NSX-V networks.
 * `dns2` - (Optional) Secondary DNS server. **Only valid** for NSX-V networks.
-* `dns_suffix` (Optional) A FQDN for the virtual machines on this network. **Only valid** for NSX-V networks.
+* `dns_suffix` - (Optional) A FQDN for the virtual machines on this network. **Only valid** for NSX-V networks.
 * `enabled` - (Optional) Default is `true`.
 
 <a id="ip-pool"></a>

--- a/website/docs/r/network_isolated.html.markdown
+++ b/website/docs/r/network_isolated.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `name` - (Required) A unique name for the network
 * `description` - (Optional *v2.6+*) An optional description of the network
 * `netmask` - (Optional) The netmask for the new network. Defaults to `255.255.255.0`
-* `gateway` (Required) The gateway for this network
+* `gateway` - (Required) The gateway for this network
 * `dns1` - (Optional) First DNS server to use.
 * `dns2` - (Optional) Second DNS server to use.
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful 
   when connected as sysadmin working across different organisations
-* `owner_id` (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
+* `owner_id` - (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
 and inherited from provider configuration)
 * `vdc` - (Deprecated; Optional) The name of VDC to use. **Deprecated**  in favor of new field
   `owner_id` which supports VDC and VDC Group IDs.
@@ -90,7 +90,7 @@ and inherited from provider configuration)
 * `description` - (Optional) An optional description of the network
 * `is_shared` - (Optional) **NSX-V only.** Defines if this network is shared between multiple VDCs
   in the Org.  Defaults to `false`.
-* `gateway` (Required) The gateway for this network (e.g. 192.168.1.1)
+* `gateway` - (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
 * `dns1` - (Optional) First DNS server to use.
 * `dns2` - (Optional) Second DNS server to use.

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -112,7 +112,7 @@ The following arguments are supported:
 * `interface_type` - (Optional) An interface for the network. One of `internal` (default), `subinterface`, 
   `distributed` (requires the edge gateway to support distributed networks). NSX-T supports only `internal`
 * `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-V or NSX-T)
-* `gateway` (Required) The gateway for this network (e.g. 192.168.1.1)
+* `gateway` - (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
 * `dns1` - (Optional) First DNS server to use.
 * `dns2` - (Optional) Second DNS server to use.

--- a/website/docs/r/nsxt_alb_pool.html.markdown
+++ b/website/docs/r/nsxt_alb_pool.html.markdown
@@ -127,9 +127,9 @@ The following arguments are supported:
 <a id="member-block"></a>
 ## Member
 
-* `ip_address` (Required) IP address of pool member. 
-* `enabled` (Optional) Defines if the pool member is enabled to receive traffic (default `true`)
-* `port` (Optional) Port for receiving traffic - overrides the root value `default_port` for individual members
+* `ip_address` - (Required) IP address of pool member. 
+* `enabled` - (Optional) Defines if the pool member is enabled to receive traffic (default `true`)
+* `port` - (Optional) Port for receiving traffic - overrides the root value `default_port` for individual members
 * `ratio` (Optional) Ratio of selecting eligible servers in the pool (default `1`)
 
 ### Attributes of members

--- a/website/docs/r/nsxt_distributed_firewall.html.markdown
+++ b/website/docs/r/nsxt_distributed_firewall.html.markdown
@@ -87,7 +87,7 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `vdc_group_id` - (Required) The ID of VDC Group to manage Distributed Firewall in. Can be looked
   up using `vcd_vdc_group` resource or data source.
-* `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions. **Order**
+* `rule` - (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions. **Order**
   defines firewall rule precedence
 
 <a id="firewall-rule"></a>
@@ -113,9 +113,9 @@ groups`). Leaving it empty matches `Any` (all)
 * `app_port_profile_ids` - (Optional) An optional set of Application Port Profiles.
 * `network_context_profile_ids` - (Optional) An optional set of Network Context Profiles. Can be
   looked up using `vcd_nsxt_network_context_profile` data source.
-* `source_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `source_ids` for the rule to
+* `source_groups_excluded` - (Optional; VCD 10.3.2+) - reverses value of `source_ids` for the rule to
   match everything except specified IDs.
-* `destination_groups_excluded` (Optional; VCD 10.3.2+) - reverses value of `destination_ids` for
+* `destination_groups_excluded` - (Optional; VCD 10.3.2+) - reverses value of `destination_ids` for
   the rule to match everything except specified IDs.
 
 ## Importing

--- a/website/docs/r/nsxt_edgegateway.html.markdown
+++ b/website/docs/r/nsxt_edgegateway.html.markdown
@@ -230,9 +230,9 @@ can be used to lookup ID by name.
 <a id="edgegateway-subnet"></a>
 ## Edge Gateway Subnet
 
-* `gateway` (Required) - Gateway for a subnet in external network
-* `prefix_length` (Required) - Prefix length of a subnet in external network (e.g. 24 for netmask of 255.255.255.0)
-* `primary_ip` (Optional) - Primary IP address for edge gateway. **Note:** `primary_ip` must fall into `allocated_ips`
+* `gateway` - (Required) - Gateway for a subnet in external network
+* `prefix_length` - (Required) - Prefix length of a subnet in external network (e.g. 24 for netmask of 255.255.255.0)
+* `primary_ip` - (Optional) - Primary IP address for edge gateway. **Note:** `primary_ip` must fall into `allocated_ips`
 block range as otherwise `plan` will not be clean with a new range defined for that particular block. There __can only
 be one__ `primary_ip` defined for edge gateway.
 * `allocated_ips` (Required) - One or more blocks of [ip ranges](#edgegateway-subnet-ip-allocation) in the subnet to be
@@ -241,8 +241,8 @@ allocated
 <a id="edgegateway-subnet-ip-allocation"></a>
 ## Edge Gateway Subnet IP Allocation
 
-* `start_address` (Required) - Start IP address of a range
-* `end_address` (Required) - End IP address of a range
+* `start_address` - (Required) - Start IP address of a range
+* `end_address` - (Required) - End IP address of a range
 
 
 ## Attribute Reference

--- a/website/docs/r/nsxt_edgegateway_bgp_configuration.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_bgp_configuration.html.markdown
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
 * `enabled` - (Required) Defines if BGP service is enabled or not
-* `ecmp_enabled` (Optional) - A flag indicating whether ECMP is enabled or not
+* `ecmp_enabled` - (Optional) - A flag indicating whether ECMP is enabled or not
 * `local_as_number` - (Optional) BGP autonomous systems (AS) number to advertise to BGP peers. BGP
   AS number can be specified in either ASPLAIN or ASDOT formats, like ASPLAIN format : '65546',
   ASDOT format : '1.10'. **Read only** for VRF backed Edge Gateways
@@ -68,10 +68,10 @@ The following arguments are supported:
  * `HELPER_ONLY` - The ability for a BGP speaker to indicate its ability to preserve forwarding
    state during BGP restart
  * `GRACEFUL_AND_HELPER` - The ability of a BGP speaker to advertise its restart to its peers
-* `graceful_restart_timer` (Optional) Maximum time taken (in seconds) for a BGP session to be
+* `graceful_restart_timer` - (Optional) Maximum time taken (in seconds) for a BGP session to be
   established after a restart. If the session is not re-established within this timer, the receiving
   speaker will delete all the stale routes from that peer. **Read only** for VRF backed Edge Gateways.
-* `stale_route_timer` (Optional) - Maximum time (in seconds) before stale routes are removed when
+* `stale_route_timer` - (Optional) - Maximum time (in seconds) before stale routes are removed when
   BGP restarts. **Read only** for VRF backed Edge Gateways
 
 More information about settings can be found in VMware Cloud Director [BGP Configuration

--- a/website/docs/r/nsxt_firewall.html.markdown
+++ b/website/docs/r/nsxt_firewall.html.markdown
@@ -79,7 +79,7 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` datasource
-* `rule` (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
+* `rule` - (Required) One or more blocks with [Firewall Rule](#firewall-rule) definitions
 
 <a id="firewall-rule"></a>
 ## Firewall Rule

--- a/website/docs/r/nsxt_ip_set.html.markdown
+++ b/website/docs/r/nsxt_ip_set.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `description` - (Optional) An optional description of the IP Set
 * `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source.
-* `ip_addresses` (Optional) A set of IP addresses, subnets or ranges (IPv4 or IPv6)
+* `ip_addresses` - (Optional) A set of IP addresses, subnets or ranges (IPv4 or IPv6)
 
 ## Importing
 

--- a/website/docs/r/nsxt_network_imported.html.markdown
+++ b/website/docs/r/nsxt_network_imported.html.markdown
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful when
   connected as sysadmin working across different organisations
-* `owner_id` (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
+* `owner_id` - (Optional) VDC or VDC Group ID. Always takes precedence over `vdc` fields (in resource
 and inherited from provider configuration)
 * `vdc` - (Deprecated; Optional) The name of VDC to use. **Deprecated**  in favor of new field
   `owner_id` which supports VDC and VDC Group IDs.
@@ -71,7 +71,7 @@ and inherited from provider configuration)
   This resource **will fail** if multiple segments with the same name are available. One can rename 
   them in NSX-T manager to make them unique.
 * `description` - (Optional) An optional description of the network
-* `gateway` (Required) The gateway for this network (e.g. 192.168.1.1)
+* `gateway` - (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
 * `dns1` - (Optional) First DNS server to use.
 * `dns2` - (Optional) Second DNS server to use.

--- a/website/docs/r/nsxt_security_group.html.markdown
+++ b/website/docs/r/nsxt_security_group.html.markdown
@@ -72,7 +72,7 @@ The following arguments are supported:
 * `description` - (Optional) An optional description of the Security Group
 * `edge_gateway_id` - (Required) The ID of the Edge Gateway (NSX-T only). Can be looked up using
   `vcd_nsxt_edgegateway` data source
-* `member_org_network_ids` (Optional) A set of Org Network IDs
+* `member_org_network_ids` - (Optional) A set of Org Network IDs
 
 ## Attribute Reference
 * `member_vms` A set of member VMs (if exist). see [Member VMs](#member-vms) below for details.

--- a/website/docs/r/org_user.html.markdown
+++ b/website/docs/r/org_user.html.markdown
@@ -102,7 +102,7 @@ The following arguments are supported:
 * `password` - (Optional, but required if `password_file` was not given and `is_external` is `false`) The user password. This value is never returned 
   on read. It is inspected on create and modify. To modify, fill with a different value. Note that if you remove the 
   password *on update*, Terraform will indicate that a change was occurring, but the empty password will be ignored by vCD.
-* `password_file` (Optional, but required if `password` was not given and `is_external` is `false`). A text file containing the password. Recommended
+* `password_file` - (Optional, but required if `password` was not given and `is_external` is `false`). A text file containing the password. Recommended
   usage: after changing the password, run an apply again with the password blank.
   Using this property instead of `password` has the advantage that the sensitive data is not saved into Terraform state 
   file. The disadvantage is that a password change requires also changing the file name.

--- a/website/docs/r/org_vdc.html.markdown
+++ b/website/docs/r/org_vdc.html.markdown
@@ -235,8 +235,8 @@ The following arguments are supported:
 * `enable_vm_discovery` - (Optional) If true, discovery of vCenter VMs is enabled for resource pools backing this VDC. If false, discovery is disabled. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.
 * `elasticity` - (Optional, *v2.7+*, *VCD 9.7+*) Indicates if the Flex VDC should be elastic. Required with the Flex allocation model.
 * `include_vm_memory_overhead` - (Optional, *v2.7+*, *VCD 9.7+*) Indicates if the Flex VDC should include memory overhead into its accounting for admission control. Required with the Flex allocation model.
-* `delete_force` - (Required) When destroying use `delete_force=True` to remove a VDC and any objects it contains, regardless of their state.
-* `delete_recursive` - (Required) When destroying use `delete_recursive=True` to remove the VDC and any objects it contains that are in a state that normally allows removal.
+* `delete_force` - (Required) When destroying use `delete_force=true` to remove a VDC and any objects it contains, regardless of their state.
+* `delete_recursive` - (Required) When destroying use `delete_recursive=true` to remove the VDC and any objects it contains that are in a state that normally allows removal.
 * `default_compute_policy_id` - (Optional, *v3.8+*, *VCD 10.2+*) ID of the default Compute Policy for this VDC. It can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy.
 * `default_vm_sizing_policy_id` - (Deprecated; Optional, *v3.0+*, *VCD 10.2+*) ID of the default Compute Policy for this VDC. It can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy. Deprecated in favor of `default_compute_policy_id`.
 * `vm_sizing_policy_ids` - (Optional, *v3.0+*, *VCD 10.2+*) Set of IDs of VM Sizing policies that are assigned to this VDC. This field requires `default_compute_policy_id` to be configured together.

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -68,8 +68,8 @@ The following arguments are supported:
   The password is only required when set by the publishing catalog. Passing in six asterisks '******' indicates to keep current password. 
   Passing in an empty string indicates to remove password.
 * `subscription_url` - (Required) The URL to subscribe to the external catalog.
-* `make_local_copy` - (Optional) If true, subscription to a catalog creates a local copy of all items. Defaults to false, which does not create a local copy of catalog items unless a sync operation is performed.
-  It can only be false if the user configured in the provider is the System administrator.
+* `make_local_copy` - (Optional) If `true`, subscription to a catalog creates a local copy of all items. Defaults to `false`, which does not create a local copy of catalog items unless a sync operation is performed.
+  It can only be `false` if the user configured in the provider is the System administrator.
 * `sync_on_refresh` - (Optional) Boolean value that shows if sync should be performed on every refresh.
 * `cancel_failed_tasks` - (Optional) When true, the subscribed catalog will attempt canceling failed tasks.
 * `sync_all` - (Optional) If true, synchronise this catalog and all items. 

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -62,8 +62,8 @@ The following arguments are supported:
 * `org` - (Optional) The name of organization to use, optional if defined at provider level.
 * `name` - (Required) Catalog name
 * `storage_profile_id` - (Optional) Allows to set specific storage profile to be used for catalog.
-* `delete_recursive` - (Optional) When destroying use delete_recursive=True to remove the catalog and any objects it contains that are in a state that normally allows removal.
-* `delete_force` -(Optional) When destroying use delete_force=True with delete_recursive=True to remove a catalog and any objects it contains, regardless of their state.
+* `delete_recursive` - (Optional) When destroying use `delete_recursive=true` to remove the catalog and any objects it contains that are in a state that normally allows removal.
+* `delete_force` -(Optional) When destroying use `delete_force=true` with `delete_recursive=true` to remove a catalog and any objects it contains, regardless of their state.
 * `subscription_password` - (Optional) An optional password to access the catalog. Only ASCII characters are allowed in a valid password. 
   The password is only required when set by the publishing catalog. Passing in six asterisks '******' indicates to keep current password. 
   Passing in an empty string indicates to remove password.
@@ -71,14 +71,14 @@ The following arguments are supported:
 * `make_local_copy` - (Optional) If `true`, subscription to a catalog creates a local copy of all items. Defaults to `false`, which does not create a local copy of catalog items unless a sync operation is performed.
   It can only be `false` if the user configured in the provider is the System administrator.
 * `sync_on_refresh` - (Optional) Boolean value that shows if sync should be performed on every refresh.
-* `cancel_failed_tasks` - (Optional) When true, the subscribed catalog will attempt canceling failed tasks.
-* `sync_all` - (Optional) If true, synchronise this catalog and all items. 
-* `sync_catalog` (Optional) If true, synchronise this catalog. Not to be used when `sync_all` is set. This operation fetches the list of items. If `make_local_copy` is set, it also synchronises all the items.
-* `sync_all_vapp_templates` (Optional) If true, synchronise all vApp templates. Not to be used when `sync_all` is set.
-* `sync_all_media_items` (Optional) If true, synchronise all media items. Not to be used when `sync_all` is set.
+* `cancel_failed_tasks` - (Optional) When `true`, the subscribed catalog will attempt canceling failed tasks.
+* `sync_all` - (Optional) If `true`, synchronise this catalog and all items. 
+* `sync_catalog` (Optional) If `true`, synchronise this catalog. Not to be used when `sync_all` is set. This operation fetches the list of items. If `make_local_copy` is set, it also synchronises all the items.
+* `sync_all_vapp_templates` (Optional) If `true`, synchronise all vApp templates. Not to be used when `sync_all` is set.
+* `sync_all_media_items` (Optional) If `true`, synchronise all media items. Not to be used when `sync_all` is set.
 * `sync_vapp_templates` (Optional) Synchronise a list of vApp templates. Not to be used when `sync_all` or `sync_all_vapp_templates` are set.
 * `sync_media_items` (Optional) Synchronise a list of media items. Not to be used when `sync_all` or `sync_all_media_items` are set.
-* `store_tasks` - (Optional) if true, saves the list of tasks to a file for later update.
+* `store_tasks` - (Optional) if `true`, saves the list of tasks to a file for later update.
  
 ## Attribute Reference
 

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -63,7 +63,7 @@ The following arguments are supported:
 * `name` - (Required) Catalog name
 * `storage_profile_id` - (Optional) Allows to set specific storage profile to be used for catalog.
 * `delete_recursive` - (Optional) When destroying use `delete_recursive=true` to remove the catalog and any objects it contains that are in a state that normally allows removal.
-* `delete_force` -(Optional) When destroying use `delete_force=true` with `delete_recursive=true` to remove a catalog and any objects it contains, regardless of their state.
+* `delete_force` - (Optional) When destroying use `delete_force=true` with `delete_recursive=true` to remove a catalog and any objects it contains, regardless of their state.
 * `subscription_password` - (Optional) An optional password to access the catalog. Only ASCII characters are allowed in a valid password. 
   The password is only required when set by the publishing catalog. Passing in six asterisks '******' indicates to keep current password. 
   Passing in an empty string indicates to remove password.
@@ -73,11 +73,11 @@ The following arguments are supported:
 * `sync_on_refresh` - (Optional) Boolean value that shows if sync should be performed on every refresh.
 * `cancel_failed_tasks` - (Optional) When `true`, the subscribed catalog will attempt canceling failed tasks.
 * `sync_all` - (Optional) If `true`, synchronise this catalog and all items. 
-* `sync_catalog` (Optional) If `true`, synchronise this catalog. Not to be used when `sync_all` is set. This operation fetches the list of items. If `make_local_copy` is set, it also synchronises all the items.
-* `sync_all_vapp_templates` (Optional) If `true`, synchronise all vApp templates. Not to be used when `sync_all` is set.
-* `sync_all_media_items` (Optional) If `true`, synchronise all media items. Not to be used when `sync_all` is set.
-* `sync_vapp_templates` (Optional) Synchronise a list of vApp templates. Not to be used when `sync_all` or `sync_all_vapp_templates` are set.
-* `sync_media_items` (Optional) Synchronise a list of media items. Not to be used when `sync_all` or `sync_all_media_items` are set.
+* `sync_catalog` - (Optional) If `true`, synchronise this catalog. Not to be used when `sync_all` is set. This operation fetches the list of items. If `make_local_copy` is set, it also synchronises all the items.
+* `sync_all_vapp_templates` - (Optional) If `true`, synchronise all vApp templates. Not to be used when `sync_all` is set.
+* `sync_all_media_items` - (Optional) If `true`, synchronise all media items. Not to be used when `sync_all` is set.
+* `sync_vapp_templates` - (Optional) Synchronise a list of vApp templates. Not to be used when `sync_all` or `sync_all_vapp_templates` are set.
+* `sync_media_items` - (Optional) Synchronise a list of media items. Not to be used when `sync_all` or `sync_all_media_items` are set.
 * `store_tasks` - (Optional) if `true`, saves the list of tasks to a file for later update.
  
 ## Attribute Reference

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -69,7 +69,7 @@ The following arguments are supported:
   Passing in an empty string indicates to remove password.
 * `subscription_url` - (Required) The URL to subscribe to the external catalog.
 * `make_local_copy` - (Optional) If true, subscription to a catalog creates a local copy of all items. Defaults to false, which does not create a local copy of catalog items unless a sync operation is performed.
-  It can only be true if the user configured in the provider is the System administrator.
+  It can only be false if the user configured in the provider is the System administrator.
 * `sync_on_refresh` - (Optional) Boolean value that shows if sync should be performed on every refresh.
 * `cancel_failed_tasks` - (Optional) When true, the subscribed catalog will attempt canceling failed tasks.
 * `sync_all` - (Optional) If true, synchronise this catalog and all items. 

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -69,6 +69,7 @@ The following arguments are supported:
   Passing in an empty string indicates to remove password.
 * `subscription_url` - (Required) The URL to subscribe to the external catalog.
 * `make_local_copy` - (Optional) If true, subscription to a catalog creates a local copy of all items. Defaults to false, which does not create a local copy of catalog items unless a sync operation is performed.
+  It can only be true if the user configured in the provider is the System administrator.
 * `sync_on_refresh` - (Optional) Boolean value that shows if sync should be performed on every refresh.
 * `cancel_failed_tasks` - (Optional) When true, the subscribed catalog will attempt canceling failed tasks.
 * `sync_all` - (Optional) If true, synchronise this catalog and all items. 

--- a/website/docs/r/vapp_network.html.markdown
+++ b/website/docs/r/vapp_network.html.markdown
@@ -51,11 +51,11 @@ The following arguments are supported:
 * `description` - (Optional; *v2.7+*, *vCD 9.5+*) Description of vApp network
 * `vapp_name` - (Required) The vApp this network belongs to.
 * `netmask` - (Optional) The netmask for the new network. Default is `255.255.255.0`.
-* `gateway` (Required) The gateway for this network.
+* `gateway` - (Required) The gateway for this network.
 * `dns1` - (Optional) First DNS server to use.
 * `dns2` - (Optional) Second DNS server to use.
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network.
-* `guest_vlan_allowed` (Optional) True if Network allows guest VLAN tagging.
+* `guest_vlan_allowed` - (Optional) True if Network allows guest VLAN tagging.
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for virtual machines; see [IP Pools](#ip-pools) below for details.
 * `dhcp_pool` - (Optional) A range of IPs to issue to virtual machines that don't have a static IP; see [IP Pools](#ip-pools) below for details.
 * `org_network_name` - (Optional; *v2.7+*) An Org network name to which vApp network is connected. If not configured, then an isolated network is created.

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -377,7 +377,7 @@
               <a href="/docs/providers/vcd/r/vm_sizing_policy.html">vcd_vm_sizing_policy</a>
             </li>
             <li<%= sidebar_current("docs-vcd-resource-vm-placement-policy") %>>
-              <a href="/docs/providers/vcd/r/vm_placement_policy.html">vm_placement_policy</a>
+              <a href="/docs/providers/vcd/r/vm_placement_policy.html">vcd_vm_placement_policy</a>
             </li>
             <li<%= sidebar_current("docs-vcd-vm-internal-disk") %>>
               <a href="/docs/providers/vcd/r/vm_internal_disk.html">vcd_vm_internal_disk</a>


### PR DESCRIPTION
This PR fixes all found typos and other mistakes in the provider documentation.

Kudos to @dataclouder for finding most of them 👍 