### PR TITLE
Fix vcd_nsxt_app_port_profile data source bug on multiple NSX-T managers

### DIFF
--- a/.changes/v3.10.0/1065-bug-fixes.md
+++ b/.changes/v3.10.0/1065-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix `SYSTEM` scope data source `vcd_nsxt_app_port_profile` when multiple NSX-T managers are configured [GH-1065]

--- a/vcd/datasource_vcd_nsxt_app_port_profile.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile.go
@@ -58,7 +58,7 @@ func datasourceVcdNsxtAppPortProfile() *schema.Resource {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				Description:   "ID of VDC, VDC Group, or NSX-T Manager. Required if the VCD instance has more than one NSX-T manage",
+				Description:   "ID of VDC, VDC Group, or NSX-T Manager. Required if the VCD instance has more than one NSX-T manager",
 				ConflictsWith: []string{"nsxt_manager_id", "vdc"},
 			},
 			"scope": {
@@ -129,6 +129,8 @@ func datasourceVcdNsxtAppPortProfileRead(_ context.Context, d *schema.ResourceDa
 		contextId = ""
 	}
 
+	// If contextId is unset, send a request without _context query filter,
+	// Works properly only with SYSTEM scope and one NSX-T Manager configured.
 	if contextId != "" {
 		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s;_context==%s", name, scope, contextId))
 	} else {

--- a/vcd/datasource_vcd_nsxt_app_port_profile.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile.go
@@ -4,13 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/vmware/go-vcloud-director/v2/govcd"
-	"github.com/vmware/go-vcloud-director/v2/types/v56"
 )
 
 var appPortDefinitionComputed = &schema.Resource{
@@ -55,11 +53,12 @@ func datasourceVcdNsxtAppPortProfile() *schema.Resource {
 				Required:    true,
 				Description: "Application Port Profile name",
 			},
+			// TODO V4 Change this to required
 			"context_id": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
-				Description:   "ID of VDC, VDC Group, or NSX-T Manager",
+				Description:   "ID of VDC, VDC Group, or NSX-T Manager. Required if the VCD instance has more than one NSX-T manage",
 				ConflictsWith: []string{"nsxt_manager_id", "vdc"},
 			},
 			"scope": {
@@ -94,9 +93,10 @@ func datasourceVcdNsxtAppPortProfile() *schema.Resource {
 func datasourceVcdNsxtAppPortProfileRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	vcdClient := meta.(*VCDClient)
 
+	vdcName := d.Get("vdc").(string)
 	org, err := vcdClient.GetOrgFromResource(d)
 	if err != nil {
-		return diag.Errorf(errorRetrievingOrgAndVdc, err)
+		return diag.Errorf(errorRetrievingOrg, err)
 	}
 
 	name := d.Get("name").(string)
@@ -105,28 +105,33 @@ func datasourceVcdNsxtAppPortProfileRead(_ context.Context, d *schema.ResourceDa
 	nsxtManagerId := d.Get("nsxt_manager_id").(string)
 
 	queryParams := url.Values{}
+
+	var contextId string
 	switch {
-	// For `TENANT` scope Org and VDC or the specified `context_id` matter. It would set _context
-	// filter to be searching for App Port Profiles in specific context
-	case strings.EqualFold(scope, types.ApplicationPortProfileScopeTenant):
-		contextId, err := pickAppPortProfileContextFilterByPriority(vcdClient, d, contextIdFieldValue)
+	// context_id is the preferred method of providing context
+	case contextIdFieldValue != "":
+		contextId = contextIdFieldValue
+	// if vdc attribute is set, use that, as it is also available for every user
+	case vdcName != "":
+		_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
 		if err != nil {
-			return diag.Errorf("error identifying correct context filter: %s", err)
+			return diag.Errorf("failed to get VDC from resource: %s", err)
 		}
-		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s;_context==%s", name, scope, contextId))
-	// For PROVIDER scoped App Port Profiles context_id of Network Provider can be specified
-	case strings.EqualFold(scope, types.ApplicationPortProfileScopeProvider) && contextIdFieldValue != "":
-		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s;_context==%s", name, scope, contextIdFieldValue))
-	// Deprecated field 'nsxt_manager_id' can be specified as context for PROVIDER scoped App Port Profiles
-	case strings.EqualFold(scope, types.ApplicationPortProfileScopeProvider) && nsxtManagerId != "":
-		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s;_context==%s", name, scope, nsxtManagerId))
+		contextId = vdc.Vdc.ID
+	// nsxt_manager_id can only be used by sysorg admin
+	case nsxtManagerId != "":
+		if !vcdClient.Client.IsSysAdmin {
+			return diag.Errorf("Only System administrators can provide NSX-T Manager ID")
+		}
+		contextId = nsxtManagerId
+	// if none of previous values are set, don't provide context (usable if only one nsxt manager is used)
 	default:
-		// For "SYSTEM" or "PROVIDER" scoped Application Port Profiles context can be ignored.
-		// * For "SYSTEM" this is correct behavior
-		// * For "PROVIDER" it can match App Port Profiles when multiple NSX-T Managers are
-		// configured, but this is left for backwards compatibility
-		//
-		// TODO V4 - remove support for PROVIDER scope without `context_id` field
+		contextId = ""
+	}
+
+	if contextId != "" {
+		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s;_context==%s", name, scope, contextId))
+	} else {
 		queryParams.Add("filter", fmt.Sprintf("name==%s;scope==%s", name, scope))
 	}
 
@@ -153,23 +158,4 @@ func datasourceVcdNsxtAppPortProfileRead(_ context.Context, d *schema.ResourceDa
 	d.SetId(appPortProfile.NsxtAppPortProfile.ID)
 
 	return nil
-}
-
-// pickAppPortProfileContextFilterByPriority will evaluate 3 fields - 'context_id', 'vdc' in
-// resource and 'vdc' in provider section. It will pick the right one based on priority:
-// * Priority 1 -> 'context_id' field
-// * Priority 2 -> 'vdc' field in data source
-// * Priority 3 -> 'vdc' field inherited from provider configuration
-func pickAppPortProfileContextFilterByPriority(vcdClient *VCDClient, d *schema.ResourceData, contextIdField string) (string, error) {
-	// Context ID can be returned directly, VDC must be looked up to return its ID
-	if contextIdField != "" {
-		return contextIdField, nil
-	}
-
-	_, vdc, err := vcdClient.GetOrgAndVdcFromResource(d)
-	if err != nil {
-		return "", fmt.Errorf("error retrieving Org and VDC: %s", err)
-	}
-
-	return vdc.Vdc.ID, nil
 }

--- a/vcd/datasource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile_test.go
@@ -26,7 +26,7 @@ func TestAccVcdNsxtAppPortProfileDsSystem(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText1 := templateFill(testAccVcdNsxtAppPortProfileSystemDSStep1, params)
+	configText1 := templateFill(testAccVcdNsxtAppPortProfileDSStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
 
 	resource.Test(t, resource.TestCase{
@@ -49,7 +49,7 @@ func TestAccVcdNsxtAppPortProfileDsSystem(t *testing.T) {
 	postTestChecks(t)
 }
 
-const testAccVcdNsxtAppPortProfileSystemDSStep1 = `
+const testAccVcdNsxtAppPortProfileDSStep1 = `
 data "vcd_nsxt_app_port_profile" "custom" {
   org  = "{{.Org}}"
   vdc  = "{{.NsxtVdc}}"
@@ -132,7 +132,7 @@ func TestAccVcdNsxtAppPortProfileDsProviderNotFound(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText1 := templateFill(testAccVcdNsxtAppPortProfileProviderDSStep1, params)
+	configText1 := templateFill(testAccVcdNsxtAppPortProfileDSStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
 
 	resource.Test(t, resource.TestCase{
@@ -146,16 +146,6 @@ func TestAccVcdNsxtAppPortProfileDsProviderNotFound(t *testing.T) {
 	})
 	postTestChecks(t)
 }
-
-const testAccVcdNsxtAppPortProfileProviderDSStep1 = `
-data "vcd_nsxt_app_port_profile" "custom" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
-
-  name  = "{{.ProfileName}}"
-  scope = "{{.Scope}}"
-}
-`
 
 // TestAccVcdNsxtAppPortProfileDsTenantNotFound tests if "Active Directory Server" Application Port Profile is not found in
 // TENANT context (because it is defined in SYSTEM context)
@@ -175,7 +165,7 @@ func TestAccVcdNsxtAppPortProfileDsTenantNotFound(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText1 := templateFill(testAccVcdNsxtAppPortProfileTenantDSStep1, params)
+	configText1 := templateFill(testAccVcdNsxtAppPortProfileDSStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
 
 	resource.Test(t, resource.TestCase{
@@ -189,16 +179,6 @@ func TestAccVcdNsxtAppPortProfileDsTenantNotFound(t *testing.T) {
 	})
 	postTestChecks(t)
 }
-
-const testAccVcdNsxtAppPortProfileTenantDSStep1 = `
-data "vcd_nsxt_app_port_profile" "custom" {
-  org  = "{{.Org}}"
-  vdc  = "{{.NsxtVdc}}"
-
-  name  = "{{.ProfileName}}"
-  scope = "{{.Scope}}"
-}
-`
 
 // TestAccVcdNsxtAppPortProfileMultiOrg tests that TENANT Application Port Profile lookup works well
 // when multiple Orgs exist in VCD. The test does the following:

--- a/vcd/datasource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_app_port_profile_test.go
@@ -49,6 +49,16 @@ func TestAccVcdNsxtAppPortProfileDsSystem(t *testing.T) {
 	postTestChecks(t)
 }
 
+const testAccVcdNsxtAppPortProfileSystemDSStep1 = `
+data "vcd_nsxt_app_port_profile" "custom" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  name  = "{{.ProfileName}}"
+  scope = "{{.Scope}}"
+}
+`
+
 // TestAccVcdNsxtAppPortProfileDsSystem tests if "Active Directory Server" Application Port Profile is not found in
 // PROVIDER context (because it is defined in SYSTEM context)
 func TestAccVcdNsxtAppPortProfileDsProviderNotFound(t *testing.T) {
@@ -67,7 +77,7 @@ func TestAccVcdNsxtAppPortProfileDsProviderNotFound(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText1 := templateFill(testAccVcdNsxtAppPortProfileSystemDSStep1, params)
+	configText1 := templateFill(testAccVcdNsxtAppPortProfileProviderDSStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
 
 	resource.Test(t, resource.TestCase{
@@ -81,6 +91,16 @@ func TestAccVcdNsxtAppPortProfileDsProviderNotFound(t *testing.T) {
 	})
 	postTestChecks(t)
 }
+
+const testAccVcdNsxtAppPortProfileProviderDSStep1 = `
+data "vcd_nsxt_app_port_profile" "custom" {
+  org  = "{{.Org}}"
+  vdc  = "{{.NsxtVdc}}"
+
+  name  = "{{.ProfileName}}"
+  scope = "{{.Scope}}"
+}
+`
 
 // TestAccVcdNsxtAppPortProfileDsTenantNotFound tests if "Active Directory Server" Application Port Profile is not found in
 // TENANT context (because it is defined in SYSTEM context)
@@ -100,7 +120,7 @@ func TestAccVcdNsxtAppPortProfileDsTenantNotFound(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText1 := templateFill(testAccVcdNsxtAppPortProfileSystemDSStep1, params)
+	configText1 := templateFill(testAccVcdNsxtAppPortProfileTenantDSStep1, params)
 	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
 
 	resource.Test(t, resource.TestCase{
@@ -115,7 +135,7 @@ func TestAccVcdNsxtAppPortProfileDsTenantNotFound(t *testing.T) {
 	postTestChecks(t)
 }
 
-const testAccVcdNsxtAppPortProfileSystemDSStep1 = `
+const testAccVcdNsxtAppPortProfileTenantDSStep1 = `
 data "vcd_nsxt_app_port_profile" "custom" {
   org  = "{{.Org}}"
   vdc  = "{{.NsxtVdc}}"

--- a/website/docs/d/nsxt_app_port_profile.html.markdown
+++ b/website/docs/d/nsxt_app_port_profile.html.markdown
@@ -46,7 +46,14 @@ data "vcd_nsxt_app_port_profile" "custom" {
 ## Example Usage 3 (Find a System defined Application Port Profile)
 
 ```hcl
+data "vcd_org_vdc" "vdc1" {
+  org  = "myOrg"
+  name = "myVDC"
+}
+
 data "vcd_nsxt_app_port_profile" "custom" {
+  context_id = data.vcd_org_vdc.vdc1.id
+
   scope = "SYSTEM"
   name  = "SSH"
 }
@@ -60,7 +67,7 @@ The following arguments are supported:
   when connected as sysadmin working across different organisations.
 * `vdc` - (Deprecated; Optional) The name of VDC to use, optional if defined at provider level.
   Deprecated and replaced by `context_id`
-* `context_id` - (Optional) ID of NSX-T Manager, VDC or VDC Group. Replaces deprecated field `vdc`.
+* `context_id` - (Optional) ID of NSX-T Manager, VDC or VDC Group. Replaces deprecated field `vdc`. Required if using more than one NSX-T Manager.
 * `name` - (Required)  - Unique name of existing Security Group.
 * `scope` - (Required)  - `SYSTEM`, `PROVIDER`, or `TENANT`.
 


### PR DESCRIPTION
This PR fixes the bug mentioned in #1058. 

Before the fix, if a user tried to fetch a `SYSTEM` App Port Profile using the `vcd_nsxt_app_port_profile` data source and had more than one NSX-T Manager configured in the infrastructure, the operation would return an error as there would be duplicate entries from every NSX-T Manager. 

Fixed by providing `_context` on `SYSTEM` scope requests, so the NSX-T Managers also get filtered.