### PR TITLE
Fix capitalization of docs guides titles

### DIFF
--- a/website/docs/guides/catalog_subscription_and_sharing.html.markdown
+++ b/website/docs/guides/catalog_subscription_and_sharing.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: Catalog subscription and sharing"
+page_title: "VMware Cloud Director: Catalog Subscription and Sharing"
 sidebar_current: "docs-vcd-guides-catalog-subscription-and-sharing"
 description: |-
  Provides guidance to VMware Cloud catalog publishing, subscribing, and sharing

--- a/website/docs/guides/data_source_filters.html.markdown
+++ b/website/docs/guides/data_source_filters.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: data source filters"
+page_title: "VMware Cloud Director: Data Source Filters"
 sidebar_current: "docs-vcd-guides-filters"
 description: |-
   Provides guidance on filters.

--- a/website/docs/guides/nsxt_alb.html.markdown
+++ b/website/docs/guides/nsxt_alb.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: nsxt alb"
+page_title: "VMware Cloud Director: NSX-T Advanced Load Balancer"
 sidebar_current: "docs-vcd-guides-nsxt-alb"
 description: |-
   Provides guidance to VMware NSX Advanced Load Balancer (Avi)

--- a/website/docs/guides/roles_management.html.markdown
+++ b/website/docs/guides/roles_management.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "vcd"
-page_title: "VMware Cloud Director: roles management"
+page_title: "VMware Cloud Director: Roles Management"
 sidebar_current: "docs-vcd-guides-roles"
 description: |-
  Provides guidance to VMware Cloud roles management
 ---
 
-# Roles management
+# Roles Management
 
 Supported in provider *v3.3+*.
 


### PR DESCRIPTION
Make guides titles consistently capitalized