### PR TITLE
Fix Issue #672 - update Org with invalid LDAP

### DIFF
--- a/.changes/v3.8.1/952-bug-fixes.md
+++ b/.changes/v3.8.1/952-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix issue #672 - Update Org with invalid LDAP [GH-952]

--- a/.changes/v3.8.1/952-bug-fixes.md
+++ b/.changes/v3.8.1/952-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix issue #672 - Update Org with invalid LDAP [GH-952]
+* Fix issue #672 - Update Org with invalid LDAP settings [GH-952]

--- a/website/docs/r/org.html.markdown
+++ b/website/docs/r/org.html.markdown
@@ -145,6 +145,9 @@ Supported in provider *v2.5+*
 ~> **Note:** The current implementation of Terraform import can only import resources into the state. It does not generate
 configuration. [More information.][docs-import]
 
+~> NOTE: when importing and then updating an organization that has LDAP settings, we must import both `vcd_org` and
+`vcd_org_ldap` resources. Setting LDAP outside of Terraform may result in incomplete settings.
+
 An existing Org can be [imported][docs-import] into this resource via supplying the path for an Org. Since the Org is
 at the top of the vCD hierarchy, the path corresponds to the Org name.
 For example, using this structure, representing an existing Org that was **not** created using Terraform:


### PR DESCRIPTION
An Org that has its LDAP settings changed outside Terraform (possibly without error checking and thus incomplete) would fail to update.
This check will prevent invalid LDAP settings from being sent to VCD during the Org update.