### PR TITLE
Fix tags and test TestAccVcdVAppVmMulti

### DIFF
--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -79,7 +79,7 @@ func TestAccVcdVAppVmMulti(t *testing.T) {
 					testAccCheckVcdVAppVmMultiExists("vcd_vapp_vm."+vmName1, vappName2, vmName1),
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName1, "name", vmName1),
 					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName1, "network.0.ip", "10.10.102.161"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName1, "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp."+vappName2, "power_on", "false"),
 				),
 			},
 		},


### PR DESCRIPTION
* Added tag ALL to file containing `TestAccVcdVAppVmMulti`
* Patched `TestAccVcdVAppVmMulti` to power off vApp before removing to prevent  network removal from powered on vApp errors