### PR TITLE
Add DVGP backing support for vcd_nsxt_network_imported

### DIFF
--- a/.changes/v3.9.0/1043-improvements.md
+++ b/.changes/v3.9.0/1043-improvements.md
@@ -1,0 +1,2 @@
+* Resource and data source `vcd_nsxt_network_imported` support Distributed Virtual Port Group (DVPG)
+  backed Org VDC network [GH-1043]

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,6 +20,10 @@ dist:
 	git archive --format=zip -o source.zip HEAD
 	git archive --format=tar HEAD | gzip -c > source.tar.gz
 
+# triggers cleanup by executing a non existent test
+cleanup:
+	cd vcd && go test -tags ALL -run "NoSuchTest\b"  -v -timeout 0
+
 # builds and deploys the plugin
 install: build
 	@sh -c "'$(CURDIR)/scripts/install-plugin.sh'"

--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,7 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f
+
+//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413061305-403520876055
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421

--- a/go.mod
+++ b/go.mod
@@ -61,4 +61,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412122909-7895743a6673

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.13
+	github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.14
 )
 
 require (
@@ -60,5 +60,3 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,4 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 )
 
-replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f
-
-//replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director
+replace github.com/vmware/go-vcloud-director/v2 => github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f h1:FgthFOhCiGHTjl+yGpxE0V5u5DCyqfmFSSWmlQ113Go=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec h1:OpbKspQAU45KbbxobjiI8x4yJQYzAsfCXmF/srSxcgY=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413061305-403520876055 h1:nilZuaAcv5EQt7kGiTY88tgVDR8aEdwv5oiNU0jjn/E=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413061305-403520876055/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421 h1:1b9Oud4FHFa1tnfGSkvSbGdG5xnUMOsSOZXB5cPC7gU=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421 h1:1b9Oud4FHFa1tnfGSkvSbGdG5xnUMOsSOZXB5cPC7gU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230413064717-90e0aa53f421/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -196,6 +194,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.14 h1:I1dfvBlcYBMCg7YbAVYW6s7X88/mxJhq3K1s9BB4NKE=
+github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.14/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec h1:OpbKspQAU45KbbxobjiI8x4yJQYzAsfCXmF/srSxcgY=
-github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230411044400-d3eeea32b8ec/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412122909-7895743a6673 h1:LmL7O8W6OyhQFTVy7BCbC4jsPFasGYACrq1kpQCffhI=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230412122909-7895743a6673/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f h1:FgthFOhCiGHTjl+yGpxE0V5u5DCyqfmFSSWmlQ113Go=
+github.com/Didainius/go-vcloud-director/v2 v2.17.0-alpha.2.0.20230407120116-c48ca066bc5f/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
@@ -194,8 +196,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.11 h1:0TNeCF30HtOodx3pQKR9PHSKHDBEYqQ8zMsVhxsa7pM=
-github.com/vmware/go-vcloud-director/v2 v2.20.0-alpha.11/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -267,3 +267,4 @@ vcd.ResourceSchema-vcd_vapp_network.tf v3.8.2 "New field 'reboot_vapp_on_removal
 vcd.ResourceSchema-vcd_nsxt_ipsec_vpn_tunnel.tf v3.8.2 "New fields 'authentication_mode', 'remote_id', 'certificate_id', 'ca_certificate_id'"
 vcd.ResourceSchema-vcd_nsxt_alb_virtual_service.tf v3.8.2 "New field 'is_transparent_mode_enabled'"
 vcd.ResourceSchema-vcd_nsxt_alb_pool.tf v3.8.2 "New field 'member_group_id'"
+vcd.ResourceSchema-vcd_nsxt_network_imported.tf v3.8.2 "New field dvpg_id"

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -140,7 +140,7 @@ type TestConfig struct {
 		Tier0router               string `json:"tier0router"`
 		Tier0routerVrf            string `json:"tier0routervrf"`
 		GatewayQosProfile         string `json:"gatewayQosProfile"`
-		Dvpg                      string `json:"dvpg"`
+		NsxtDvpg                  string `json:"nsxtDvpg"`
 		Vdc                       string `json:"vdc"`
 		ExternalNetwork           string `json:"externalNetwork"`
 		EdgeGateway               string `json:"edgeGateway"`

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -139,6 +139,7 @@ type TestConfig struct {
 		Manager                   string `json:"manager"`
 		Tier0router               string `json:"tier0router"`
 		Tier0routerVrf            string `json:"tier0routervrf"`
+		Dvpg                      string `json:"dvpg"`
 		Vdc                       string `json:"vdc"`
 		ExternalNetwork           string `json:"externalNetwork"`
 		EdgeGateway               string `json:"edgeGateway"`

--- a/vcd/datasource_vcd_nsxt_network_imported.go
+++ b/vcd/datasource_vcd_nsxt_network_imported.go
@@ -64,7 +64,7 @@ func datasourceVcdNsxtNetworkImported() *schema.Resource {
 			"dvpg_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "DVPG ID of used Distributed Virtual Port Group",
+				Description: "ID of used Distributed Virtual Port Group",
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/vcd/datasource_vcd_nsxt_network_imported.go
+++ b/vcd/datasource_vcd_nsxt_network_imported.go
@@ -61,6 +61,11 @@ func datasourceVcdNsxtNetworkImported() *schema.Resource {
 				Computed:    true,
 				Description: "ID of existing NSX-T Logical Switch",
 			},
+			"dvpg_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "DVPG ID of used Distributed Virtual Port Group",
+			},
 			"description": {
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/vcd/resource_vcd_nsxt_network_imported_test.go
+++ b/vcd/resource_vcd_nsxt_network_imported_test.go
@@ -239,12 +239,10 @@ data "vcd_org_vdc" "nsxtVdc" {
 }
 
 resource "vcd_nsxt_network_imported" "net1" {
-  org  = "{{.Org}}"
-
+  org      = "{{.Org}}"
   owner_id = data.vcd_org_vdc.nsxtVdc.id
 
-  name = "{{.TestName}}"
-
+  name      = "{{.TestName}}"
   dvpg_name = "{{.Dvpg}}"
 
   gateway       = "1.1.1.1"
@@ -264,12 +262,10 @@ data "vcd_org_vdc" "nsxtVdc" {
 }
 
 resource "vcd_nsxt_network_imported" "net1" {
-  org  = "{{.Org}}"
-
+  org      = "{{.Org}}"
   owner_id = data.vcd_org_vdc.nsxtVdc.id
 
-  name = "{{.TestName}}-updated"
-
+  name      = "{{.TestName}}-updated"
   dvpg_name = "{{.Dvpg}}"
 
   gateway       = "1.1.1.1"

--- a/vcd/resource_vcd_nsxt_network_imported_test.go
+++ b/vcd/resource_vcd_nsxt_network_imported_test.go
@@ -154,7 +154,7 @@ func TestAccVcdNsxtNetworkImportedNsxtDvpg(t *testing.T) {
 		"NsxtVdc":     testConfig.Nsxt.Vdc,
 		"EdgeGw":      testConfig.Nsxt.EdgeGateway,
 		"NetworkName": t.Name(),
-		"Dvpg":        testConfig.Nsxt.Dvpg,
+		"Dvpg":        testConfig.Nsxt.NsxtDvpg,
 		"TestName":    t.Name(),
 		"Tags":        "network nsxt",
 	}

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -115,7 +115,7 @@
     "//":"Gateway QoS Profile used for NSX-T Edge Gateway Rate Limiting (defined in NSX-T Manager)",
     "gatewayQosProfile":"Gateway QoS Profile 1",
     "//": "Distributed Virtual Port Group",
-    "dvpg": "test-nsxt-dvpg-no-uplink",
+    "nsxtDvpg": "test-nsxt-dvpg-no-uplink",
     "//": "Existing NSX-T based VDC",
     "vdc": "nsxt-vdc-dainius",
     "//": "Existing NSX-T Edge Gateway",

--- a/vcd/sample_vcd_test_config.json
+++ b/vcd/sample_vcd_test_config.json
@@ -112,6 +112,8 @@
     "tier0routervrf": "tier-0-2",
     "//": "Existing External Network with correct configuration",
     "externalNetwork": "tier-0-backed-external-network",
+    "//": "Distributed Virtual Port Group",
+    "dvpg": "test-nsxt-dvpg-no-uplink",
     "//": "Existing NSX-T based VDC",
     "vdc": "nsxt-vdc-dainius",
     "//": "Existing NSX-T Edge Gateway",

--- a/website/docs/r/nsxt_network_imported.html.markdown
+++ b/website/docs/r/nsxt_network_imported.html.markdown
@@ -103,6 +103,9 @@ and inherited from provider configuration)
 * `dvpg_name` - (Optional) Unique name of an existing Distributed Virtual Port Group (DVPG). 
   **Note** it will never be refreshed because API does not allow reading this name after it is
   consumed. Instead ID will be stored in `dvpg_id` attribute.
+
+-> One of `nsxt_logical_switch_name` or `dvpg_name` must be provided.
+
 * `description` - (Optional) An optional description of the network
 * `gateway` - (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).

--- a/website/docs/r/nsxt_network_imported.html.markdown
+++ b/website/docs/r/nsxt_network_imported.html.markdown
@@ -21,7 +21,7 @@ guide](/providers/vmware/vcd/latest/docs/guides/vdc_groups).
 network** in NSX-T VDC. Read more about Imported Network in [official VCD
 documentation](https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-FB303D62-67EA-4209-BE4D-C3746481BCC8.html).
 
-## Example Usage (NSX-T backed imported Org VDC network)
+## Example Usage (NSX-T backed imported Org VDC network backed by NSX-T logical switch)
 ```hcl
 data "vcd_org_vdc" "main" {
   org  = "my-org"
@@ -52,6 +52,36 @@ resource "vcd_nsxt_network_imported" "nsxt-backed" {
 }
 ```
 
+## Example Usage (NSX-T backed imported Org VDC network backed by Distributed Virtual Port Group - DVPG)
+
+```hcl
+data "vcd_org_vdc" "main" {
+  org  = "my-org"
+  name = "my-nsxt-org-vdc"
+}
+
+resource "vcd_nsxt_network_imported" "nsxt-backed" {
+  org      = "my-org"
+  owner_id = data.vcd_org_vdc.main.id
+
+  name      = "nsxt-imported"
+  dvpg_name = "vc-dvpg"
+
+  gateway       = "1.1.1.1"
+  prefix_length = 24
+
+  static_ip_pool {
+    start_address = "1.1.1.10"
+    end_address   = "1.1.1.20"
+  }
+
+  static_ip_pool {
+    start_address = "1.1.1.100"
+    end_address   = "1.1.1.103"
+  }
+}
+```
+
 
 ## Argument Reference
 
@@ -64,12 +94,15 @@ and inherited from provider configuration)
 * `vdc` - (Deprecated; Optional) The name of VDC to use. **Deprecated**  in favor of new field
   `owner_id` which supports VDC and VDC Group IDs.
 * `name` - (Required) A unique name for the network
-* `nsxt_logical_switch_name` - (Required) Unique name of an existing NSX-T segment. 
+* `nsxt_logical_switch_name` - (Optional) Unique name of an existing NSX-T segment. 
   **Note** it will never be refreshed because API does not allow reading this name after it is
   consumed. Instead ID will be stored in `nsxt_logical_switch_id` attribute.
   
   This resource **will fail** if multiple segments with the same name are available. One can rename 
   them in NSX-T manager to make them unique.
+* `dvpg_name` - (Optional) Unique name of an existing Distributed Virtual Port Group (DVPG). 
+  **Note** it will never be refreshed because API does not allow reading this name after it is
+  consumed. Instead ID will be stored in `dvpg_id` attribute.
 * `description` - (Optional) An optional description of the network
 * `gateway` - (Required) The gateway for this network (e.g. 192.168.1.1)
 * `prefix_length` - (Required) The prefix length for the new network (e.g. 24 for netmask 255.255.255.0).
@@ -88,12 +121,13 @@ Static IP Pools  support the following attributes:
 * `end_address` - (Required) The final address in the IP Range
 
 ## Attribute Reference
-* `nsxt_logical_switch_id` - ID of an existing NSX-T segment
+* `nsxt_logical_switch_id` - ID of NSX-T logical switch used by this network
+* `dvpg_id` - ID of Distributed Virtual Port Group used by this network
 
 ## Importing
 
-~> After import the field `nsxt_logical_switch_name` will remain empty because it is
-impossible to read it in API once it is consumed by network.
+~> After import the fields `nsxt_logical_switch_name` and `dvpg_name` will remain empty because it
+is impossible to read them in API once it is consumed by network.
 
 ~> The current implementation of Terraform import can only import resources into the state. It does not generate
 configuration. [More information.][docs-import]


### PR DESCRIPTION
This PR adds Distributed Virtual Port Group backing support for `vcd_nsxt_network_imported`. 

Closes #865 (adds support for DVPG backed imported networks)
Closes #951 (there is unfortunately still no support for it in current versions)

Note. A new `Dvpg` test config is added.


Additionally, this PR adds a `make cleanup` target.