### PR TITLE
Skip disabled Org upgrade tests

### DIFF
--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -276,3 +276,8 @@ vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-update.tf v3.8.2 "Org p
 vcd.TestAccVcdSubscribedCatalog-with-local-copy-subscriber-update.tf v3.8.2 "Org permissions are fragile until VCD 10.4"
 vcd.TestAccVcdVsphereSubscriber.tf v3.8.2 "Org permissions are fragile until VCD 10.4"
 vcd.TestAccVcdStandaloneVmTemplate.tf v3.8.2 "output field shows diff for a computed value security_tags"
+vcd.TestAccVcdOrgFull_org1_updated.tf v3.8.2 "Cannot create disabled Orgs in 10.4.2"
+vcd.TestAccVcdOrgFull_org2.tf v3.8.2 "Cannot create disabled Orgs in 10.4.2"
+vcd.TestAccVcdOrgFull_org3_updated.tf v3.8.2 "Cannot create disabled Orgs in 10.4.2"
+vcd.TestAccVcdOrgFull_org4.tf v3.8.2 "Cannot create disabled Orgs in 10.4.2"
+vcd.TestAccVcdOrgFull_org5_updated.tf v3.8.2 "Cannot create disabled Orgs in 10.4.2"


### PR DESCRIPTION
This PR continues on failing test reviews:
* Adding 5 Org tests to `skip-upgrade-tests.txt`. They fail because VCD 10.4.2 has a bug which doesn't allow creating disabled Org.