### PR TITLE
Use changed LDAP structure field sequence

### DIFF
--- a/.changes/v3.8.1/952-bug-fixes.md
+++ b/.changes/v3.8.1/952-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix issue #672 - Update Org with invalid LDAP settings [GH-952]
+* Fix issue #672 - Update Org with invalid or extended LDAP settings [GH-952] [GH-955]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.1
+	github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.2
 )
 
 require (
@@ -59,7 +59,3 @@ require (
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c
-
-// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,7 @@ require (
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c
+
+// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c h1:LQdd9kXac1jY0l8iWvGu8JGOb5g+fYRAWkFGLOwy2sQ=
+github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c/go.mod h1:KjnB8t5l1bRrc+jLKDJbx0vZLRzz2RPzNQ7xzg7yI3o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -178,8 +180,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.1 h1:x3lYpixRSkIsC4I4MkAW+QtwMwVIsF2nImItod5ChGY=
-github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.1/go.mod h1:KjnB8t5l1bRrc+jLKDJbx0vZLRzz2RPzNQ7xzg7yI3o=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkY
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c h1:LQdd9kXac1jY0l8iWvGu8JGOb5g+fYRAWkFGLOwy2sQ=
-github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20221209181540-bf4af8efbe7c/go.mod h1:KjnB8t5l1bRrc+jLKDJbx0vZLRzz2RPzNQ7xzg7yI3o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -180,6 +178,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.2 h1:dAepTtJhTRVEZV+yZFtdYzXZ5zWgm4OJgMOZl2bVGkI=
+github.com/vmware/go-vcloud-director/v2 v2.18.0-alpha.2/go.mod h1:KjnB8t5l1bRrc+jLKDJbx0vZLRzz2RPzNQ7xzg7yI3o=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/vcd/resource_vcd_vapp_vm_multi_test.go
+++ b/vcd/resource_vcd_vapp_vm_multi_test.go
@@ -192,6 +192,7 @@ resource "vcd_vapp_vm" "{{.VmName1}}" {
   memory        = 1024
   cpus          = 2
   cpu_cores     = 1
+  power_on      = {{.PowerOn}}
 
   network {
     type               = "org"
@@ -218,7 +219,8 @@ resource "vcd_vapp_vm" "{{.VmName2}}" {
   template_name = "{{.CatalogItem}}"
   memory        = 1024
   cpus          = 2
-  cpu_cores     = 1 
+  cpu_cores     = 1
+  power_on      = {{.PowerOn}}
 
   network {
     type               = "org"
@@ -238,6 +240,7 @@ resource "vcd_vapp_vm" "{{.VmName3}}" {
   memory        = 1024
   cpus          = 2
   cpu_cores     = 1
+  power_on      = {{.PowerOn}}
   
   network {
     type               = "org"
@@ -245,6 +248,5 @@ resource "vcd_vapp_vm" "{{.VmName3}}" {
     ip_allocation_mode = "MANUAL"
     ip            = "10.10.102.163"
   }
-
 }
 `


### PR DESCRIPTION
Addresses Issue #672 (again!) with changed field sequence in LDAP configuration.

In addition to failing with invalid LDAP configuration, the update also fails when using `group_back_link_identifier`, which was not in the right position in go-vcloud-director types. This change picks the right field sequence.

Test for compatibility:
```
go test -tags functional -run 'TestAccVcdOrgLdap|TestAccVcdOrgGroup' -v -timeout 0
```

Test for this specific issue:

1. apply the script from this [issue comment:](https://github.com/vmware/terraform-provider-vcd/issues/672#issuecomment-1344659008) (change the LDAP server IP or hostname).
2. remove terraform state file
3. remove or comment out from the script the resource `vcd_org_ldap.dummy`
4. run `terraform import vcd_org.dummy dummy`
5. Change the org description and run `terraform apply`
6. check in the UI that the LDAP configuration persists, and that you can import groups.
