### PR TITLE
NSX-T ALB Virtual Service Transparent mode and Pool Firewall Group membership (VCD 10.4.1+)

### DIFF
--- a/.changes/v3.9.0/1024-improvements.md
+++ b/.changes/v3.9.0/1024-improvements.md
@@ -1,0 +1,4 @@
+* Resource and data source `vcd_nsxt_alb_virtual_service` add support for Transparent mode in VCD
+  10.4.1+ via field `is_transparent_mode_enabled` [GH-1024]
+* Resource and data source `vcd_nsxt_alb_pool` add support for pool group membership via field
+  `member_group_id` [GH-1024]

--- a/.changes/v3.9.0/1024-improvements.md
+++ b/.changes/v3.9.0/1024-improvements.md
@@ -1,4 +1,4 @@
 * Resource and data source `vcd_nsxt_alb_virtual_service` add support for Transparent mode in VCD
   10.4.1+ via field `is_transparent_mode_enabled` [GH-1024]
-* Resource and data source `vcd_nsxt_alb_pool` add support for pool group membership via field
+* Resource and data source `vcd_nsxt_alb_pool` add support for Pool Group Membership via field
   `member_group_id` [GH-1024]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.25.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.9
+	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.10
 )
 
 require (
@@ -60,7 +60,3 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230323053049-ff4dada149c5
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -60,5 +60,7 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 56cbf1a3
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230321091205-56cbf1a313c2
+
 //replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,5 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 56cbf1a3
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230323053049-ff4dada149c5 h1:4wMlNxOV9UaLjQQE+3Y59kEPswDIJ6P1AUYFdOZ8TCk=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230323053049-ff4dada149c5/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -198,6 +196,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.10 h1:3Xn5vLmrbchivjwaWhRln46s3MXy9+ZUkVdZVNDZvYQ=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.10/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230321091205-56cbf1a313c2 h1:QR19cNkClmbEJzpTEnnIBXO9Onk7YOFd2G7KqS2Yjhg=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230321091205-56cbf1a313c2/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -196,8 +198,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.7 h1:DggqPLAJMv2Akqy50/ad7zzhzD6Z17UqW54tWpFRUpc=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.7/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -263,3 +263,5 @@ vcd.TestAccVcdVAppVmMulti.tf v3.7.0 "vApp network removal from powered on vApp i
 vcd.ResourceSchema-vcd_nsxt_alb_settings.tf v3.8.2 "New fields to support latest ALB features"
 vcd.ResourceSchema-vcd_vapp_org_network.tf v3.8.2 "New field 'reboot_vapp_on_removal'"
 vcd.ResourceSchema-vcd_vapp_network.tf v3.8.2 "New field 'reboot_vapp_on_removal'"
+vcd.ResourceSchema-vcd_nsxt_alb_virtual_service.tf v3.8.2 "New field 'is_transparent_mode_enabled'"
+vcd.ResourceSchema-vcd_nsxt_alb_pool.tf v3.8.2 "New field 'member_group_id'"

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -150,6 +150,7 @@ type TestConfig struct {
 		NsxtAlbControllerUser     string `json:"nsxtAlbControllerUser"`
 		NsxtAlbControllerPassword string `json:"nsxtAlbControllerPassword"`
 		NsxtAlbImportableCloud    string `json:"nsxtAlbImportableCloud"`
+		NsxtAlbServiceEngineGroup string `json:"nsxtAlbServiceEngineGroup"`
 		RoutedNetwork             string `json:"routedNetwork"`
 		IsolatedNetwork           string `json:"isolatedNetwork"`
 		DirectNetwork             string `json:"directNetwork"`

--- a/vcd/datasource_vcd_nsxt_alb_pool.go
+++ b/vcd/datasource_vcd_nsxt_alb_pool.go
@@ -113,7 +113,7 @@ func datasourceVcdAlbPool() *schema.Resource {
 			"member_group_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "ID of Firewall Group to use for pool Membership (VCD 10.4.1+)",
+				Description: "ID of Firewall Group to use for Pool Membership (VCD 10.4.1+)",
 			},
 			"health_monitor": {
 				Type:     schema.TypeSet,

--- a/vcd/datasource_vcd_nsxt_alb_pool.go
+++ b/vcd/datasource_vcd_nsxt_alb_pool.go
@@ -110,6 +110,11 @@ func datasourceVcdAlbPool() *schema.Resource {
 					},
 				},
 			},
+			"member_group_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID of Firewall Group to use for pool Membership (VCD 10.4.1+)",
+			},
 			"health_monitor": {
 				Type:     schema.TypeSet,
 				Computed: true,

--- a/vcd/datasource_vcd_nsxt_alb_virtual_service.go
+++ b/vcd/datasource_vcd_nsxt_alb_virtual_service.go
@@ -100,6 +100,11 @@ func datasourceVcdAlbVirtualService() *schema.Resource {
 					},
 				},
 			},
+			"is_transparent_mode_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Preserves Client IP on a Virtual Service when enabled",
+			},
 		},
 	}
 }

--- a/vcd/datasource_vcd_nsxt_alb_virtual_service.go
+++ b/vcd/datasource_vcd_nsxt_alb_virtual_service.go
@@ -103,7 +103,7 @@ func datasourceVcdAlbVirtualService() *schema.Resource {
 			"is_transparent_mode_enabled": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "Preserves Client IP on a Virtual Service when enabled",
+				Description: "Preserves Client IP on a Virtual Service when enabled (VCD 10.4.1+)",
 			},
 		},
 	}

--- a/vcd/remove_leftovers_test.go
+++ b/vcd/remove_leftovers_test.go
@@ -265,7 +265,6 @@ func removeLeftovers(govcdClient *govcd.VCDClient, verbose bool) error {
 				}
 			}
 		}
-
 	}
 	// --------------------------------------------------------------
 	// RDE Types
@@ -486,7 +485,6 @@ func removeLeftoversNsxtAlbTenant(govcdClient *govcd.VCDClient, verbose bool) er
 				}
 			}
 		}
-
 	}
 
 	return nil

--- a/vcd/remove_leftovers_test.go
+++ b/vcd/remove_leftovers_test.go
@@ -425,7 +425,7 @@ func removeLeftoversNsxtAlbTenant(govcdClient *govcd.VCDClient, verbose bool) er
 			}
 
 			for _, albEdgeGatewayServiceEngineGroup := range albEdgeGatewayServiceEngineGroups {
-				// Edge Gateay Service Engine Group Assignment does not have names, therefore we use
+				// Edge Gateway Service Engine Group Assignment does not have names, therefore we use
 				// Service Engine Group name as a name for the resource
 				edgeServiceEngineGroupAssignmentName := albEdgeGatewayServiceEngineGroup.NsxtAlbServiceEngineGroupAssignment.ServiceEngineGroupRef.Name
 				toBeDeletedAlbEdgeGatewayServiceEngineGroup := shouldDeleteEntity(alsoDelete, doNotDelete, edgeServiceEngineGroupAssignmentName, "vcd_nsxt_alb_edgegateway_service_engine_group", 4, verbose)

--- a/vcd/remove_leftovers_test.go
+++ b/vcd/remove_leftovers_test.go
@@ -83,9 +83,6 @@ var alsoDelete = entityList{
 	{Type: "vcd_vapp", Name: "Vapp-AC-2", Comment: "from vcd.TestAccVcdVappAccessControl-update.tf: Vapp-AC-2"},
 	{Type: "vcd_vapp", Name: "Vapp-AC-3", Comment: "from vcd.TestAccVcdVappAccessControl-update.tf: Vapp-AC-3"},
 	{Type: "vcd_org_vdc", Name: "ForInternalDiskTest", Comment: "from vcd.TestAccVcdVmInternalDisk-CreateALl.tf: ForInternalDiskTest"},
-	// {Type: "vcd_nsxt_alb_service_engine_group", Name: "first-se", Comment: "from many ALB tests"},
-	// {Type: "vcd_nsxt_alb_edgegateway_service_engine_group", Name: "first-se", Comment: "from many ALB tests"},
-	// {Type: "vcd_nsxt_alb_settings", Name: "first-se", Comment: "from many ALB tests"},
 }
 
 // isTest is a regular expression that tells if an entity needs to be deleted
@@ -323,7 +320,9 @@ func removeLeftoversNsxtAlb(govcdClient *govcd.VCDClient, verbose bool) error {
 				albServiceEngineGroupToBeDeleted := shouldDeleteEntity(alsoDelete, doNotDelete, albServiceEngineGroup.NsxtAlbServiceEngineGroup.Name, "vcd_nsxt_alb_service_engine_group", 2, verbose)
 				if albServiceEngineGroupToBeDeleted {
 
-					// Trigger tenant part cleanup inside Edge Gateways
+					// --------------------------------------------------------------
+					// NSX-T ALB Tenant Configuration cleanup
+					// --------------------------------------------------------------
 					err = removeLeftoversNsxtAlbTenant(govcdClient, verbose)
 					if err != nil {
 						return fmt.Errorf("error removing NSX-T ALB Tenant leftovers: %s", err)
@@ -354,11 +353,6 @@ func removeLeftoversNsxtAlb(govcdClient *govcd.VCDClient, verbose bool) error {
 			}
 		}
 	}
-
-	// --------------------------------------------------------------
-	// NSX-T ALB Provider Configuration cleanup
-	// --------------------------------------------------------------
-
 	return nil
 }
 

--- a/vcd/resource_vcd_nsxt_alb_pool.go
+++ b/vcd/resource_vcd_nsxt_alb_pool.go
@@ -99,7 +99,7 @@ func resourceVcdAlbPool() *schema.Resource {
 			"member_group_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Description:   "ID of Firewall Group to use for pool Membership (VCD 10.4.1+)",
+				Description:   "ID of Firewall Group to use for Pool Membership (VCD 10.4.1+)",
 				ConflictsWith: []string{"member"},
 			},
 			"health_monitor": {

--- a/vcd/resource_vcd_nsxt_alb_pool_test.go
+++ b/vcd/resource_vcd_nsxt_alb_pool_test.go
@@ -28,6 +28,7 @@ func TestAccVcdNsxtAlbPool(t *testing.T) {
 
 	// String map to fill the template
 	var params = StringMap{
+		"TestName":           t.Name(),
 		"PoolName":           t.Name(),
 		"ControllerName":     t.Name(),
 		"ControllerUrl":      testConfig.Nsxt.NsxtAlbControllerUrl,
@@ -685,7 +686,7 @@ resource "vcd_nsxt_alb_controller" "first" {
 }
 
 resource "vcd_nsxt_alb_cloud" "first" {
-  name        = "nsxt-cloud"
+  name        = "{{.TestName}}-alb-cloud"
   description = "first alb cloud"
 
   controller_id       = vcd_nsxt_alb_controller.first.id
@@ -694,7 +695,7 @@ resource "vcd_nsxt_alb_cloud" "first" {
 }
 
 resource "vcd_nsxt_alb_service_engine_group" "first" {
-  name                                 = "first-se"
+  name                                 = "{{.TestName}}-se-group"
   alb_cloud_id                         = vcd_nsxt_alb_cloud.first.id
   importable_service_engine_group_name = "Default-Group"
   reservation_model                    = "{{.ReservationModel}}"

--- a/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
@@ -6,22 +6,12 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
-
-func sleepTester() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		fmt.Println("sleeping")
-		time.Sleep(4 * time.Minute)
-		fmt.Println("finished sleeping")
-		return nil
-	}
-}
 
 func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 	preTestChecks(t)
@@ -130,7 +120,6 @@ func TestAccVcdNsxtAlbVirtualService(t *testing.T) {
 						"end_port":   "81",
 						"type":       "TCP_PROXY",
 					}),
-					sleepTester(),
 				),
 			},
 			{

--- a/website/docs/r/nsxt_alb_pool.html.markdown
+++ b/website/docs/r/nsxt_alb_pool.html.markdown
@@ -117,8 +117,8 @@ The following arguments are supported:
 * `member` - (Optional) A block to define pool members. Multiple can be used. See
   [Member](#member-block) and example for usage details. **Note** only one of `member`,
   `member_group_id` can be specified.
-* `member_group_id` - (Optional, **VCD 10.4.1+**) A reference to Security Group. **Note** only one
-  of `member`, `member_group_id` can be specified.
+* `member_group_id` - (Optional; *v3.9+*, *VCD 10.4.1+*) A reference to NSX-T IP Set (`vcd_nsxt_ip_set`).
+  **Note** only one of `member`, `member_group_id` can be specified.
 * `persistence_profile` - (Optional) Persistence profile will ensure that the same user sticks to the same server for a
   desired duration of time. If the persistence profile is unmanaged by Cloud Director, updates that leave the values
   unchanged will continue to use the same unmanaged profile. Any changes made to the persistence profile will cause

--- a/website/docs/r/nsxt_alb_pool.html.markdown
+++ b/website/docs/r/nsxt_alb_pool.html.markdown
@@ -114,8 +114,11 @@ The following arguments are supported:
 * `domain_names` - (Optional) A set of domain names which will be used to verify the common names or subject alternative
   names presented by the pool member certificates. It is performed only when common name check `cn_check_enabled` is
   enabled
-* `member` - (Optional) A block to define pool members. Multiple can be used. See [Member](#member-block) and example
-  for usage details.
+* `member` - (Optional) A block to define pool members. Multiple can be used. See
+  [Member](#member-block) and example for usage details. **Note** only one of `member`,
+  `member_group_id` can be specified.
+* `member_group_id` - (Optional, **VCD 10.4.1+**) A reference to Security Group. **Note** only one
+  of `member`, `member_group_id` can be specified.
 * `persistence_profile` - (Optional) Persistence profile will ensure that the same user sticks to the same server for a
   desired duration of time. If the persistence profile is unmanaged by Cloud Director, updates that leave the values
   unchanged will continue to use the same unmanaged profile. Any changes made to the persistence profile will cause

--- a/website/docs/r/nsxt_alb_virtual_service.html.markdown
+++ b/website/docs/r/nsxt_alb_virtual_service.html.markdown
@@ -150,7 +150,6 @@ resource "vcd_nsxt_alb_virtual_service" "test" {
   name            = "new-virtual-service"
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-
   # Preserve Client IP - can only be enabled in VCD 10.4.1+ (must also be enabled in `vcd_nsxt_alb_settings`)
   is_transparent_mode_enabled = true
 


### PR DESCRIPTION
This PR continues on ALB feature catchup (started in  #996), where `vcd_nsxt_alb_settings` added support for Transparent mode.



This PR adds two new things (both require VCD 10.4.1+):
* `vcd_nsxt_alb_virtual_service` support for Transparent mode (via field `is_transparent_mode_enabled`)
* `vcd_nsxt_alb_pool` Group membership via `member_group_id` field (members of ALB Pool can come from IP Set instead of being manually enabled) 


**Note** There is quite a list of prerequisites to enable Transparent mode for ALB Virtual Services now. They are well outlined in [this blog post](https://fojta.wordpress.com/2022/12/16/new-networking-features-in-vmware-cloud-director-10-4-1/) (section _Transparent Load Balancing_) however, I don't think it is worth putting it all in our docs as it may soon get outdated due to this being fresh technology. I also observed that errors are meaningful when creation fails due to missed requirements.

#### UI views

`vcd_nsxt_alb_virtual_service`

<img width="575" alt="image" src="https://user-images.githubusercontent.com/15804230/226569912-491efa80-b426-4584-aac2-741dbcc55c78.png">

`vcd_nsxt_alb_pool`
<img width="880" alt="image" src="https://user-images.githubusercontent.com/15804230/226569942-31828acf-2637-4b00-a78e-85e787b464c7.png">


#### Testing 
* Test leftover cleanup support for all ALB resources added. They must _always_ be removed in reverse order as each of them depend on the parent. The cleanup should look similar to this (I am open to discussion if we need to make the indentation somehow different although it does reflect dependencies correctly):
```
....
Start leftovers removal
[vcd_nsxt_alb_controller] TestAccVcdNsxtAlbVirtualService (DELETE)
        [vcd_nsxt_alb_cloud] TestAccVcdNsxtAlbVirtualService-alb-cloud (DELETE)
                [vcd_nsxt_alb_service_engine_group] TestAccVcdNsxtAlbVirtualService-se-group (DELETE)
                        [vcd_nsxt_alb_settings] Testnsxt-gw-datacloud (DELETE)
                                [vcd_nsxt_alb_edgegateway_service_engine_group] TestAccVcdNsxtAlbVirtualService-se-group (DELETE)
                                        [vcd_nsxt_alb_pool] TestAccVcdNsxtAlbVirtualService-pool (DELETE)
                                                [vcd_nsxt_alb_virtual_service] TestAccVcdNsxtAlbVirtualService (DELETE)
[vcd_org] System (keep)
[vcd_org] datacloud (keep)
....
```

Tested on 10.3.0, 10.3.3, 10.4.0, 10.4.1