### PR TITLE
Try to amend TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVm

### DIFF
--- a/.changes/v3.8.2/980-notes.md
+++ b/.changes/v3.8.2/980-notes.md
@@ -1,0 +1,2 @@
+* Try to amend quirky test `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVm` that sometimes fails due to a bad filter.
+  It now uses a shorter name for the Dynamic Security Groups to try to not break the resulting filter chain [GH-980]

--- a/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
@@ -410,7 +410,7 @@ func TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms(t *testing.T) {
 		"NsxtVdc":  testConfig.Nsxt.Vdc,
 		"VdcGroup": testConfig.Nsxt.VdcGroup,
 		"EdgeGw":   testConfig.Nsxt.VdcGroupEdgeGateway,
-		"TestName": t.Name(),
+		"TestName": "DSGVdcGroupCritWithVms", // Shortened name instead of t.Name() as it could be the reason sometimes VdcGroup.GetNsxtFirewallGroupByName fails complaining about the filter
 		"Tags":     "network nsxt",
 	}
 	testParamsNotEmpty(t, params)
@@ -591,7 +591,7 @@ resource "vcd_nsxt_dynamic_security_group" "group1" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group1"
+  name = "{{.TestName}}-1"
 
   criteria {
 	rule {
@@ -607,7 +607,7 @@ resource "vcd_nsxt_dynamic_security_group" "group2" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group2"
+  name = "{{.TestName}}-2"
 
   criteria {
     rule {
@@ -623,7 +623,7 @@ resource "vcd_nsxt_dynamic_security_group" "group3" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group3"
+  name = "{{.TestName}}-3"
 
   criteria {
     rule {
@@ -639,7 +639,7 @@ resource "vcd_nsxt_dynamic_security_group" "group4" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group4"
+  name = "{{.TestName}}-4"
 
   criteria {
     rule {
@@ -657,28 +657,28 @@ data "vcd_nsxt_dynamic_security_group" "group1" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group1"
+  name = "{{.TestName}}-1"
 }
 
 data "vcd_nsxt_dynamic_security_group" "group2" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group2"
+  name = "{{.TestName}}-2"
 }
 
 data "vcd_nsxt_dynamic_security_group" "group3" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group3"
+  name = "{{.TestName}}-3"
 }
 
 data "vcd_nsxt_dynamic_security_group" "group4" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group4"
+  name = "{{.TestName}}-4"
 }
 `
 
@@ -688,7 +688,7 @@ resource "vcd_nsxt_dynamic_security_group" "group5" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group5"
+  name = "{{.TestName}}-5"
 
   criteria {
 	rule {
@@ -704,7 +704,7 @@ resource "vcd_nsxt_dynamic_security_group" "group6" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group6"
+  name = "{{.TestName}}-6"
 
   criteria {
     rule {
@@ -723,14 +723,14 @@ data "vcd_nsxt_dynamic_security_group" "group5" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group5"
+  name = "{{.TestName}}-5"
 }
 
 data "vcd_nsxt_dynamic_security_group" "group6" {
   org          = "{{.Org}}"
   vdc_group_id = data.vcd_vdc_group.group1.id
 
-  name = "{{.TestName}}-group6"
+  name = "{{.TestName}}-6"
 }
 `
 


### PR DESCRIPTION
This PR tries to solve the following test failure that is intermittent and difficult to catch:

```
=== RUN   TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms
    resource_vcd_nsxt_dynamic_security_group_test.go:438: Step 2/4 error: Error running post-apply plan: exit status 1
        
        Error: [nsxt dynamic security group data source read] error getting NSX-T dynamic security group: could not find NSX-T Firewall Group with name 'TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms-group2': error getting all pages for endpoint https://my-super-duper-vcd.company.com/cloudapi/1.0.0/firewallGroups/summaries: error in HTTP GET request: BAD_REQUEST - Cannot parse the supplied filter: typeValue==VM_CRITERIA;ownerRef.id==urn:vcloud:vdcGroup:65aff636-d9ef-4aca-b4ca-3132f6346fde;name==TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms-group2
        
          with data.vcd_nsxt_dynamic_security_group.group2,
          on terraform_plugin_test.tf line 164, in data "vcd_nsxt_dynamic_security_group" "group2":
         164: data "vcd_nsxt_dynamic_security_group" "group2" {
        
--- FAIL: TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms (156.58s)
```

The hypothesis is that the `name` could be too long and sometimes it could break the VCD API filter, but this is not 100% sure.
This PR changes the used name to shorter ones, like
`name==DSGVdcGroupCritWithVms-2`

We should check in future whether this test continues to fail despite this change.