### PR TITLE
Add provider_type OAUTH to vdc_org_group

### DIFF
--- a/.changes/v3.9.0/1013-improvements.md
+++ b/.changes/v3.9.0/1013-improvements.md
@@ -1,1 +1,1 @@
-* `vcd_org_group` adds `OAUTH` as an option to argument `provider_type`  [GH-1013]
+* `vcd_org_group` adds `OAUTH` as an option to argument `provider_type` [GH-1013]

--- a/.changes/v3.9.0/1013-improvements.md
+++ b/.changes/v3.9.0/1013-improvements.md
@@ -1,0 +1,1 @@
+* `vcd_org_group` adds `OAUTH` as an option to argument `provider_type`  [GH-1013]

--- a/.changes/v3.9.0/984-improvements.md
+++ b/.changes/v3.9.0/984-improvements.md
@@ -1,2 +1,2 @@
 * `vcd_external_network_v2` allows setting DNS fields `dns1`, `dns2` and `dns_suffix` for NSX-T
-  backed entities so that it can be inherited by direct Org VDC networks  [GH-984]
+  backed entities so that it can be inherited by direct Org VDC networks [GH-984]

--- a/.changes/v3.9.0/984-improvements.md
+++ b/.changes/v3.9.0/984-improvements.md
@@ -1,3 +1,2 @@
 * `vcd_external_network_v2` allows setting DNS fields `dns1`, `dns2` and `dns_suffix` for NSX-T
   backed entities so that it can be inherited by direct Org VDC networks  [GH-984]
-* `vcd_org_group` adds `OAUTH` as an option to argument `provider_type`  [GH-1013]

--- a/.changes/v3.9.0/984-improvements.md
+++ b/.changes/v3.9.0/984-improvements.md
@@ -1,2 +1,3 @@
 * `vcd_external_network_v2` allows setting DNS fields `dns1`, `dns2` and `dns_suffix` for NSX-T
   backed entities so that it can be inherited by direct Org VDC networks  [GH-984]
+* `vcd_org_group` adds `OAUTH` as an option to argument `provider_type`  [GH-1013]

--- a/vcd/datasource_vcd_org_group.go
+++ b/vcd/datasource_vcd_org_group.go
@@ -25,7 +25,7 @@ func datasourceVcdOrgGroup() *schema.Resource {
 			"provider_type": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Identity provider type - 'SAML' or 'INTEGRATED' for local or LDAP",
+				Description: "Identity provider type for this this group. One of: 'INTEGRATED', 'SAML', 'OAUTH'.",
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/vcd/resource_vcd_org_group.go
+++ b/vcd/resource_vcd_org_group.go
@@ -42,7 +42,7 @@ func resourceVcdOrgGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true, // VCD does not allow to change provider type
-				Description:  "Identity provider type for this this group. One of: 'INTEGRATED', 'SAML', 'OAUTH'."
+				Description:  "Identity provider type for this this group. One of: 'INTEGRATED', 'SAML', 'OAUTH'.",
 				ValidateFunc: validation.StringInSlice([]string{"INTEGRATED", "SAML", "OAUTH"}, false),
 			},
 			"description": {

--- a/vcd/resource_vcd_org_group.go
+++ b/vcd/resource_vcd_org_group.go
@@ -42,8 +42,8 @@ func resourceVcdOrgGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true, // VCD does not allow to change provider type
-				Description:  "Identity provider type - 'SAML' or 'INTEGRATED' for LDAP",
-				ValidateFunc: validation.StringInSlice([]string{"SAML", "INTEGRATED"}, false),
+				Description:  "Identity provider type for this this group. One of: 'INTEGRATED', 'SAML', 'OAUTH'."
+				ValidateFunc: validation.StringInSlice([]string{"INTEGRATED", "SAML", "OAUTH"}, false),
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/website/docs/d/org_group.html.markdown
+++ b/website/docs/d/org_group.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # vcd\_org\_group
 
-Provides a data source for VMware Cloud Director Organization Groups. This can be used to fetch organization groups already defined in `SAML` or `LDAP`.
+Provides a data source for VMware Cloud Director Organization Groups. This can be used to fetch organization groups already defined in `SAML`, `OAUTH` or `LDAP`.
 
 Supported in provider *v3.6+*
 

--- a/website/docs/r/org_group.html.markdown
+++ b/website/docs/r/org_group.html.markdown
@@ -9,12 +9,12 @@ description: |-
 # vcd\_org\_group
 
 Provides a VMware Cloud Director Organization group. This can be used to create, update, and delete
-organization groups defined in `SAML` or `LDAP`.
+organization groups defined in `SAML`, `OAUTH`  or `LDAP`.
 
 Supported in provider *v2.9+*
 
 ~> **Note:** This operation requires the rights included in the predefined `Organization
-Administrator` role or an equivalent set of rights. `SAML` or `LDAP` must be configured as vCD
+Administrator` role or an equivalent set of rights. `SAML`, `OAUTH` or `LDAP` must be configured as vCD
 does not support local groups and will return HTTP error 403 "This operation is denied." if selected
 `provider_type` is not configured.
 
@@ -25,6 +25,18 @@ resource "vcd_org_group" "org1" {
   org = "org1"
 
   provider_type = "SAML"
+  name          = "Org1-AdminGroup"
+  role          = "Organization Administrator"
+}
+```
+
+## Example Usage to add OAUTH group
+
+```hcl
+resource "vcd_org_group" "org1" {
+  org = "org1"
+
+  provider_type = "OAUTH"
   name          = "Org1-AdminGroup"
   role          = "Organization Administrator"
 }
@@ -50,7 +62,7 @@ The following arguments are supported:
 * `org` - (Optional) The name of organization to which the VDC belongs. Optional if defined at provider level.
 * `name` - (Required) A unique name for the group.
 * `description` - (Optional) The description of Organization group
-* `provider_type` - (Required) Identity provider type for this this group. One of `SAML` or
+* `provider_type` - (Required) Identity provider type for this this group. One of `SAML`, `OAUTH` or
   `INTEGRATED`. **Note** `LDAP` must be configured to create `INTEGRATED` groups and names must
   match `LDAP` group names. If LDAP is not configured - it will return 403 errors.
 * `role` - (Required) The role of the group. Role names can be retrieved from the organization. Both built-in roles and

--- a/website/docs/r/org_group.html.markdown
+++ b/website/docs/r/org_group.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # vcd\_org\_group
 
 Provides a VMware Cloud Director Organization group. This can be used to create, update, and delete
-organization groups defined in `SAML`, `OAUTH`  or `LDAP`.
+organization groups defined in `SAML`, `OAUTH` or `LDAP`.
 
 Supported in provider *v2.9+*
 


### PR DESCRIPTION
fixes #1011 
we have organizations using an IdP with oidc and we need to import oauth groups using terrafrom.

Since the changes are trivial, I thought it was a good oppertunity to do them by my self a open a pull request.

#### Changes made:
* add 'OAUTH' to list of valid input for attribute 'provider_type' at resource 'vcd_org_group'
* change description of datasource and resource 'vcd_org_group'
* update docs