### PR TITLE
Fix IndependentDisk, SubscribedCatalog and NsxtDynamicSecurityGroup flaky tests

### DIFF
--- a/.changes/v3.9.0/1014-notes.md
+++ b/.changes/v3.9.0/1014-notes.md
@@ -1,0 +1,3 @@
+* Removed disk update steps from `TestAccVcdIndependentDiskBasic`, created a new one `TestAccVcdIndependentDiskBasicWithUpdates` which will be run only on new releases of VCD (< v10.4.1) [GH-1014]
+* Increased sleep in between testing steps in `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms` from 15s to 25s to let VMs get created. [GH-1014]
+* Added skipping of `TestAccVcdVsphereSubscriber` and `TestAccVcdSubscribedCatalog` if VCD version is older than v10.4.0 as there was a bug with catalog sharing rights that caused the tests to fail. [GH-1014] 

--- a/.changes/v3.9.0/1014-notes.md
+++ b/.changes/v3.9.0/1014-notes.md
@@ -1,3 +1,3 @@
-* Removed disk update steps from `TestAccVcdIndependentDiskBasic`, created a new one `TestAccVcdIndependentDiskBasicWithUpdates` which will be run only on new releases of VCD (>=v10.4.1) [GH-1014]
-* Increased sleep in between testing steps in `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms` from 15s to 25s to let VMs get created. [GH-1014]
-* Added skipping of `TestAccVcdVsphereSubscriber` and `TestAccVcdSubscribedCatalog` if VCD version is older than v10.4.0 as there was a bug with catalog sharing rights that caused the tests to fail. [GH-1014] 
+* Removed disk update steps from `TestAccVcdIndependentDiskBasic`, as it was sometimes failing due to a bug in VCD. Created a new one `TestAccVcdIndependentDiskBasicWithUpdates` which will be run only on new releases of VCD (>=v10.4.1) [GH-1014]
+* Increased sleep in between testing steps in `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms` from 15s to 25s to let VMs get created [GH-1014]
+* Added skipping of `TestAccVcdVsphereSubscriber` and `TestAccVcdSubscribedCatalog` if VCD version is older than v10.4.0 as there was a bug with catalog sharing rights that caused the tests to fail [GH-1014] 

--- a/.changes/v3.9.0/1014-notes.md
+++ b/.changes/v3.9.0/1014-notes.md
@@ -1,3 +1,3 @@
-* Removed disk update steps from `TestAccVcdIndependentDiskBasic`, created a new one `TestAccVcdIndependentDiskBasicWithUpdates` which will be run only on new releases of VCD (< v10.4.1) [GH-1014]
+* Removed disk update steps from `TestAccVcdIndependentDiskBasic`, created a new one `TestAccVcdIndependentDiskBasicWithUpdates` which will be run only on new releases of VCD (>=v10.4.1) [GH-1014]
 * Increased sleep in between testing steps in `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms` from 15s to 25s to let VMs get created. [GH-1014]
 * Added skipping of `TestAccVcdVsphereSubscriber` and `TestAccVcdSubscribedCatalog` if VCD version is older than v10.4.0 as there was a bug with catalog sharing rights that caused the tests to fail. [GH-1014] 

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -180,7 +180,7 @@ func TestAccVcdIndependentDiskBasicWithUpdates(t *testing.T) {
 	// released after v10.4.1.
 	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("<= 37.1") {
-		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
+		t.Skip("This test may fail on versions up to VCD 10.4.1 (API V37.1) because of a known bug. Skipping.")
 	}
 
 	if testConfig.VCD.NsxtProviderVdc.StorageProfile == "" || testConfig.VCD.NsxtProviderVdc.StorageProfile2 == "" {

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -175,8 +175,9 @@ func TestAccVcdIndependentDiskBasicWithUpdates(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	// As of VCD 10.4.1, there might be some errors while updating on the VCD side, so the test is skipped
-	// to be re-evaluated after an upgrade of VCD.
+	// The test is being skipped due to a known bug in the current versions of VCD
+	// when updating the disk resources, thus the test will only be run on versions
+	// released after v10.4.1.
 	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("<= 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -27,6 +27,166 @@ func TestAccVcdIndependentDiskBasic(t *testing.T) {
 	}
 
 	var params = StringMap{
+		"Org":                testConfig.VCD.Org,
+		"Vdc":                testConfig.Nsxt.Vdc,
+		"name":               name,
+		"description":        "independent disk description",
+		"secondName":         name + "second",
+		"size":               "5000",
+		"busType":            "SCSI",
+		"busSubType":         "lsilogicsas",
+		"storageProfileName": testConfig.VCD.NsxtProviderVdc.StorageProfile,
+		"ResourceName":       resourceName,
+		"secondResourceName": resourceNameSecond,
+		"thirdResourceName":  resourceNameThird,
+		"Tags":               "disk",
+		"sizeUpdate":         "6000",
+		"busTypeNvme":        "NVME",
+		"busSubTypeNvme":     "nvmecontroller",
+		"VmName":             t.Name(),
+		"Catalog":            testSuiteCatalogName,
+		"CatalogItem":        testSuiteCatalogOVAItem,
+		"metadataKey":        "key1",
+		"metadataValue":      "value1",
+	}
+	testParamsNotEmpty(t, params)
+
+	params["FuncName"] = t.Name() + "-Compatibility"
+	configTextForCompatibility := templateFill(testAccCheckVcdIndependentDiskForCompatibility, params)
+	params["FuncName"] = t.Name() + "-WithoutOptionals"
+	configTextWithoutOptionals := templateFill(testAccCheckVcdIndependentDiskWithoutOptionals, params)
+	params["FuncName"] = t.Name() + "-Nvme"
+	configTextNvme := templateFill(testAccCheckVcdIndependentDiskNvmeType, params)
+	params["FuncName"] = t.Name() + "-attachedToVm"
+	configTextAttachedToVm := templateFill(testAccCheckVcdIndependentDiskAttachedToVm, params)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configTextForCompatibility)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testDiskResourcesDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: configTextForCompatibility,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskCreated("vcd_independent_disk."+resourceName),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "owner_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "datastore_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "iops", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_type", params["busType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_sub_type", params["busSubType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "is_attached", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "size_in_mb", params["size"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "name", params["name"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "description", params["description"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "storage_profile", params["storageProfileName"].(string)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "uuid", regexp.MustCompile(`^\S+`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "sharing_type", "None"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "encrypted", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "attached_vm_ids.#", "0"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "metadata."+params["metadataKey"].(string), params["metadataValue"].(string)),
+				),
+			},
+			{
+				ResourceName:            "vcd_independent_disk." + resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       importStateIdByDisk("vcd_independent_disk." + resourceName),
+				ImportStateVerifyIgnore: []string{"org", "vdc"},
+			},
+			{
+				Config: configTextWithoutOptionals,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDiskCreated("vcd_independent_disk."+resourceNameSecond),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameSecond, "size_in_mb", params["size"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameSecond, "bus_type", "SCSI"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameSecond, "bus_sub_type", "lsilogic"),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameSecond, "owner_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameSecond, "datastore_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameSecond, "iops", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameSecond, "is_attached", "false"),
+				),
+			},
+			{
+				Config: configTextNvme,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "owner_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "datastore_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "iops", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_type", params["busTypeNvme"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_sub_type", params["busSubTypeNvme"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "is_attached", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "size_in_mb", params["size"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "name", params["name"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "description", params["description"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "storage_profile", params["storageProfileName"].(string)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "uuid", regexp.MustCompile(`^\S+`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "sharing_type", "None"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "encrypted", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "attached_vm_ids.#", "0"),
+				),
+			},
+			{
+				Config: configTextAttachedToVm,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "owner_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "datastore_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "iops", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_type", params["busType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "bus_sub_type", params["busSubType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "is_attached", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "size_in_mb", params["size"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "name", params["name"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "description", params["description"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "storage_profile", params["storageProfileName"].(string)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceName, "uuid", regexp.MustCompile(`^\S+`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "sharing_type", "None"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "encrypted", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceName, "attached_vm_ids.#", "0"),
+
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameThird, "owner_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameThird, "datastore_name", regexp.MustCompile(`^\S+`)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameThird, "iops", regexp.MustCompile(`^\d+$`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "bus_type", params["busType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "bus_sub_type", params["busSubType"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "is_attached", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "size_in_mb", params["size"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "name", resourceNameThird),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "description", params["description"].(string)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "storage_profile", params["storageProfileName"].(string)),
+					resource.TestMatchResourceAttr("vcd_independent_disk."+resourceNameThird, "uuid", regexp.MustCompile(`^\S+`)),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "sharing_type", "None"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "encrypted", "false"),
+					resource.TestCheckResourceAttr("vcd_independent_disk."+resourceNameThird, "attached_vm_ids.#", "0"),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+// TestAccVcdIndependentDiskBasicWithUpdates is very similar to TestAccVcdIndependentDiskBasic, but also tests updating the disks.
+func TestAccVcdIndependentDiskBasicWithUpdates(t *testing.T) {
+	preTestChecks(t)
+	skipIfNotSysAdmin(t)
+
+	// As of VCD 10.4.1, there might be some errors while updating on the VCD side, so the test is skipped
+	// to be re-evaluated after an upgrade of VCD.
+	vcdClient := createTemporaryVCDConnection(false)
+	if vcdClient.Client.APIVCDMaxVersionIs("<= 37.1") {
+		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
+	}
+
+	if testConfig.VCD.NsxtProviderVdc.StorageProfile == "" || testConfig.VCD.NsxtProviderVdc.StorageProfile2 == "" {
+		t.Skip("Both variables testConfig.VCD.ProviderVdc.StorageProfile and testConfig.VCD.ProviderVdc.StorageProfile2 must be set")
+	}
+
+	var params = StringMap{
 		"Org":                      testConfig.VCD.Org,
 		"Vdc":                      testConfig.Nsxt.Vdc,
 		"name":                     name,

--- a/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
+++ b/vcd/resource_vcd_nsxt_dynamic_security_group_test.go
@@ -453,7 +453,7 @@ func TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms(t *testing.T) {
 			{
 				// VM membership is not immediately updated by VCD, therefore we apply the same step to check that VM counts are updated
 				Config:    configText2DS,
-				PreConfig: func() { time.Sleep(time.Second * 15) }, // Sleeping additional 15 seconds to be sure Member VMs are populated by VCD
+				PreConfig: func() { time.Sleep(time.Second * 25) }, // Sleeping additional 25 seconds to be sure Member VMs are populated by VCD
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group1", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),
 					resource.TestMatchResourceAttr("vcd_nsxt_dynamic_security_group.group2", "id", regexp.MustCompile(`^urn:vcloud:firewallGroup:.*$`)),

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -23,6 +23,12 @@ func TestAccVcdVsphereSubscriber(t *testing.T) {
 	if testConfig.VCD.Catalog.VSphereSubscribedCatalog == "" {
 		t.Skip("vSphereSubscribedCatalog was not defined")
 	}
+
+	vcdClient := createTemporaryVCDConnection(false)
+	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
+	}
+
 	subscriberCatalog := t.Name()
 	subscriberOrg := testConfig.VCD.Org
 	var params = StringMap{
@@ -68,6 +74,11 @@ func TestAccVcdVsphereSubscriber(t *testing.T) {
 func TestAccVcdSubscribedCatalog(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
+
+	vcdClient := createTemporaryVCDConnection(false)
+	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
+	}
 
 	var (
 		publisherDescription  = "test publisher catalog"

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -26,7 +26,7 @@ func TestAccVcdVsphereSubscriber(t *testing.T) {
 
 	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
-		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
+		t.Skip("This test may fail with versions prior to 10.4.0 because of side effects from other operations. Skipping.")
 	}
 
 	subscriberCatalog := t.Name()
@@ -77,7 +77,7 @@ func TestAccVcdSubscribedCatalog(t *testing.T) {
 
 	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
-		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
+		t.Skip("This test may fail with versions prior to 10.4.0 because of side effects from other operations. Skipping.")
 	}
 
 	var (


### PR DESCRIPTION
This PR fixes these flaky tests:
* `TestAccVcdIndependentDiskBasic` was sometimes failing while updating the independent disk, but it seems that this is VCD's fault. The `update` steps were removed, and another version of this test was created, `TestAccVcdIndependentDiskBasicWithUpdates` that is automatically skipped on all the current versions of VCD and will be run in the new one to see if the issue is gone.
* `TestAccVcdNsxtDynamicSecurityGroupVdcGroupCriteriaWithVms` was sometimes failing as it was trying to retrieve the count of member VMs, while the VMs weren't fully created, so the time.Sleep() function length was increased to accomodate for the time when VMs are still being created.
* `TestAccVcdVsphereSubscriber` and `TestAccVcdSubscribedCatalog` were failing due to a bug in VCD versions prior to v10.4.0, so they are skipped if ran on versions that don't match that requirement.