### PR TITLE
Go 1.20 support for testing scripts

### DIFF
--- a/.changes/v3.9.0/1034-notes.md
+++ b/.changes/v3.9.0/1034-notes.md
@@ -1,0 +1,2 @@
+* Add support for Go 1.20 in testing workflows [GH-1034]
+* Bump `staticcheck` to 2023.1.3 [GH-1034]

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version: '1.20'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -80,12 +80,12 @@ function check_for_config_file {
 function unit_test {
     if [ -n "$VERBOSE" ]
     then
-        echo "go test -race -i ${TEST} || exit 1"
+        echo "go test -race -tags unit ${TEST} || exit 1"
         echo "go test -race -tags unit -v -timeout 5m"
     fi
     if [ -z "$DRY_RUN" ]
     then
-        go test -race -i ${TEST} || exit 1
+        go test -race -tags unit ${TEST} || exit 1
         go test -race -tags unit -v -timeout 5m
     fi
 }
@@ -99,12 +99,10 @@ function short_test {
     fi
     if [ -n "$VERBOSE" ]
     then
-        echo "go test -race  -i ${TEST} || exit 1"
-        echo "VCD_SHORT_TEST=1 go test -race -tags "functional $MORE_TAGS" -v -timeout 5m"
+        echo "VCD_SHORT_TEST=1 go test -race -tags 'functional $MORE_TAGS' -v -timeout 5m"
     fi
     if [ -z "$DRY_RUN" ]
     then
-        go test -race -i ${TEST} || exit 1
         VCD_SHORT_TEST=1 go test -race -tags "functional $MORE_TAGS" -v -timeout 5m
         check_exit_code
     fi

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,4 +1,3 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=v0.4.3
+export STATICCHECK_VERSION=2023.1.3
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
-

--- a/scripts/staticcheck-config.sh
+++ b/scripts/staticcheck-config.sh
@@ -1,4 +1,4 @@
 export STATICCHECK_URL=https://github.com/dominikh/go-tools/releases/download
-export STATICCHECK_VERSION=v0.3.3
+export STATICCHECK_VERSION=v0.4.3
 export STATICCHECK_FILE=staticcheck_linux_amd64.tar.gz
 


### PR DESCRIPTION
Go 1.20 removed `-i` flag (was deprecated in 1.19) and `make test-binary-prepare` fails on Go 1.20 now. This PR fixes it.

It also uses Go 1.20 in GitHub actions now.

Additionally, it bumps `staticcheck` to latest version `2023.1.3`