### PR TITLE
Add flag to CSE 4.0 vApp network proposed config to remove it flawlessly

### DIFF
--- a/.changes/v3.9.0/1003-features.md
+++ b/.changes/v3.9.0/1003-features.md
@@ -1,1 +1,1 @@
-* New guide to install Container Service Extension v4.0 in VCD 10.4+ [GH-1003]
+* New guide to install Container Service Extension v4.0 in VCD 10.4+ [GH-1003, GH-1053]

--- a/examples/container-service-extension-4.0/install/step2/3.9-cse-4.0-install-step2.tf
+++ b/examples/container-service-extension-4.0/install/step2/3.9-cse-4.0-install-step2.tf
@@ -720,6 +720,8 @@ resource "vcd_vapp_org_network" "cse_server_network" {
 
   vapp_name        = vcd_vapp.cse_server_vapp.name
   org_network_name = vcd_network_routed_v2.solutions_routed_network.name
+
+  reboot_vapp_on_removal = true
 }
 
 resource "vcd_vapp_vm" "cse_server_vm" {


### PR DESCRIPTION
This PR simply adds `reboot_vapp_on_removal = true` so everything is destroyed flawlessly without changing anything from CSE configuration.
