### PR TITLE
add "reboot_vapp_on_removal" field to test's template

### DIFF
--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -115,6 +115,7 @@ func TestAccVcdVappNetwork_Isolated_ipv6(t *testing.T) {
 		"orgNetworkForUpdate":         " ",
 		"retainIpMacEnabled":          "false",
 		"retainIpMacEnabledForUpdate": "false",
+		"RebootVappOnRemoval":         "true",
 	}
 	testParamsNotEmpty(t, params)
 
@@ -562,8 +563,9 @@ resource "vcd_vapp_network" "{{.resourceName}}" {
   {{.OrgNetworkKey}} {{.equalsChar}} {{.quotationChar}}{{.orgNetwork}}{{.quotationChar}}
   
   retain_ip_mac_enabled = "{{.retainIpMacEnabled}}"
+  reboot_vapp_on_removal = {{.RebootVappOnRemoval}}
 
-  depends_on = ["vcd_vapp.{{.vappName}}"]
+  depends_on = [vcd_vapp.{{.vappName}}]
 }
 `
 
@@ -683,7 +685,7 @@ resource "vcd_vapp_network" "{{.resourceName}}" {
   {{.OrgNetworkKey}} {{.equalsChar}} {{.quotationChar}}{{.orgNetworkForUpdate}}{{.quotationChar}}
 
   retain_ip_mac_enabled  = "{{.retainIpMacEnabledForUpdate}}"
-  reboot_vapp_on_removal = true
+  reboot_vapp_on_removal = {{.RebootVappOnRemoval}}
 
   depends_on = ["vcd_vapp.{{.vappName}}"]
 }


### PR DESCRIPTION
Simple PR that adds `reboot_vapp_on_removal: True` field to the `testAccCheckVappNetwork_basic_ipv6` template as it caused the binary test to fail.