### PR TITLE
3.9.0-beta.2 release (documentation only improvements from 3.9.0-beta.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.9.0-beta.1 (March 23, 2023)
+## 3.9.0-beta.2 (March 24, 2023)
 
 ### FEATURES
 * **New Resource:** `vcd_rde_interface` to manage Runtime Defined Entity Interfaces

--- a/scripts/hcl-check.sh
+++ b/scripts/hcl-check.sh
@@ -131,7 +131,7 @@ terraform {
   required_providers {
     vcd = {
       source  = \"vmware/vcd\"
-      version = \">=$provider_version\"
+      version = \"= $provider_version\"
     }
     nsxt = {
       source = \"vmware/nsxt\"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # VMware Cloud Director Provider 3.9 (v3.9.0-beta.2)
 
 -> We encourage users to try the **beta** build, and to report errors in the code behavior or in the
-documentation, by opening [an issue](https://github.com/vmware/terraform-provider-vcd/issues),
-making sure to indicate that the report is about the beta version.
+documentation, by opening [an issue](https://github.com/vmware/terraform-provider-vcd/issues)
+and indicating that the report is about the beta version.
 
 To use **beta** version, it **must be selected by an exact version constraint** (the `=` operator or
 no operator). Prerelease versions do not match inexact operators such as `>=`, `~>`, etc. as per

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -6,7 +6,13 @@ description: |-
   The VMware Cloud Director provider is used to interact with the resources supported by VMware Cloud Director. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
-# VMware Cloud Director Provider 3.9
+# Beta Release of VMware Cloud Director Provider 3.9
+
+## Latest stable version 3.8.2 documentation is [here](3-8-2-docs)
+
+~> We encourage users to try the beta build, and to report errors in the code behavior or in the
+documentation, by opening [an issue][terraform-issues], making sure to indicate that the report is
+about the beta version.
 
 The VMware Cloud Director provider is used to interact with the resources supported by VMware Cloud Director. The provider needs to be configured with the proper credentials before it can be used.
 
@@ -326,3 +332,6 @@ Cloud Director connection calls can be expensive, and if a definition file conta
 multiple connections. There is a cache engine, disabled by default, which can be activated by the `VCD_CACHE` 
 environment variable. When enabled, the provider will not reconnect, but reuse an active connection for up to 20 
 minutes, and then connect again.
+
+[3-8-2-docs]:https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs
+[terraform-issues]:https://github.com/vmware/terraform-provider-vcd/issues

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -6,13 +6,29 @@ description: |-
   The VMware Cloud Director provider is used to interact with the resources supported by VMware Cloud Director. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
-# Beta Release of VMware Cloud Director Provider 3.9
+# VMware Cloud Director Provider 3.9 (v3.9.0-beta.2)
 
-## Latest stable version 3.8.2 documentation is [here](3-8-2-docs)
+-> We encourage users to try the **beta** build, and to report errors in the code behavior or in the
+documentation, by opening [an issue](https://github.com/vmware/terraform-provider-vcd/issues),
+making sure to indicate that the report is about the beta version.
 
-~> We encourage users to try the beta build, and to report errors in the code behavior or in the
-documentation, by opening [an issue][terraform-issues], making sure to indicate that the report is
-about the beta version.
+To use **beta** version, it **must be selected by an exact version constraint** (the `=` operator
+or no operator). Prerelease versions do not match inexact operators such as >=, ~>, etc. as per
+[Hashicorp
+documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-behavior).
+
+```
+terraform {
+  required_providers {
+    vcd = {
+      source = "vmware/vcd"
+      version = "3.9.0-beta.2"
+    }
+  }
+}
+```
+
+## Latest stable version 3.8.2 documentation is [here](https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs)
 
 The VMware Cloud Director provider is used to interact with the resources supported by VMware Cloud Director. The provider needs to be configured with the proper credentials before it can be used.
 
@@ -332,6 +348,3 @@ Cloud Director connection calls can be expensive, and if a definition file conta
 multiple connections. There is a cache engine, disabled by default, which can be activated by the `VCD_CACHE` 
 environment variable. When enabled, the provider will not reconnect, but reuse an active connection for up to 20 
 minutes, and then connect again.
-
-[3-8-2-docs]:https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs
-[terraform-issues]:https://github.com/vmware/terraform-provider-vcd/issues

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -12,8 +12,8 @@ description: |-
 documentation, by opening [an issue](https://github.com/vmware/terraform-provider-vcd/issues),
 making sure to indicate that the report is about the beta version.
 
-To use **beta** version, it **must be selected by an exact version constraint** (the `=` operator
-or no operator). Prerelease versions do not match inexact operators such as >=, ~>, etc. as per
+To use **beta** version, it **must be selected by an exact version constraint** (the `=` operator or
+no operator). Prerelease versions do not match inexact operators such as `>=`, `~>`, etc. as per
 [Hashicorp
 documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#version-constraint-behavior).
 


### PR DESCRIPTION
Apparently, Terraform registry puts `3.9.0-beta.1` as latest version in documentation (https://registry.terraform.io/providers/vmware/vcd/latest/docs) which is unexpected (it should be showing latest stable version `v3.8.2`).

This PR is to improve our index page with additional warning that this documentation is for beta version and additional reference to documentation of latest stable version 3.8.2 https://registry.terraform.io/providers/vmware/vcd/3.8.2/docs

**Note.** check-docs was failing because of the code tries pulling in Beta release with inexact version spec
<img width="635" alt="image" src="https://user-images.githubusercontent.com/15804230/227466310-4cbc0ddf-8f63-4afc-9271-d448edab12c2.png">
Constraint for `hclcheck` has been improved to use exact version `=` instead of `>=` which doesn't pull pre-release versions.
