### PR TITLE
NSX-T Edge Gateway Rate limiting support 

### DIFF
--- a/.changes/v3.9.0/1042-features.md
+++ b/.changes/v3.9.0/1042-features.md
@@ -1,0 +1,4 @@
+* **New Resource:** `vcd_nsxt_edgegateway_rate_limiting` to manage NSX-T Edge Gateway Rate Limiting [GH-1042]
+* **New Data Source:** `vcd_nsxt_edgegateway_rate_limiting` to read NSX-T Edge Gateway Rate Limiting [GH-1042]
+* **New Data Source:** `vcd_nsxt_edgegateway_qos_profile` to read QoS profiles available for
+  `vcd_nsxt_edgegateway_rate_limiting` resource [GH-1042]

--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,5 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+//replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20211018060826-c7f8ab32330e
+replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.12
+	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.13
 )
 
 require (
@@ -60,5 +60,3 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412105923-df7289e5c488

--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230406053638-7a4b258c84b6

--- a/go.mod
+++ b/go.mod
@@ -60,5 +60,5 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-//replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.12.1-0.20211018060826-c7f8ab32330e
-replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412105923-df7289e5c488 h1:qty7xLpm0/++2IFx9ZepzGGP3lUNbSQnS6FmaN9n2a8=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412105923-df7289e5c488/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -196,6 +194,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.13 h1:WY9DQk3qcymiERA1yrOLK7QaHFHPypoGprjFcjn/AwI=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.13/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb h1:1VKR8+dqFxOAou2RDq3VbEvGSTly+Kt+K6+K2Uwcl3s=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230406053638-7a4b258c84b6 h1:xZjAeAIRIkmbFSUusoObYvQH3IdTSa3GuCkyxty/GPY=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230406053638-7a4b258c84b6/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb h1:1VKR8+dqFxOAou2RDq3VbEvGSTly+Kt+K6+K2Uwcl3s=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230405090112-4095a84ca4fb/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -194,8 +196,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.11 h1:0TNeCF30HtOodx3pQKR9PHSKHDBEYqQ8zMsVhxsa7pM=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.11/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -139,6 +139,7 @@ type TestConfig struct {
 		Manager                   string `json:"manager"`
 		Tier0router               string `json:"tier0router"`
 		Tier0routerVrf            string `json:"tier0routervrf"`
+		GatewayQosProfile         string `json:"gatewayQosProfile"`
 		Vdc                       string `json:"vdc"`
 		ExternalNetwork           string `json:"externalNetwork"`
 		EdgeGateway               string `json:"edgeGateway"`

--- a/vcd/datasource_not_found_test.go
+++ b/vcd/datasource_not_found_test.go
@@ -165,7 +165,8 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 		}
 
 		if (dataSourceName == "vcd_nsxt_edgegateway_bgp_configuration" || dataSourceName == "vcd_nsxt_alb_settings" ||
-			dataSourceName == "vcd_nsxt_firewall" || dataSourceName == "vcd_nsxt_route_advertisement") &&
+			dataSourceName == "vcd_nsxt_firewall" || dataSourceName == "vcd_nsxt_route_advertisement" ||
+			dataSourceName == "vcd_nsxt_edgegateway_rate_limiting") &&
 			mandatoryFields[fieldIndex] == "edge_gateway_id" {
 			// injecting fake Edge Gateway ID
 			templateFields = templateFields + `edge_gateway_id = "urn:vcloud:gateway:784feb3d-87e4-4905-202a-bfe9faa5476f"` + "\n"

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
@@ -29,12 +29,12 @@ func datasourceVcdNsxtEdgeGatewayQosProfile() *schema.Resource {
 			"committed_bandwidth": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Committed bandwidth in Kbps",
+				Description: "Committed bandwidth in Mb/s",
 			},
 			"burst_size": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "Burst size in Kbps",
+				Description: "Burst size in bytes",
 			},
 			"excess_action": {
 				Type:        schema.TypeString,

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
@@ -10,7 +10,6 @@ import (
 func datasourceVcdNsxtEdgeGatewayQosProfile() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: datasourceVcdNsxtEdgeGatewayQosProfileRead,
-
 		Schema: map[string]*schema.Schema{
 			"nsxt_manager_id": {
 				Type:        schema.TypeString,
@@ -47,14 +46,13 @@ func datasourceVcdNsxtEdgeGatewayQosProfile() *schema.Resource {
 }
 
 func datasourceVcdNsxtEdgeGatewayQosProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	vcdClient := meta.(*VCDClient)
 	nsxtManagerId := d.Get("nsxt_manager_id").(string)
 	qosProfileName := d.Get("name").(string)
 
 	qosProfile, err := vcdClient.GetNsxtEdgeGatewayQosProfileByDisplayName(nsxtManagerId, qosProfileName)
 	if err != nil {
-		return diag.Errorf("could not find NSX-T QoS profile by name '%s' in NSX-T manager %s: %s",
+		return diag.Errorf("could not find NSX-T QoS profile by Name '%s' in NSX-T manager %s: %s",
 			qosProfileName, nsxtManagerId, err)
 	}
 

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
@@ -1,0 +1,69 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdNsxtEdgeGatewayQosProfile() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdNsxtEdgeGatewayQosProfileRead,
+
+		Schema: map[string]*schema.Schema{
+			"nsxt_manager_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "ID of NSX-T manager",
+			},
+			"name": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of QoS profile in NSX-T manager",
+			},
+			"description": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Description of QoS profile in NSX-T manager",
+			},
+			"committed_bandwidth": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Committed bandwidth in Kbps",
+			},
+			"burst_size": &schema.Schema{
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Burst size in Kbps",
+			},
+			"excess_action": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Excess action",
+			},
+		},
+	}
+}
+
+func datasourceVcdNsxtEdgeGatewayQosProfileRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	vcdClient := meta.(*VCDClient)
+	nsxtManagerId := d.Get("nsxt_manager_id").(string)
+	qosProfileName := d.Get("name").(string)
+
+	qosProfile, err := vcdClient.GetNsxtEdgeGatewayQosProfileByDisplayName(nsxtManagerId, qosProfileName)
+	if err != nil {
+		return diag.Errorf("could not find NSX-T QoS profile by name '%s' in NSX-T manager %s: %s",
+			qosProfileName, nsxtManagerId, err)
+	}
+
+	d.SetId(qosProfile.NsxtEdgeGatewayQosProfile.ID)
+	dSet(d, "name", qosProfile.NsxtEdgeGatewayQosProfile.DisplayName)
+	dSet(d, "excess_action", qosProfile.NsxtEdgeGatewayQosProfile.ExcessAction)
+	dSet(d, "description", qosProfile.NsxtEdgeGatewayQosProfile.Description)
+	dSet(d, "burst_size", qosProfile.NsxtEdgeGatewayQosProfile.BurstSize)
+	dSet(d, "committed_bandwidth", qosProfile.NsxtEdgeGatewayQosProfile.CommittedBandwidth)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile.go
@@ -14,30 +14,30 @@ func datasourceVcdNsxtEdgeGatewayQosProfile() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"nsxt_manager_id": {
 				Type:        schema.TypeString,
-				Optional:    true,
+				Required:    true,
 				Description: "ID of NSX-T manager",
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of QoS profile in NSX-T manager",
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Description of QoS profile in NSX-T manager",
 			},
-			"committed_bandwidth": &schema.Schema{
+			"committed_bandwidth": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Committed bandwidth in Kbps",
 			},
-			"burst_size": &schema.Schema{
+			"burst_size": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Burst size in Kbps",
 			},
-			"excess_action": &schema.Schema{
+			"excess_action": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Excess action",

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -19,19 +19,10 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 
-	qosProfileName, err := findQosProfile(vcdClient)
-	if err != nil {
-		t.Fatalf("error finding QoS profile: %s", err)
-	}
-
-	if qosProfileName == "" {
-		t.Skip("No QoS profile found. Skipping test")
-	}
-
 	var params = StringMap{
 		"FuncName":           t.Name(),
 		"NsxtManager":        testConfig.Nsxt.Manager,
-		"NsxtQosProfileName": qosProfileName,
+		"NsxtQosProfileName": testConfig.Nsxt.GatewayQosProfile,
 
 		"Tags": "nsxt gateway",
 	}

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -9,8 +9,24 @@ import (
 )
 
 func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
-
 	skipIfNotSysAdmin(t)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil {
+		t.Skip(acceptanceTestsSkipped)
+	}
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
+	}
+
+	qosPolicyName, err := findQosPolicy(vcdClient)
+	if err != nil {
+		t.Fatalf("error finding QoS profile: %s", err)
+	}
+
+	if qosPolicyName == "" {
+		t.Skip("No QoS profile found. Skipping test")
+	}
 
 	var params = StringMap{
 		"FuncName":          t.Name(),

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -9,12 +9,13 @@ import (
 )
 
 func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
-	skipIfNotSysAdmin(t)
-
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
+	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
+		return
 	}
+
+	skipIfNotSysAdmin(t)
+	vcdClient := createTemporaryVCDConnection(false)
 	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
@@ -29,11 +30,6 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 	testParamsNotEmpty(t, params)
 
 	configText := templateFill(testAccVcdDatasourceNsxtGatewayQosProfile, params)
-
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
 	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
 
 	resource.Test(t, resource.TestCase{

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -19,19 +19,19 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 
-	qosPolicyName, err := findQosProfile(vcdClient)
+	qosProfileName, err := findQosProfile(vcdClient)
 	if err != nil {
 		t.Fatalf("error finding QoS profile: %s", err)
 	}
 
-	if qosPolicyName == "" {
+	if qosProfileName == "" {
 		t.Skip("No QoS profile found. Skipping test")
 	}
 
 	var params = StringMap{
 		"FuncName":           t.Name(),
 		"NsxtManager":        testConfig.Nsxt.Manager,
-		"NsxtQosProfileName": qosPolicyName,
+		"NsxtQosProfileName": qosProfileName,
 
 		"Tags": "nsxt gateway",
 	}

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -1,0 +1,59 @@
+//go:build ALL || nsxt || gateway || functional
+
+package vcd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
+
+	skipIfNotSysAdmin(t)
+
+	var params = StringMap{
+		"FuncName":          t.Name(),
+		"NsxtManager":       testConfig.Nsxt.Manager,
+		"NsxtQosPolicyName": "qos-policy-1", // TODO - MUST BE PRECREATED on NSXT Manager
+
+		"Tags": "nsxt gateway",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccVcdDatasourceNsxtGatewayQosProfile, params)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+	debugPrintf("#[DEBUG] CONFIGURATION: %s", configText)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					// ID must match URN 'urn:vcloud:nsxtmanager:09722307-aee0-4623-af95-7f8e577c9ebc'
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_manager.nsxt", "id"),
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "id"),
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "committed_bandwidth"),
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "burst_size"),
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "excess_action"),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdDatasourceNsxtGatewayQosProfile = `
+data "vcd_nsxt_manager" "nsxt" {
+  name = "{{.NsxtManager}}"
+}
+
+data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
+  nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
+  name = "{{.NsxtQosPolicyName}}"
+}
+`

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -19,7 +19,7 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 
-	qosPolicyName, err := findQosPolicy(vcdClient)
+	qosPolicyName, err := findQosProfile(vcdClient)
 	if err != nil {
 		t.Fatalf("error finding QoS profile: %s", err)
 	}
@@ -29,9 +29,9 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 	}
 
 	var params = StringMap{
-		"FuncName":          t.Name(),
-		"NsxtManager":       testConfig.Nsxt.Manager,
-		"NsxtQosPolicyName": "qos-policy-1", // TODO - MUST BE PRECREATED on NSXT Manager
+		"FuncName":           t.Name(),
+		"NsxtManager":        testConfig.Nsxt.Manager,
+		"NsxtQosProfileName": qosPolicyName,
 
 		"Tags": "nsxt gateway",
 	}
@@ -70,6 +70,6 @@ data "vcd_nsxt_manager" "nsxt" {
 
 data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
   nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
-  name = "{{.NsxtQosPolicyName}}"
+  name            = "{{.NsxtQosProfileName}}"
 }
 `

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -1,1 +1,1 @@
-// https://atl1-vcd-static-105-104.eng.vmware.com/cloudapi/1.0.0/nsxTResources/gatewayQoSProfiles?page=1&pageSize=128&filterEncoded=true&filter=(nsxTManagerRef.id==urn:vcloud:nsxtmanager:0d16637d-5adc-4a6e-85e5-90e655c62516)
+package vcd

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -23,12 +23,12 @@ func datasourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
 				Required:    true,
 				Description: "Edge gateway ID for rate limiting Configuration",
 			},
-			"ingress_policy_id": {
+			"ingress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Ingress policy ID for rate limiting Configuration",
 			},
-			"egress_policy_id": {
+			"egress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Egress policy ID for rate limiting Configuration",

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -1,0 +1,1 @@
+// https://atl1-vcd-static-105-104.eng.vmware.com/cloudapi/1.0.0/nsxTResources/gatewayQoSProfiles?page=1&pageSize=128&filterEncoded=true&filter=(nsxTManagerRef.id==urn:vcloud:nsxtmanager:0d16637d-5adc-4a6e-85e5-90e655c62516)

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -21,17 +21,17 @@ func datasourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
 			"edge_gateway_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "Edge gateway ID for rate limiting Configuration",
+				Description: "Edge gateway ID for Rate Limiting (QoS) configuration",
 			},
 			"ingress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Ingress profile ID for rate limiting Configuration",
+				Description: "Ingress profile ID for Rate Limiting (QoS) configuration",
 			},
 			"egress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Egress profile ID for rate limiting Configuration",
+				Description: "Egress profile ID for Rate Limiting (QoS) configuration",
 			},
 		},
 	}
@@ -45,17 +45,17 @@ func datasourceVcdNsxtEdgegatewayRateLimitingRead(ctx context.Context, d *schema
 
 	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
 	if err != nil {
-		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+		return diag.Errorf("[rate limiting (QoS) DS read] error retrieving NSX-T Edge Gateway Rate Limiting (QoS): %s", err)
 	}
 
-	qosProfile, err := nsxtEdge.GetQoS()
+	rateLimitConfig, err := nsxtEdge.GetQoS()
 	if err != nil {
-		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+		return diag.Errorf("[rate limiting (QoS) DS read] error retrieving NSX-T Edge Gateway Rate Limiting (QoS): %s", err)
 	}
 
 	// Rate limiting does not have its own ID - it is a part of Edge Gateway
 	d.SetId(edgeGatewayId)
-	setNsxtEdgeGatewayQosData(d, qosProfile)
+	setNsxtEdgeGatewayRateLimitingData(d, rateLimitConfig)
 
 	return nil
 }

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -1,1 +1,61 @@
 package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdNsxtEdgegatewayRateLimitingRead,
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Edge gateway ID for rate limiting Configuration",
+			},
+			"ingress_policy_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Ingress policy ID for rate limiting Configuration",
+			},
+			"egress_policy_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Egress policy ID for rate limiting Configuration",
+			},
+		},
+	}
+}
+
+func datasourceVcdNsxtEdgegatewayRateLimitingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+	}
+
+	qosPolicy, err := nsxtEdge.GetQoS()
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+	}
+
+	// Rate limiting does not have its own ID - it is a part of Edge Gateway
+	d.SetId(edgeGatewayId)
+	setNsxtEdgeGatewayQosData(d, qosPolicy)
+
+	return nil
+}

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -26,12 +26,12 @@ func datasourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
 			"ingress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Ingress policy ID for rate limiting Configuration",
+				Description: "Ingress profile ID for rate limiting Configuration",
 			},
 			"egress_profile_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "Egress policy ID for rate limiting Configuration",
+				Description: "Egress profile ID for rate limiting Configuration",
 			},
 		},
 	}
@@ -48,14 +48,14 @@ func datasourceVcdNsxtEdgegatewayRateLimitingRead(ctx context.Context, d *schema
 		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
 	}
 
-	qosPolicy, err := nsxtEdge.GetQoS()
+	qosProfile, err := nsxtEdge.GetQoS()
 	if err != nil {
 		return diag.Errorf("[rate limiting (qos) DS read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
 	}
 
 	// Rate limiting does not have its own ID - it is a part of Edge Gateway
 	d.SetId(edgeGatewayId)
-	setNsxtEdgeGatewayQosData(d, qosPolicy)
+	setNsxtEdgeGatewayQosData(d, qosProfile)
 
 	return nil
 }

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -15,6 +15,14 @@ func TestAccVcdDataSourceNsxtEdgeRateLimiting(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil {
+		t.Skip(acceptanceTestsSkipped)
+	}
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
+	}
+
 	// String map to fill the template
 	var params = StringMap{
 		"Org":                  testConfig.VCD.Org,

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -1,0 +1,93 @@
+//go:build gateway || network || nsxt || ALL || functional
+
+package vcd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// TestAccVcdDataSourceNsxtEdgeRateLimiting is a test for datasource
+// vcd_nsxt_edgegateway_rate_limiting It only check if ingress and egress policy IDs are empty
+// ("unlimited" rate). Other values are tested in resource test.
+func TestAccVcdDataSourceNsxtEdgeRateLimiting(t *testing.T) {
+	preTestChecks(t)
+	skipIfNotSysAdmin(t)
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"NsxtVdcGroup":         testConfig.Nsxt.VdcGroup,
+		"NsxtEdgeGwInVdcGroup": testConfig.Nsxt.VdcGroupEdgeGateway,
+		"NsxtEdgeGw":           testConfig.Nsxt.EdgeGateway,
+		"TestName":             t.Name(),
+		"NsxtManager":          testConfig.Nsxt.Manager,
+
+		"Tags": "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText1 := templateFill(testAccVcdDataSourceNsxtEdgeRateLimitingStep1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "id"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "ingress_policy_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "egress_policy_id", ""),
+
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "id"),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "ingress_policy_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "egress_policy_id", ""),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdDataSourceNsxtEdgeRateLimitingStep1 = `
+data "vcd_vdc_group" "g1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdcGroup}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing-in-vdc-group" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.g1.id
+
+  name = "{{.NsxtEdgeGwInVdcGroup}}"
+}
+
+data "vcd_org_vdc" "v1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdc}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing-in-vdc" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_org_vdc.v1.id
+
+  name = "{{.NsxtEdgeGw}}"
+}
+
+data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
+  org               = "{{.Org}}"
+  edge_gateway_id   = data.vcd_nsxt_edgegateway.testing-in-vdc.id
+}
+
+data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc-group" {
+  org               = "{{.Org}}"
+  edge_gateway_id   = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
+}
+`

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -44,12 +44,12 @@ func TestAccVcdDataSourceNsxtEdgeRateLimiting(t *testing.T) {
 				Config: configText1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "id"),
-					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "ingress_policy_id", ""),
-					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "egress_policy_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "ingress_profile_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "egress_profile_id", ""),
 
 					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "id"),
-					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "ingress_policy_id", ""),
-					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "egress_policy_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "ingress_profile_id", ""),
+					resource.TestCheckResourceAttr("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "egress_profile_id", ""),
 				),
 			},
 		},

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // TestAccVcdDataSourceNsxtEdgeRateLimiting is a test for datasource
-// vcd_nsxt_edgegateway_rate_limiting It only check if ingress and egress policy IDs are empty
+// vcd_nsxt_edgegateway_rate_limiting It only check if ingress and egress profile IDs are empty
 // ("unlimited" rate). Other values are tested in resource test.
 func TestAccVcdDataSourceNsxtEdgeRateLimiting(t *testing.T) {
 	preTestChecks(t)

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -90,12 +90,12 @@ data "vcd_nsxt_edgegateway" "testing-in-vdc" {
 }
 
 data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
-  org               = "{{.Org}}"
-  edge_gateway_id   = data.vcd_nsxt_edgegateway.testing-in-vdc.id
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
 }
 
 data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc-group" {
-  org               = "{{.Org}}"
-  edge_gateway_id   = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
 }
 `

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -118,7 +118,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_rde_type":                                  datasourceVcdRdeType(),                          // 3.9
 	"vcd_rde":                                       datasourceVcdRde(),                              // 3.9
 	"vcd_nsxt_edgegateway_qos_profile":              datasourceVcdNsxtEdgeGatewayQosProfile(),        // 3.9
-	"vcd_nsxt_edgegateway_rate_limiting":            datasourceVcdNsxtEdgeGatewayQosProfile(),        // 3.9
+	"vcd_nsxt_edgegateway_rate_limiting":            datasourceVcdNsxtEdgegatewayRateLimiting(),      // 3.9
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -201,7 +201,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_rde_interface":                             resourceVcdRdeInterface(),                     // 3.9
 	"vcd_rde_type":                                  resourceVcdRdeType(),                          // 3.9
 	"vcd_rde":                                       resourceVcdRde(),                              // 3.9
-	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdEdgeBgpConfig(),                    // 3.9
+	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdNsxtEdgegatewayRateLimiting(),      // 3.9
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -118,7 +118,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_rde_type":                                  datasourceVcdRdeType(),                          // 3.9
 	"vcd_rde":                                       datasourceVcdRde(),                              // 3.9
 	"vcd_nsxt_edgegateway_qos_profile":              datasourceVcdNsxtEdgeGatewayQosProfile(),        // 3.9
-	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdEdgeBgpConfig(),                      // 3.9
+	"vcd_nsxt_edgegateway_rate_limiting":            datasourceVcdNsxtEdgeGatewayQosProfile(),        // 3.9
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -117,6 +117,8 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_rde_interface":                             datasourceVcdRdeInterface(),                     // 3.9
 	"vcd_rde_type":                                  datasourceVcdRdeType(),                          // 3.9
 	"vcd_rde":                                       datasourceVcdRde(),                              // 3.9
+	"vcd_nsxt_edgegateway_qos_profile":              datasourceVcdNsxtEdgeGatewayQosProfile(),        // 3.9
+	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdEdgeBgpConfig(),                      // 3.9
 }
 
 var globalResourceMap = map[string]*schema.Resource{
@@ -199,6 +201,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_rde_interface":                             resourceVcdRdeInterface(),                     // 3.9
 	"vcd_rde_type":                                  resourceVcdRdeType(),                          // 3.9
 	"vcd_rde":                                       resourceVcdRde(),                              // 3.9
+	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdEdgeBgpConfig(),                    // 3.9
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -1,0 +1,1 @@
+package vcd

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -36,12 +36,12 @@ func resourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
 				ForceNew:    true,
 				Description: "Edge gateway ID for rate limiting Configuration",
 			},
-			"ingress_policy_id": {
+			"ingress_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Ingress policy ID for rate limiting Configuration",
 			},
-			"egress_policy_id": {
+			"egress_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Egress policy ID for rate limiting Configuration",
@@ -195,8 +195,8 @@ func resourceVcdNsxtEdgegatewayRateLimitingImport(ctx context.Context, d *schema
 func getNsxtEdgeGatewayQosType(d *schema.ResourceData) (*types.NsxtEdgeGatewayQos, error) {
 
 	qosType := &types.NsxtEdgeGatewayQos{}
-	ingressPolicyId := d.Get("ingress_policy_id").(string)
-	egressPolicyId := d.Get("egress_policy_id").(string)
+	ingressPolicyId := d.Get("ingress_profile_id").(string)
+	egressPolicyId := d.Get("egress_profile_id").(string)
 
 	if ingressPolicyId != "" {
 		qosType.IngressProfile = &types.OpenApiReference{
@@ -215,14 +215,14 @@ func getNsxtEdgeGatewayQosType(d *schema.ResourceData) (*types.NsxtEdgeGatewayQo
 
 func setNsxtEdgeGatewayQosData(d *schema.ResourceData, qosType *types.NsxtEdgeGatewayQos) {
 	if qosType.IngressProfile != nil {
-		dSet(d, "ingress_policy_id", qosType.IngressProfile.ID)
+		dSet(d, "ingress_profile_id", qosType.IngressProfile.ID)
 	} else {
-		dSet(d, "ingress_policy_id", "")
+		dSet(d, "ingress_profile_id", "")
 	}
 
 	if qosType.EgressProfile != nil {
-		dSet(d, "egress_policy_id", qosType.EgressProfile.ID)
+		dSet(d, "egress_profile_id", qosType.EgressProfile.ID)
 	} else {
-		dSet(d, "egress_policy_id", "")
+		dSet(d, "egress_profile_id", "")
 	}
 }

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -79,14 +79,14 @@ func resourceVcdNsxtEdgegatewayRateLimitingCreateUpdate(ctx context.Context, d *
 		return diag.Errorf("[rate limiting (qos) create/update] error retrieving Edge Gateway: %s", err)
 	}
 
-	qosPolicy, err := getNsxtEdgeGatewayQosType(d)
+	qosConfig, err := getNsxtEdgeGatewayQosType(d)
 	if err != nil {
-		return diag.Errorf("[rate limiting (qos) create/update] error getting QoS Policy: %s", err)
+		return diag.Errorf("[rate limiting (qos) create/update] error getting QoS configuration: %s", err)
 	}
 
-	_, err = nsxtEdge.UpdateQoS(qosPolicy)
+	_, err = nsxtEdge.UpdateQoS(qosConfig)
 	if err != nil {
-		return diag.Errorf("[rate limiting (qos) create/update] error updating QoS Policy: %s", err)
+		return diag.Errorf("[rate limiting (qos) create/update] error updating QoS configuration: %s", err)
 	}
 
 	d.SetId(edgeGatewayId)
@@ -111,12 +111,12 @@ func resourceVcdNsxtEdgegatewayRateLimitingRead(ctx context.Context, d *schema.R
 		return diag.Errorf("[rate limiting (qos) read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
 	}
 
-	qosPolicy, err := nsxtEdge.GetQoS()
+	qosConfig, err := nsxtEdge.GetQoS()
 	if err != nil {
 		return diag.Errorf("[rate limiting (qos) read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
 	}
 
-	setNsxtEdgeGatewayQosData(d, qosPolicy)
+	setNsxtEdgeGatewayQosData(d, qosConfig)
 
 	return nil
 }
@@ -150,10 +150,10 @@ func resourceVcdNsxtEdgegatewayRateLimitingDelete(ctx context.Context, d *schema
 		return diag.Errorf("[rate limiting (qos) delete] error retrieving Edge Gateway: %s", err)
 	}
 
-	// There is no real "delete" for QoS Policy. It can only be updated to empty values (unlimited)
+	// There is no real "delete" for QoS. It can only be updated to empty values (unlimited)
 	_, err = nsxtEdge.UpdateQoS(&types.NsxtEdgeGatewayQos{})
 	if err != nil {
-		return diag.Errorf("[rate limiting (qos) delete] error updating QoS Policy: %s", err)
+		return diag.Errorf("[rate limiting (qos) delete] error updating QoS Profile: %s", err)
 	}
 
 	return nil
@@ -195,18 +195,18 @@ func resourceVcdNsxtEdgegatewayRateLimitingImport(ctx context.Context, d *schema
 func getNsxtEdgeGatewayQosType(d *schema.ResourceData) (*types.NsxtEdgeGatewayQos, error) {
 
 	qosType := &types.NsxtEdgeGatewayQos{}
-	ingressPolicyId := d.Get("ingress_profile_id").(string)
-	egressPolicyId := d.Get("egress_profile_id").(string)
+	ingressProfileId := d.Get("ingress_profile_id").(string)
+	egressProfileId := d.Get("egress_profile_id").(string)
 
-	if ingressPolicyId != "" {
+	if ingressProfileId != "" {
 		qosType.IngressProfile = &types.OpenApiReference{
-			ID: ingressPolicyId,
+			ID: ingressProfileId,
 		}
 	}
 
-	if egressPolicyId != "" {
+	if egressProfileId != "" {
 		qosType.EgressProfile = &types.OpenApiReference{
-			ID: egressPolicyId,
+			ID: egressProfileId,
 		}
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -1,1 +1,228 @@
 package vcd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func resourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdNsxtEdgegatewayRateLimitingCreateUpdate,
+		UpdateContext: resourceVcdNsxtEdgegatewayRateLimitingCreateUpdate,
+		ReadContext:   resourceVcdNsxtEdgegatewayRateLimitingRead,
+		DeleteContext: resourceVcdNsxtEdgegatewayRateLimitingDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdNsxtEdgegatewayRateLimitingImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"edge_gateway_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Edge gateway ID for rate limiting Configuration",
+			},
+			"ingress_policy_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Ingress policy ID for rate limiting Configuration",
+			},
+			"egress_policy_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Egress policy ID for rate limiting Configuration",
+			},
+		},
+	}
+}
+
+func resourceVcdNsxtEdgegatewayRateLimitingCreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) create/update] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) create/update] error retrieving Edge Gateway: %s", err)
+	}
+
+	qosPolicy, err := getNsxtEdgeGatewayQosType(d)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) create/update] error getting QoS Policy: %s", err)
+	}
+
+	_, err = nsxtEdge.UpdateQoS(qosPolicy)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) create/update] error updating QoS Policy: %s", err)
+	}
+
+	d.SetId(edgeGatewayId)
+
+	return resourceVcdNsxtEdgegatewayRateLimitingRead(ctx, d, meta)
+}
+
+func resourceVcdNsxtEdgegatewayRateLimitingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		if govcd.ContainsNotFound(err) {
+			// When parent Edge Gateway is not found - this resource is also not found and should be
+			// removed from state
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("[rate limiting (qos) read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+	}
+
+	qosPolicy, err := nsxtEdge.GetQoS()
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) read] error retrieving NSX-T Edge Gateway rate limiting (qos): %s", err)
+	}
+
+	setNsxtEdgeGatewayQosData(d, qosPolicy)
+
+	return nil
+}
+
+func resourceVcdNsxtEdgegatewayRateLimitingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// Handling locks on for BGP configuration is conditional. There are two scenarios:
+	// * When the parent Edge Gateway is in a VDC - a lock on parent Edge Gateway must be acquired
+	// * When the parent Edge Gateway is in a VDC Group - a lock on parent VDC Group must be acquired
+	// To find out parent lock object, Edge Gateway must be looked up and its OwnerRef must be checked
+	// Note. It is not safe to do multiple locks in the same resource as it can result in a deadlock
+	parentEdgeGatewayOwnerId, _, err := getParentEdgeGatewayOwnerId(vcdClient, d)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) delete] error finding parent Edge Gateway: %s", err)
+	}
+
+	if govcd.OwnerIsVdcGroup(parentEdgeGatewayOwnerId) {
+		vcdClient.lockById(parentEdgeGatewayOwnerId)
+		defer vcdClient.unlockById(parentEdgeGatewayOwnerId)
+	} else {
+		vcdClient.lockParentEdgeGtw(d)
+		defer vcdClient.unLockParentEdgeGtw(d)
+	}
+
+	orgName := d.Get("org").(string)
+	edgeGatewayId := d.Get("edge_gateway_id").(string)
+
+	nsxtEdge, err := vcdClient.GetNsxtEdgeGatewayById(orgName, edgeGatewayId)
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) delete] error retrieving Edge Gateway: %s", err)
+	}
+
+	// There is no real "delete" for QoS Policy. It can only be updated to empty values (unlimited)
+	_, err = nsxtEdge.UpdateQoS(&types.NsxtEdgeGatewayQos{})
+	if err != nil {
+		return diag.Errorf("[rate limiting (qos) delete] error updating QoS Policy: %s", err)
+	}
+
+	return nil
+}
+
+func resourceVcdNsxtEdgegatewayRateLimitingImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("[TRACE] NSX-T Edge Gateway Rate Limiting (QoS) import initiated")
+
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 3 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.vdc-name.nsxt-edge-gw-name or org-name.vdc-group-name.nsxt-edge-gw-name")
+	}
+	orgName, vdcOrVdcGroupName, edgeName := resourceURI[0], resourceURI[1], resourceURI[2]
+
+	vcdClient := meta.(*VCDClient)
+	vdcOrVdcGroup, err := lookupVdcOrVdcGroup(vcdClient, orgName, vdcOrVdcGroupName)
+	if err != nil {
+		return nil, err
+	}
+
+	if !vdcOrVdcGroup.IsNsxt() {
+		return nil, fmt.Errorf("please use 'vcd_edgegateway' for NSX-V backed VDC")
+	}
+
+	edge, err := vdcOrVdcGroup.GetNsxtEdgeGatewayByName(edgeName)
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve NSX-T Edge Gateway with ID '%s': %s", d.Id(), err)
+	}
+
+	dSet(d, "org", orgName)
+	dSet(d, "edge_gateway_id", edge.EdgeGateway.ID)
+
+	// Storing Edge Gateway ID and Read will retrieve all other data
+	d.SetId(edge.EdgeGateway.ID)
+
+	return []*schema.ResourceData{d}, nil
+}
+
+func getNsxtEdgeGatewayQosType(d *schema.ResourceData) (*types.NsxtEdgeGatewayQos, error) {
+
+	qosType := &types.NsxtEdgeGatewayQos{}
+	ingressPolicyId := d.Get("ingress_policy_id").(string)
+	egressPolicyId := d.Get("egress_policy_id").(string)
+
+	if ingressPolicyId != "" {
+		qosType.IngressProfile = &types.OpenApiReference{
+			ID: ingressPolicyId,
+		}
+	}
+
+	if egressPolicyId != "" {
+		qosType.EgressProfile = &types.OpenApiReference{
+			ID: egressPolicyId,
+		}
+	}
+
+	return qosType, nil
+}
+
+func setNsxtEdgeGatewayQosData(d *schema.ResourceData, qosType *types.NsxtEdgeGatewayQos) {
+	if qosType.IngressProfile != nil {
+		dSet(d, "ingress_policy_id", qosType.IngressProfile.ID)
+	} else {
+		dSet(d, "ingress_policy_id", "")
+	}
+
+	if qosType.EgressProfile != nil {
+		dSet(d, "egress_policy_id", qosType.EgressProfile.ID)
+	} else {
+		dSet(d, "egress_policy_id", "")
+	}
+}

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -159,6 +159,10 @@ func resourceVcdNsxtEdgegatewayRateLimitingDelete(ctx context.Context, d *schema
 	return nil
 }
 
+// resourceVcdNsxtEdgegatewayRateLimitingImport imports rate limiting (QoS) configuration for NSX-T
+// Edge Gateway.
+// The import path for this resource is Edge Gateway. ID of the field is also Edge Gateway ID as it
+// rate limiting is a property of Edge Gateway, not a separate entity.
 func resourceVcdNsxtEdgegatewayRateLimitingImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	log.Printf("[TRACE] NSX-T Edge Gateway Rate limiting (QoS) import initiated")
 

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting.go
@@ -39,12 +39,12 @@ func resourceVcdNsxtEdgegatewayRateLimiting() *schema.Resource {
 			"ingress_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Ingress policy ID for rate limiting Configuration",
+				Description: "Ingress profile ID for rate limiting Configuration",
 			},
 			"egress_profile_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Egress policy ID for rate limiting Configuration",
+				Description: "Egress profile ID for rate limiting Configuration",
 			},
 		},
 	}

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -119,7 +119,7 @@ data "vcd_nsxt_manager" "nsxt" {
 
 data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
   nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
-  name = "{{.NsxtQosProfileName}}"
+  name            = "{{.NsxtQosProfileName}}"
 }
 
 data "vcd_vdc_group" "g1" {

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -1,0 +1,224 @@
+//go:build gateway || network || nsxt || ALL || functional
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+func TestAccVcdNsxtEdgeRateLimiting(t *testing.T) {
+	preTestChecks(t)
+	skipIfNotSysAdmin(t)
+
+	vcdClient := createTemporaryVCDConnection(true)
+	if vcdClient == nil {
+		t.Skip(acceptanceTestsSkipped)
+	}
+	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
+	}
+
+	qosPolicyName, err := findQosPolicy(vcdClient)
+	if err != nil {
+		t.Fatalf("error finding QoS profile: %s", err)
+	}
+
+	if qosPolicyName == "" {
+		t.Skip("No QoS profile found. Skipping test")
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"Org":                  testConfig.VCD.Org,
+		"NsxtVdc":              testConfig.Nsxt.Vdc,
+		"NsxtVdcGroup":         testConfig.Nsxt.VdcGroup,
+		"NsxtEdgeGwInVdcGroup": testConfig.Nsxt.VdcGroupEdgeGateway,
+		"NsxtEdgeGw":           testConfig.Nsxt.EdgeGateway,
+		"TestName":             t.Name(),
+		"NsxtManager":          testConfig.Nsxt.Manager,
+		"NsxtQosPolicyName":    qosPolicyName,
+
+		"Tags": "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText1 := templateFill(testAccVcdNsxtEdgeRateLimitingStep1, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "-step2"
+	configText2DS := templateFill(testAccVcdNsxtEdgeRateLimitingStep2DS, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2DS)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testAccCheckNsxtEdgeRateLimitDestroy(params["NsxtVdc"].(string), params["NsxtEdgeGw"].(string)),
+			testAccCheckNsxtEdgeRateLimitDestroy(params["NsxtVdcGroup"].(string), params["NsxtEdgeGwInVdcGroup"].(string)),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "id"),
+
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "id"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "id"),
+				),
+			},
+			{
+				ResourceName:      "vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgNsxtVdcObject(params["NsxtEdgeGw"].(string)),
+			},
+			{
+				ResourceName:      "vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: importStateIdOrgNsxtVdcGroupObject(params["NsxtVdcGroup"].(string), params["NsxtEdgeGwInVdcGroup"].(string)),
+			},
+			{
+				Config: configText2DS,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vcd_nsxt_edgegateway_qos_profile.qos-1", "id"),
+
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "id"),
+					resource.TestCheckResourceAttrSet("vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "id"),
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", "vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc", nil),
+					resourceFieldsEqual("data.vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", "vcd_nsxt_edgegateway_rate_limiting.testing-in-vdc-group", nil),
+				),
+			},
+		},
+	})
+}
+
+const testAccVcdNsxtEdgeRateLimitingStep1 = `
+data "vcd_nsxt_manager" "nsxt" {
+  name = "{{.NsxtManager}}"
+}
+
+data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
+  nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
+  name = "{{.NsxtQosPolicyName}}"
+}
+
+data "vcd_vdc_group" "g1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdcGroup}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing-in-vdc-group" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_vdc_group.g1.id
+
+  name = "{{.NsxtEdgeGwInVdcGroup}}"
+}
+
+data "vcd_org_vdc" "v1" {
+  org  = "{{.Org}}"
+  name = "{{.NsxtVdc}}"
+}
+
+data "vcd_nsxt_edgegateway" "testing-in-vdc" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_org_vdc.v1.id
+
+  name = "{{.NsxtEdgeGw}}"
+}
+
+resource "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
+
+  ingress_policy_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  egress_policy_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+}
+
+resource "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc-group" {
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
+
+  ingress_policy_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  egress_policy_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+}
+`
+
+const testAccVcdNsxtEdgeRateLimitingStep2DS = testAccVcdNsxtEdgeRateLimitingStep1 + `
+# skip-binary-test: datasource test will fail when run together with resource
+data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
+}
+
+data "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc-group" {
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
+}
+`
+
+// testAccCheckNsxtEdgeRateLimitDestroy checks if the resource was destroyed.
+// "destroy" means that Edge Gateway Qos profile was removed (is unlimited).
+func testAccCheckNsxtEdgeRateLimitDestroy(vdcOrVdcGroupName, edgeGatewayName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		vdcOrVdcGroup, err := lookupVdcOrVdcGroup(conn, testConfig.VCD.Org, vdcOrVdcGroupName)
+		if err != nil {
+			return fmt.Errorf("unable to find VDC or VDC group %s: %s", vdcOrVdcGroupName, err)
+		}
+
+		edge, err := vdcOrVdcGroup.GetNsxtEdgeGatewayByName(edgeGatewayName)
+		if err != nil {
+			return fmt.Errorf(errorUnableToFindEdgeGateway, edgeGatewayName)
+		}
+
+		qosPolicy, err := edge.GetQoS()
+		if err != nil {
+			return fmt.Errorf("unable to get Qos profile: %s", err)
+		}
+
+		if qosPolicy.EgressProfile != nil && qosPolicy.EgressProfile.ID != "" {
+			return fmt.Errorf("QoS Egress policy still exists")
+		}
+
+		if qosPolicy.IngressProfile != nil && qosPolicy.IngressProfile.ID != "" {
+			return fmt.Errorf("QoS Ingress policy still exists")
+		}
+
+		return nil
+	}
+}
+
+func findQosPolicy(vcdClient *VCDClient) (string, error) {
+	nsxtManagers, err := vcdClient.QueryNsxtManagerByName(testConfig.Nsxt.Manager)
+	if err != nil {
+		return "", fmt.Errorf("unable to find NSX-T manager: %s", err)
+	}
+
+	id := extractUuid(nsxtManagers[0].HREF)
+	nsxtManagerUrn, err := govcd.BuildUrnWithUuid("urn:vcloud:nsxtmanager:", id)
+	if err != nil {
+		return "", fmt.Errorf("could not construct URN from id '%s': %s", id, err)
+	}
+
+	allQosPolicies, err := vcdClient.GetAllNsxtEdgeGatewayQosProfiles(nsxtManagerUrn, nil)
+	if err != nil {
+		return "", fmt.Errorf("unable to find Qos profile: %s", err)
+	}
+
+	if len(allQosPolicies) == 0 {
+		return "", nil
+	}
+
+	return allQosPolicies[0].NsxtEdgeGatewayQosProfile.DisplayName, nil
+}

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -140,16 +140,16 @@ resource "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
   org             = "{{.Org}}"
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
 
-  ingress_policy_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
-  egress_policy_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  ingress_profile_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  egress_profile_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
 }
 
 resource "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc-group" {
   org             = "{{.Org}}"
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc-group.id
 
-  ingress_policy_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
-  egress_policy_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  ingress_profile_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  egress_profile_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
 }
 `
 

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -23,7 +23,7 @@ func TestAccVcdNsxtEdgeRateLimiting(t *testing.T) {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 
-	qosPolicyName, err := findQosPolicy(vcdClient)
+	qosPolicyName, err := findQosProfile(vcdClient)
 	if err != nil {
 		t.Fatalf("error finding QoS profile: %s", err)
 	}
@@ -199,7 +199,7 @@ func testAccCheckNsxtEdgeRateLimitDestroy(vdcOrVdcGroupName, edgeGatewayName str
 	}
 }
 
-func findQosPolicy(vcdClient *VCDClient) (string, error) {
+func findQosProfile(vcdClient *VCDClient) (string, error) {
 	nsxtManagers, err := vcdClient.QueryNsxtManagerByName(testConfig.Nsxt.Manager)
 	if err != nil {
 		return "", fmt.Errorf("unable to find NSX-T manager: %s", err)

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -112,6 +112,8 @@
     "tier0routervrf": "tier-0-2",
     "//": "Existing External Network with correct configuration",
     "externalNetwork": "tier-0-backed-external-network",
+    "//":"Gateway QoS Profile used for NSX-T Edge Gateway Rate Limiting (defined in NSX-T Manager)",
+    "gatewayQosProfile":"Gateway QoS Profile 1",
     "//": "Existing NSX-T based VDC",
     "vdc": "nsxt-vdc-dainius",
     "//": "Existing NSX-T Edge Gateway",

--- a/website/docs/d/edgegateway.html.markdown
+++ b/website/docs/d/edgegateway.html.markdown
@@ -3,12 +3,12 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_edgegateway"
 sidebar_current: "docs-vcd-data-source-edgegateway"
 description: |-
-  Provides an edge gateway data source.
+  Provides an NSX-V edge gateway data source.
 ---
 
 # vcd\_edgegateway
 
-Provides a VMware Cloud Director edge gateway data source, directly connected to one or more external networks. This can be used to reference
+Provides a VMware Cloud Director NSX-V edge gateway data source, directly connected to one or more external networks. This can be used to reference
 edge gateways for Org VDC networks to connect.
 
 Supported in provider *v2.5+*

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html
@@ -1,0 +1,39 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_qos_profile"
+sidebar_current: "docs-vcd-data-source-nsxt-qos-profile"
+description: |-
+  Provides a data source to read NSX-T Edge Gateway QoS profiles.
+---
+
+# vcd\_nsxt\_edgegateway\_qos\_profile
+
+Provides a data source to read NSX-T Edge Gateway QoS profiles.
+
+-> Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T
+
+## Example Usage
+
+```hcl
+data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
+  nsxt_manager_id = data.nsxt_manager_id.first.id
+  name = "qos-policy-1"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `nsxt_manager_id` - (Required) NSX-T Manager where the QoS profile is defined in (can be looked up
+using `vcd_nsxt_manager` data source)
+* `nsxt_manager_id` - (Required) QoS Profile Name
+
+
+## Attribute Reference
+
+* `description` - Description of QoS Profile
+* `committed_bandwidth` - Committed bandwith specificd in Mb/s
+* `burst_size` - Burst size defined in bytes
+* `excess_action` - Excess action defines action on traffic exceeding bandwidth

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
@@ -8,9 +8,9 @@ description: |-
 
 # vcd\_nsxt\_edgegateway\_qos\_profile
 
-Provides a data source to read NSX-T Edge Gateway QoS profiles.
+Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
 
--> Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T
+Provides a data source to read NSX-T Edge Gateway QoS profiles.
 
 ## Example Usage
 

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
@@ -3,14 +3,16 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_qos_profile"
 sidebar_current: "docs-vcd-data-source-nsxt-qos-profile"
 description: |-
-  Provides a data source to read NSX-T Edge Gateway QoS profiles.
+  Provides a data source to read NSX-T Edge Gateway QoS profiles. Which can be used to modify NSX-T 
+  Edge Gateway Rate Limiting (QoS) configuration.
 ---
 
 # vcd\_nsxt\_edgegateway\_qos\_profile
 
 Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
 
-Provides a data source to read NSX-T Edge Gateway QoS profiles.
+Provides a data source to read NSX-T Edge Gateway QoS profiles. Which can be used to modify NSX-T
+Edge Gateway Rate Limiting (QoS) configuration.
 
 ## Example Usage
 
@@ -31,7 +33,7 @@ The following arguments are supported:
 
 * `nsxt_manager_id` - (Required) NSX-T Manager where the QoS profile is defined in (can be looked up
 using `vcd_nsxt_manager` data source)
-* `nsxt_manager_id` - (Required) QoS Profile Name
+* `name` - (Required) QoS Profile Name
 
 
 ## Attribute Reference

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
@@ -23,7 +23,7 @@ data "vcd_nsxt_manager" "first" {
 
 data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
   nsxt_manager_id = data.nsxt_manager_id.first.id
-  name = "qos-policy-1"
+  name            = "qos-profile-1"
 }
 ```
 

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
@@ -3,7 +3,7 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_qos_profile"
 sidebar_current: "docs-vcd-data-source-nsxt-qos-profile"
 description: |-
-  Provides a data source to read NSX-T Edge Gateway QoS profiles. Which can be used to modify NSX-T 
+  Provides a data source to read NSX-T Edge Gateway QoS profiles, which can be used to modify NSX-T 
   Edge Gateway Rate Limiting (QoS) configuration.
 ---
 
@@ -11,7 +11,7 @@ description: |-
 
 Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
 
-Provides a data source to read NSX-T Edge Gateway QoS profiles. Which can be used to modify NSX-T
+Provides a data source to read NSX-T Edge Gateway QoS profiles, which can be used to modify NSX-T
 Edge Gateway Rate Limiting (QoS) configuration.
 
 ## Example Usage

--- a/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_qos_profile.html.markdown
@@ -15,11 +15,14 @@ Provides a data source to read NSX-T Edge Gateway QoS profiles.
 ## Example Usage
 
 ```hcl
+data "vcd_nsxt_manager" "first" {
+  name = "nsxt-manager-name"
+}
+
 data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
   nsxt_manager_id = data.nsxt_manager_id.first.id
   name = "qos-policy-1"
 }
-
 ```
 
 ## Argument Reference

--- a/website/docs/d/nsxt_edgegateway_rate_limiting.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_rate_limiting.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_rate_limiting"
+sidebar_current: "docs-vcd-data-source-nsxt-edge-rate-limiting"
+description: |-
+  Provides a data source to read NSX-T Edge Gateway Rate Limiting configuration.
+---
+
+# vcd\_nsxt\_edgegateway\_rate\_limiting
+
+Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
+
+Provides a data source to read NSX-T Edge Gateway Rate Limiting configuration.
+
+## Example Usage
+
+```hcl
+data "vcd_org_vdc" "v1" {
+  org  = "datacloud"
+  name = "nsxt-vdc-datacloud"
+}
+
+data "vcd_nsxt_edgegateway" "in-vdc" {
+  org      = "datacloud"
+  owner_id = data.vcd_org_vdc.v1.id
+
+  name = "nsxt-gw-datacloud"
+}
+
+data "vcd_nsxt_edgegateway_rate_limiting" "in-vdc" {
+  org             = "datacloud"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.in-vdc.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Required) Org in which the NSX-T Edge Gateway is located
+* `edge_gateway_id` - (Required) NSX-T Edge Gateway ID
+
+## Attribute Reference
+
+All the arguments and attributes defined in
+[`vcd_nsxt_edgegateway_rate_limiting`](/providers/vmware/vcd/latest/docs/resources/nsxt_edgegateway_rate_limiting)
+resource are available.

--- a/website/docs/d/nsxt_edgegateway_rate_limiting.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_rate_limiting.html.markdown
@@ -3,14 +3,14 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_rate_limiting"
 sidebar_current: "docs-vcd-data-source-nsxt-edge-rate-limiting"
 description: |-
-  Provides a data source to read NSX-T Edge Gateway Rate Limiting configuration.
+  Provides a data source to read NSX-T Edge Gateway Rate Limiting (QoS) configuration.
 ---
 
 # vcd\_nsxt\_edgegateway\_rate\_limiting
 
 Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
 
-Provides a data source to read NSX-T Edge Gateway Rate Limiting configuration.
+Provides a data source to read NSX-T Edge Gateway Rate Limiting (QoS) configuration.
 
 ## Example Usage
 

--- a/website/docs/r/edgegateway.html.markdown
+++ b/website/docs/r/edgegateway.html.markdown
@@ -3,12 +3,12 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_edgegateway"
 sidebar_current: "docs-vcd-resource-edgegateway"
 description: |-
-  Provides a VMware Cloud Director edge gateway. This can be used to create and delete edge gateways connected to one or more external networks.
+  Provides a VMware Cloud Director NSX-V edge gateway. This can be used to create and delete edge gateways connected to one or more external networks.
 ---
 
 # vcd\_edgegateway
 
-Provides a VMware Cloud Director edge gateway directly connected to one or more external networks. This can be used to create
+Provides a VMware Cloud Director NSX-V edge gateway directly connected to one or more external networks. This can be used to create
 and delete edge gateways for Org VDC networks to connect.
 
 Supported in provider *v2.4+*

--- a/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
@@ -1,0 +1,80 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_rate_limiting"
+sidebar_current: "docs-vcd-resource-nsxt-edge-rate-limiting"
+description: |-
+  Provides a resource to manage NSX-T Edge Gateway Rate Limiting configuration.
+---
+
+# vcd\_nsxt\_edgegateway\_rate\_limiting
+
+Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
+
+Provides a resource to manage NSX-T Edge Gateway Rate Limiting configuration.
+
+~> Only `System Administrator` can create this resource.
+
+## Example Usage
+
+```hcl
+data "vcd_nsxt_manager" "nsxt" {
+  name = "nsxManager1"
+}
+
+data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
+  nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
+  name = "qos-policy-1"
+}
+
+data "vcd_org_vdc" "v1" {
+  org  = "datacloud"
+  name = "nsxt-vdc-datacloud"
+}
+
+data "vcd_nsxt_edgegateway" "testing-in-vdc" {
+  org      = "datacloud"
+  owner_id = data.vcd_org_vdc.v1.id
+
+  name = "nsxt-gw-datacloud"
+}
+
+resource "vcd_nsxt_edgegateway_rate_limiting" "testing-in-vdc" {
+  org             = "datacloud"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
+
+  ingress_profile_id = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+  egress_profile_id  = data.vcd_nsxt_edgegateway_qos_profile.qos-1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Required) Org in which the NSX-T Edge Gateway is located
+* `edge_gateway_id` - (Required) NSX-T Edge Gateway ID
+* `ingress_profile_id` - (Optional) A QoS profile to apply for ingress traffic. *Note* it will be
+  `unlimited` if not set.
+* `egress_profile_id` - (Optional) A QoS profile to apply for egress traffic. *Note* it will be
+  `unlimited` if not set.
+
+-> Ingress and Egress profile IDs can be looked up using
+  [`vcd_nsxt_edgegateway_qos_profile`](/providers/vmware/vcd/latest/docs/resources/nsxt_edgegateway_qos_profile)
+  data source. 
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.](https://www.terraform.io/docs/import/)
+
+An existing NSX-T Edge Gateway Rate Limiting configuration can be [imported][docs-import] into this
+resource via supplying path for it. An example is below:
+
+[docs-import]: https://www.terraform.io/docs/import/
+
+```
+terraform import vcd_nsxt_edgegateway_rate_limiting.imported my-org.nsxt-vdc.nsxt-edge
+```
+
+The above would import the `nsxt-edge` Edge Gateway Rate Limiting configuration for this particular
+Edge Gateway.

--- a/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
@@ -21,7 +21,7 @@ data "vcd_nsxt_manager" "nsxt" {
 
 data "vcd_nsxt_edgegateway_qos_profile" "qos-1" {
   nsxt_manager_id = data.vcd_nsxt_manager.nsxt.id
-  name = "qos-policy-1"
+  name            = "qos-profile-1"
 }
 
 data "vcd_org_vdc" "v1" {

--- a/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_rate_limiting.html.markdown
@@ -3,16 +3,14 @@ layout: "vcd"
 page_title: "VMware Cloud Director: vcd_nsxt_edgegateway_rate_limiting"
 sidebar_current: "docs-vcd-resource-nsxt-edge-rate-limiting"
 description: |-
-  Provides a resource to manage NSX-T Edge Gateway Rate Limiting configuration.
+  Provides a resource to manage NSX-T Edge Gateway Rate Limiting (QoS) configuration.
 ---
 
 # vcd\_nsxt\_edgegateway\_rate\_limiting
 
 Supported in provider *v3.9+* and VCD 10.3.2+ with NSX-T.
 
-Provides a resource to manage NSX-T Edge Gateway Rate Limiting configuration.
-
-~> Only `System Administrator` can create this resource.
+Provides a resource to manage NSX-T Edge Gateway Rate Limiting (QoS) configuration.
 
 ## Example Usage
 
@@ -53,10 +51,10 @@ The following arguments are supported:
 
 * `org` - (Required) Org in which the NSX-T Edge Gateway is located
 * `edge_gateway_id` - (Required) NSX-T Edge Gateway ID
-* `ingress_profile_id` - (Optional) A QoS profile to apply for ingress traffic. *Note* it will be
-  `unlimited` if not set.
-* `egress_profile_id` - (Optional) A QoS profile to apply for egress traffic. *Note* it will be
-  `unlimited` if not set.
+* `ingress_profile_id` - (Optional) A QoS profile to apply for ingress traffic. *Note* leaving empty
+  means `unlimited`.
+* `egress_profile_id` - (Optional) A QoS profile to apply for egress traffic. *Note* leaving empty
+  means `unlimited`.
 
 -> Ingress and Egress profile IDs can be looked up using
   [`vcd_nsxt_edgegateway_qos_profile`](/providers/vmware/vcd/latest/docs/resources/nsxt_edgegateway_qos_profile)

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -299,6 +299,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-qos-profile") %>>
               <a href="/docs/providers/vcd/d/nsxt_edgegateway_qos_profile.html">vcd_nsxt_edgegateway_qos_profile</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-nsxt-edge-rate-limiting") %>>
+              <a href="/docs/providers/vcd/d/nsxt_edgegateway_rate_limiting.html">vcd_nsxt_edgegateway_rate_limiting</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -531,6 +534,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-rde") %>>
               <a href="/docs/providers/vcd/r/rde.html">vcd_rde</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-nsxt-edge-rate-limiting") %>>
+              <a href="/docs/providers/vcd/r/nsxt_edgegateway_rate_limiting.html">vcd_nsxt_edgegateway_rate_limiting</a>
             </li>
           </ul>
         </li>

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -296,6 +296,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-task") %>>
               <a href="/docs/providers/vcd/d/task.html">vcd_task</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-nsxt-qos-profile") %>>
+              <a href="/docs/providers/vcd/d/nsxt_edgegateway_qos_profile.html">vcd_nsxt_edgegateway_qos_profile</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>


### PR DESCRIPTION
Closes #974

* Resource and data source `vcd_nsxt_edgegateway_rate_limiting` - NSX-T Edge Gateway rate limiting configuration
* Data source `vcd_nsxt_edgegateway_qos_profile` for QoS profile lookup in NSX-T Manager

**Note** This feature requires VCD 10.3.2+