### PR TITLE
API Token and Service Account resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,3 +60,5 @@ require (
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/vmware/go-vcloud-director/v2 v2.21.0-alpha.1 h1:K38h2Cu8kPihLd33PDFHGECrmj/rMQSlwaou+FqdbFU=
-github.com/vmware/go-vcloud-director/v2 v2.21.0-alpha.1/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/vcd/datasource_vcd_service_account.go
+++ b/vcd/datasource_vcd_service_account.go
@@ -1,0 +1,56 @@
+package vcd
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdServiceAccount() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdServiceAccountRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of service account",
+			},
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"software_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of software, e.g: 12345678-1234-5678-90ab-1234567890ab",
+			},
+			"role_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Role ID of service account",
+			},
+			"software_version": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Version of software using the service account",
+			},
+			"uri": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URI of the client using the service account",
+			},
+			"active": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Status of the service account.",
+			},
+		},
+	}
+}
+
+func datasourceVcdServiceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcdServiceAccountRead(ctx, d, meta, "datasource")
+}

--- a/vcd/datasource_vcd_service_account.go
+++ b/vcd/datasource_vcd_service_account.go
@@ -27,7 +27,7 @@ func datasourceVcdServiceAccount() *schema.Resource {
 				Computed:    true,
 				Description: "UUID of software, e.g: 12345678-1234-5678-90ab-1234567890ab",
 			},
-			"role_id": {
+			"role": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Role ID of service account",

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -207,6 +207,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_network_dhcp_binding":                 resourceVcdNsxtDhcpBinding(),                  // 3.9
 	"vcd_nsxt_edgegateway_dhcp_forwarding":          resourceVcdNsxtEdgegatewayDhcpForwarding(),    // 3.10
 	"vcd_api_token":                                 resourceVcdApiToken(),                         // 3.10
+	"vcd_service_account":                           resourceVcdServiceAccount(),                   // 3.10
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -121,6 +121,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_edgegateway_rate_limiting":            datasourceVcdNsxtEdgegatewayRateLimiting(),      // 3.9
 	"vcd_nsxt_network_dhcp_binding":                 datasourceVcdNsxtDhcpBinding(),                  // 3.9
 	"vcd_nsxt_edgegateway_dhcp_forwarding":          datasourceVcdNsxtEdgegatewayDhcpForwarding(),    // 3.10
+	"vcd_service_account":                           datasourceVcdServiceAccount(),                   // 3.10
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -206,6 +206,7 @@ var globalResourceMap = map[string]*schema.Resource{
 	"vcd_nsxt_edgegateway_rate_limiting":            resourceVcdNsxtEdgegatewayRateLimiting(),      // 3.9
 	"vcd_nsxt_network_dhcp_binding":                 resourceVcdNsxtDhcpBinding(),                  // 3.9
 	"vcd_nsxt_edgegateway_dhcp_forwarding":          resourceVcdNsxtEdgegatewayDhcpForwarding(),    // 3.10
+	"vcd_api_token":                                 resourceVcdApiToken(),                         // 3.10
 }
 
 // Provider returns a terraform.ResourceProvider.

--- a/vcd/resource_vcd_api_token.go
+++ b/vcd/resource_vcd_api_token.go
@@ -103,6 +103,14 @@ func resourceVcdApiTokenUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func resourceVcdApiTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	token, err := vcdClient.GetTokenById(d.Id())
+	if err != nil {
+		return diag.Errorf("[API token read] error getting API token: %s", err)
+	}
+
+	dSet(d, "name", token.Token.Name)
 
 	return nil
 }

--- a/vcd/resource_vcd_api_token.go
+++ b/vcd/resource_vcd_api_token.go
@@ -42,7 +42,6 @@ func resourceVcdApiToken() *schema.Resource {
 			},
 		},
 	}
-
 }
 
 func resourceVcdApiTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/vcd/resource_vcd_api_token.go
+++ b/vcd/resource_vcd_api_token.go
@@ -1,0 +1,148 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+)
+
+func resourceVcdApiToken() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdApiTokenCreate,
+		UpdateContext: resourceVcdApiTokenUpdate,
+		ReadContext:   resourceVcdApiTokenRead,
+		DeleteContext: resourceVcdApiTokenDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdApiTokenImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of API token",
+			},
+			"file_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Name of the file that the API token will be saved to",
+			},
+			"allow_token_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Set this to true if you understand the security risks of using" +
+					" API token files and would like to suppress the warnings",
+			},
+		},
+	}
+
+}
+
+func resourceVcdApiTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	// System Admin can't create API tokens outside SysOrg,
+	// just as Org admins can't create API tokens in other Orgs
+	org := vcdClient.SysOrg
+	if org == "" {
+		org = vcdClient.Org
+	}
+
+	tokenName := d.Get("name").(string)
+	token, err := vcdClient.CreateToken(org, tokenName)
+	if err != nil {
+		return diag.Errorf("[API token create] error creating API token: %s", err)
+	}
+
+	// token.Token.ID is in URN format, convert it to UUID
+	// for convenience in management
+	uuid := extractUuid(token.Token.ID)
+	d.SetId(uuid)
+
+	apiToken, err := token.GetInitialApiToken()
+	if err != nil {
+		return diag.Errorf("[API token create] error getting refresh token from API token: %s", err)
+	}
+
+	filename := d.Get("file_name").(string)
+	if filename == "" {
+		return diag.Errorf("[API token create] file_name must be set on creation")
+	}
+
+	allowTokenFile := d.Get("allow_token_file").(bool)
+
+	var diagnostics diag.Diagnostics
+	if !allowTokenFile {
+		diagnostics = append(diagnostics, diag.Diagnostic{
+			Severity: diag.Warning,
+			Summary:  "The file " + filename + " should be considered sensitive information.",
+			Detail: "The file " + filename + " containing the initial service account API " +
+				"HAS BEEN UPDATED with a freshly generated token. The initial token was invalidated and the " +
+				"token currently in the file will be invalidated at the next usage. In the meantime, it is " +
+				"usable by anyone to run operations to the current VCD. As such, it should be considered SENSITIVE INFORMATION. " +
+				"If you would like to remove this warning, add\n\n" + "	allow_token_file = true\n\nto the provider settings.",
+		})
+	}
+
+	err = govcd.SaveApiTokenToFile(filename, vcdClient.Client.UserAgent, apiToken)
+	if err != nil {
+		return diag.Errorf("[API token create] error saving API token to file: %s", err)
+	}
+
+	return diagnostics
+}
+
+func resourceVcdApiTokenUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return nil
+}
+
+func resourceVcdApiTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+
+	return nil
+}
+
+func resourceVcdApiTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	token, err := vcdClient.GetTokenById(d.Id())
+	if err != nil {
+		return diag.Errorf("[API token delete] error getting API token: %s", err)
+	}
+
+	err = token.Delete()
+	if err != nil {
+		return diag.Errorf("[API token delete] error deleting API token: %s", err)
+	}
+	d.SetId("")
+
+	return nil
+}
+
+func resourceVcdApiTokenImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("[TRACE] API token import initiated")
+
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 2 {
+		return nil, fmt.Errorf("resource name must be specified as user-name.token-name")
+	}
+	userName := resourceURI[0]
+	tokenName := resourceURI[1]
+
+	vcdClient := meta.(*VCDClient)
+	token, err := vcdClient.GetTokenByNameAndUsername(tokenName, userName)
+	if err != nil {
+		return []*schema.ResourceData{}, fmt.Errorf("error getting token by name: %s", err)
+	}
+
+	dSet(d, "name", token.Token.Name)
+	d.SetId(extractUuid(token.Token.ID))
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/vcd/resource_vcd_api_token_test.go
+++ b/vcd/resource_vcd_api_token_test.go
@@ -1,0 +1,57 @@
+//go:build api || ALL || functional
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccVcdApiToken(t *testing.T) {
+	skipIfNotSysAdmin(t)
+
+	preTestChecks(t)
+
+	var params = StringMap{
+		"Org":   testConfig.Provider.SysOrg,
+		"Token": t.Name(),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { preRunChecks(t) },
+		ProviderFactories: buildMultipleProviders(),
+		CheckDestroy:      testAccCheckApiTokenDestroy(params["Token"].(string)),
+		Steps: []resource.TestStep{
+			{},
+		},
+	})
+}
+
+// const testAccVcdApiToken_sysorg = `
+// resource
+
+// `
+
+func testAccCheckApiTokenDestroy(tokenName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "vcd_api_token" && rs.Primary.Attributes["name"] != tokenName {
+				continue
+			}
+
+			_, err := conn.GetTokenById(rs.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("Token still exist")
+			}
+
+			return nil
+		}
+
+		return nil
+	}
+}

--- a/vcd/resource_vcd_service_account.go
+++ b/vcd/resource_vcd_service_account.go
@@ -42,7 +42,7 @@ func resourceVcdServiceAccount() *schema.Resource {
 				Required:    true,
 				Description: "UUID of software, e.g: 12345678-1234-5678-90ab-1234567890ab",
 			},
-			"role_id": {
+			"role": {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Role ID of service account",
@@ -59,12 +59,12 @@ func resourceVcdServiceAccount() *schema.Resource {
 			},
 			"active": {
 				Type:        schema.TypeBool,
-				Required:    true,
+				Optional:    true,
 				Description: "Status of the service account.",
 			},
 			"file_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Name of the file that the API token will be saved to",
 			},
 			"allow_token_file": {
@@ -99,7 +99,7 @@ func resourceVcdServiceAccountCreate(ctx context.Context, d *schema.ResourceData
 
 	// Role needs to be sent in URN format, and the role name needs to be percent-encoded
 	// e.g urn:vcloud:role:Organization%20Administrator
-	roleId := d.Get("role_id").(string)
+	roleId := d.Get("role").(string)
 	role, err := adminOrg.GetRoleById(roleId)
 	if err != nil {
 		return diag.Errorf("[Service Account create] error getting Role: %s", err)
@@ -111,8 +111,7 @@ func resourceVcdServiceAccountCreate(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.Errorf("[Service Account create] error creating Service Account: %s", err)
 	}
-	uuid := extractUuid(sa.ServiceAccount.ID)
-	d.SetId(uuid)
+	d.SetId(sa.ServiceAccount.ID)
 
 	active := d.Get("active").(bool)
 	allowTokenFile := d.Get("allow_token_file").(bool)
@@ -150,8 +149,7 @@ func resourceVcdServiceAccountUpdate(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("[Service Account update] error getting Service Account: %s", err)
 	}
 
-	roleId := d.Get("role_id").(string)
-
+	roleId := d.Get("role").(string)
 	softwareId := d.Get("software_id").(string)
 	softwareVersion := d.Get("software_version").(string)
 	uri := d.Get("uri").(string)
@@ -277,7 +275,7 @@ func genericVcdServiceAccountRead(ctx context.Context, d *schema.ResourceData, m
 	dSet(d, "name", sa.ServiceAccount.Name)
 	dSet(d, "software_id", sa.ServiceAccount.SoftwareID)
 	dSet(d, "software_version", sa.ServiceAccount.SoftwareVersion)
-	dSet(d, "role_id", sa.ServiceAccount.Role.ID)
+	dSet(d, "role", sa.ServiceAccount.Role.ID)
 	dSet(d, "uri", sa.ServiceAccount.URI)
 	if sa.ServiceAccount.Status == "ACTIVE" {
 		dSet(d, "active", true)

--- a/vcd/resource_vcd_service_account.go
+++ b/vcd/resource_vcd_service_account.go
@@ -59,8 +59,7 @@ func resourceVcdServiceAccount() *schema.Resource {
 			},
 			"active": {
 				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
+				Required:    true,
 				Description: "Status of the service account.",
 			},
 			"file_name": {
@@ -274,6 +273,7 @@ func genericVcdServiceAccountRead(ctx context.Context, d *schema.ResourceData, m
 		return diag.Errorf("[Service Account read] error: %s", err)
 	}
 
+	d.SetId(sa.ServiceAccount.ID)
 	dSet(d, "name", sa.ServiceAccount.Name)
 	dSet(d, "software_id", sa.ServiceAccount.SoftwareID)
 	dSet(d, "software_version", sa.ServiceAccount.SoftwareVersion)

--- a/vcd/resource_vcd_service_account.go
+++ b/vcd/resource_vcd_service_account.go
@@ -1,0 +1,316 @@
+package vcd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/vmware/go-vcloud-director/v2/govcd"
+	"github.com/vmware/go-vcloud-director/v2/types/v56"
+)
+
+func resourceVcdServiceAccount() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceVcdServiceAccountCreate,
+		UpdateContext: resourceVcdServiceAccountUpdate,
+		ReadContext:   resourceVcdServiceAccountRead,
+		DeleteContext: resourceVcdServiceAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceVcdServiceAccountImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of service account",
+			},
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"software_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "UUID of software, e.g: 12345678-1234-5678-90ab-1234567890ab",
+			},
+			"role_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Role ID of service account",
+			},
+			"software_version": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Version of software using the service account",
+			},
+			"uri": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "URI of the client using the service account",
+			},
+			"active": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Status of the service account.",
+			},
+			"file_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the file that the API token will be saved to",
+			},
+			"allow_token_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Set this to true if you understand the security risks of using" +
+					" API token files and would like to suppress the warnings",
+			},
+		},
+	}
+}
+
+func resourceVcdServiceAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Service Account create] error getting Org from resource: %s", err)
+	}
+
+	adminOrg, err := vcdClient.GetAdminOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Service Account create] error getting AdminOrg from resource: %s", err)
+	}
+
+	saName := d.Get("name").(string)
+	softwareId := d.Get("software_id").(string)
+	softwareVersion := d.Get("software_version").(string)
+	uri := d.Get("uri").(string)
+	filename := d.Get("file_name").(string)
+
+	// Role needs to be sent in URN format, and the role name needs to be percent-encoded
+	// e.g urn:vcloud:role:Organization%20Administrator
+	roleId := d.Get("role_id").(string)
+	role, err := adminOrg.GetRoleById(roleId)
+	if err != nil {
+		return diag.Errorf("[Service Account create] error getting Role: %s", err)
+	}
+	escapedRoleName := url.PathEscape(role.Role.Name)
+	formattedRole := "urn:vcloud:role:" + escapedRoleName
+
+	sa, err := vcdClient.CreateServiceAccount(org.Org.Name, saName, formattedRole, softwareId, softwareVersion, uri)
+	if err != nil {
+		return diag.Errorf("[Service Account create] error creating Service Account: %s", err)
+	}
+	uuid := extractUuid(sa.ServiceAccount.ID)
+	d.SetId(uuid)
+
+	active := d.Get("active").(bool)
+	useragent := vcdClient.Client.UserAgent
+	err = updateServiceAccountStatus(sa, active, filename, useragent)
+	if err != nil {
+		return diag.Errorf("[Service Account create] error changing Service Account status: %s", err)
+	}
+
+	return resourceVcdServiceAccountRead(ctx, d, meta)
+}
+
+func resourceVcdServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf("[Service Account update] error getting Org from resource: %s", err)
+	}
+
+	sa, err := org.GetServiceAccountById(d.Id())
+	if err != nil {
+		return diag.Errorf("[Service Account update] error getting Service Account: %s", err)
+	}
+
+	// Role needs to be sent in URN format, and the role name needs to be percent-encoded
+	roleId := d.Get("role_id").(string)
+
+	softwareId := d.Get("software_id").(string)
+	softwareVersion := d.Get("software_version").(string)
+	uri := d.Get("uri").(string)
+	filename := d.Get("file_name").(string)
+	active := d.Get("active").(bool)
+
+	saConfig := &types.ServiceAccount{
+		SoftwareID:      softwareId,
+		SoftwareVersion: softwareVersion,
+		URI:             uri,
+		Role: &types.OpenApiReference{
+			ID: roleId,
+		},
+	}
+
+	sa, err = sa.Update(saConfig)
+	if err != nil {
+		return diag.Errorf("[Service Account update] error updating Service Account: %s", err)
+	}
+
+	if d.HasChange("active") {
+		useragent := vcdClient.Client.UserAgent
+		err = updateServiceAccountStatus(sa, active, filename, useragent)
+		if err != nil {
+			return diag.Errorf("[Service Account update] error updating Service Account status: %s", err)
+		}
+	}
+
+	return resourceVcdServiceAccountRead(ctx, d, meta)
+}
+
+func updateServiceAccountStatus(sa *govcd.ServiceAccount, active bool, filename, useragent string) error {
+	if active {
+		err := sa.Authorize()
+		if err != nil {
+			return fmt.Errorf("error authorizing Service Account: %s", err)
+		}
+		err = sa.Refresh()
+		if err != nil {
+			return fmt.Errorf("error refreshing Service Account: %s", err)
+		}
+		err = sa.Grant()
+		if err != nil {
+			return fmt.Errorf("error granting Service Account: %s", err)
+		}
+		err = sa.Refresh()
+		if err != nil {
+			return fmt.Errorf("error refreshing Service Account: %s", err)
+		}
+		initialApiToken, err := sa.GetInitialApiToken()
+		if err != nil {
+			return fmt.Errorf("error activating Service Account: %s", err)
+		}
+		err = sa.Refresh()
+		if err != nil {
+			return fmt.Errorf("error refreshing Service Account: %s", err)
+		}
+		err = govcd.SaveServiceAccountToFile(filename, useragent, initialApiToken)
+		if err != nil {
+			return fmt.Errorf("error saving service account api token to file: %s", err)
+		}
+	} else {
+		err := sa.Revoke()
+		if err != nil {
+			return fmt.Errorf("error revoking Service Account: %s", err)
+		}
+		err = sa.Refresh()
+		if err != nil {
+			return fmt.Errorf("error refreshing Service Account: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceVcdServiceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcdServiceAccountRead(ctx, d, meta, "resource")
+}
+
+func genericVcdServiceAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}, origin string) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrg, err)
+	}
+	var sa *govcd.ServiceAccount
+	if d.Id() != "" {
+		sa, err = org.GetServiceAccountById(d.Id())
+	} else {
+		saName := d.Get("name").(string)
+		sa, err = org.GetServiceAccountByName(saName)
+	}
+	if govcd.ContainsNotFound(err) {
+		// When parent Edge Gateway is not found - this resource is also not found and should be
+		// removed from state
+		if origin == "datasource" {
+			return diag.Errorf("[Service Account DS read] error retrieving Service Account: %s", err)
+		}
+		d.SetId("")
+		log.Printf("[DEBUG] Service Account no longer exists. Removing from tfstate")
+		return nil
+	}
+
+	if err != nil {
+		return diag.Errorf("[Service Account read] error: %s", err)
+	}
+
+	dSet(d, "name", sa.ServiceAccount.Name)
+	dSet(d, "software_id", sa.ServiceAccount.SoftwareID)
+	dSet(d, "software_version", sa.ServiceAccount.SoftwareVersion)
+	dSet(d, "role_id", sa.ServiceAccount.Role.ID)
+	dSet(d, "uri", sa.ServiceAccount.URI)
+	if sa.ServiceAccount.Status == "ACTIVE" {
+		dSet(d, "active", true)
+	} else {
+		dSet(d, "active", false)
+	}
+
+	return nil
+}
+
+func resourceVcdServiceAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vcdClient := meta.(*VCDClient)
+
+	org, err := vcdClient.GetOrgFromResource(d)
+	if err != nil {
+		return diag.Errorf(errorRetrievingOrg, err)
+	}
+	sa, err := org.GetServiceAccountById(d.Id())
+	if err != nil {
+		return diag.Errorf("[Service Account delete] error retrieving Service Account: %s", err)
+	}
+
+	err = sa.Delete()
+	if err != nil {
+		return diag.Errorf("[Service Account delete] error deleting Service Account: %s", err)
+	}
+
+	return resourceVcdServiceAccountRead(ctx, d, meta)
+}
+
+func resourceVcdServiceAccountImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	log.Printf("[TRACE] API token import initiated")
+
+	resourceURI := strings.Split(d.Id(), ImportSeparator)
+	if len(resourceURI) != 2 {
+		return nil, fmt.Errorf("resource name must be specified as org-name.service-account-name")
+	}
+	orgName := resourceURI[0]
+	saName := resourceURI[1]
+
+	vcdClient := meta.(*VCDClient)
+	org, err := vcdClient.GetOrgByName(orgName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving org: %s", err)
+	}
+
+	sa, err := org.GetServiceAccountByName(saName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving service account: %s", err)
+	}
+
+	dSet(d, "name", sa.ServiceAccount.Name)
+	dSet(d, "role", sa.ServiceAccount.Role.Name)
+	dSet(d, "software_id", sa.ServiceAccount.SoftwareID)
+	dSet(d, "software_version", sa.ServiceAccount.SoftwareVersion)
+	dSet(d, "uri", sa.ServiceAccount.URI)
+	dSet(d, "status", sa.ServiceAccount.Status)
+	d.SetId(extractUuid(sa.ServiceAccount.ID))
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/vcd/resource_vcd_service_account_test.go
+++ b/vcd/resource_vcd_service_account_test.go
@@ -1,0 +1,236 @@
+//go:build api || functional || ALL
+
+package vcd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccServiceAccount_SysOrg(t *testing.T) {
+	preTestChecks(t)
+	skipTestForApiToken(t)
+
+	params := StringMap{
+		"SaName":                 t.Name(),
+		"Org":                    testConfig.Provider.SysOrg,
+		"RoleName":               "System Administrator",
+		"SoftwareId":             "12345678-1234-1234-1234-1234567890ab",
+		"SoftwareVersion":        "1.0.0",
+		"Uri":                    "example.com",
+		"FileName":               "sa_api_token.json",
+		"SoftwareIdUpdated":      "87654321-4321-4321-4321-ba0987654321",
+		"SoftwareVersionUpdated": "2.3.4",
+		"UriUpdated":             "test.xyz",
+	}
+	testParamsNotEmpty(t, params)
+
+	params["FuncName"] = t.Name() + "step1"
+	configText1 := templateFill(testAccServiceAccount_SysOrg, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "step2"
+	configText2 := templateFill(testAccServiceAccount_SysOrg_Active, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	t.Cleanup(deleteApiTokenFile(t.Name()))
+	resourceName := "vcd_service_account.sysadmin"
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceAccountDestroy(params["Org"].(string), params["SaName"].(string)),
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "software_id", params["SoftwareId"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "software_version", params["SoftwareVersion"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "uri", params["Uri"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "active", "false"),
+				),
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "software_id", params["SoftwareIdUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "software_version", params["SoftwareVersionUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "uri", params["UriUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					testCheckFileExists(params["FileName"].(string)),
+				),
+			},
+		},
+	})
+}
+
+const testAccServiceAccount_SysOrg_Role = `
+data "vcd_role" "sys_admin" {
+  org  = "{{.Org}}"
+  name = "{{.RoleName}}"
+}
+`
+
+const testAccServiceAccount_SysOrg = testAccServiceAccount_SysOrg_Role + `
+resource "vcd_service_account" "sysadmin" {
+  name = "{{.SaName}}"
+  org  = "{{.Org}}"
+
+  role             = data.vcd_role.sys_admin.id
+  software_id      = "{{.SoftwareId}}"
+  software_version = "{{.SoftwareVersion}}"
+  uri              = "{{.Uri}}"
+
+  active = false
+}
+`
+const testAccServiceAccount_SysOrg_Active = testAccServiceAccount_SysOrg_Role + `
+resource "vcd_service_account" "sysadmin" {
+  name = "{{.SaName}}"
+  org  = "{{.Org}}"
+
+  role             = data.vcd_role.sys_admin.id
+  software_id      = "{{.SoftwareIdUpdated}}"
+  software_version = "{{.SoftwareVersionUpdated}}"
+  uri              = "{{.UriUpdated}}"
+
+  active   = true
+  file_name = "{{.FileName}}"
+}
+`
+
+func TestAccServiceAccount_Org(t *testing.T) {
+	preTestChecks(t)
+	skipTestForApiToken(t)
+
+	params := StringMap{
+		"SaName":                 t.Name(),
+		"Org":                    testConfig.VCD.Org,
+		"RoleName":               "System Administrator",
+		"SoftwareId":             "12345678-1234-1234-1234-1234567890ab",
+		"SoftwareVersion":        "1.0.0",
+		"Uri":                    "example.com",
+		"FileName":               "sa_api_token.json",
+		"SoftwareIdUpdated":      "87654321-4321-4321-4321-ba0987654321",
+		"SoftwareVersionUpdated": "2.3.4",
+		"UriUpdated":             "test.xyz",
+	}
+	testParamsNotEmpty(t, params)
+
+	params["FuncName"] = t.Name() + "step1"
+	configText1 := templateFill(testAccServiceAccount_Org, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText1)
+
+	params["FuncName"] = t.Name() + "step2"
+	configText2 := templateFill(testAccServiceAccount_Org_Active, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 2: %s", configText2)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	t.Cleanup(deleteApiTokenFile(params["FileName"].(string)))
+	resourceName := "vcd_service_account.org_user"
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckServiceAccountDestroy(params["Org"].(string), params["SaName"].(string)),
+		Steps: []resource.TestStep{
+			{
+				Config: configText1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "software_id", params["SoftwareId"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "software_version", params["SoftwareVersion"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "uri", params["Uri"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "active", "false"),
+				),
+			},
+			{
+				Config: configText2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", t.Name()),
+					resource.TestCheckResourceAttr(resourceName, "software_id", params["SoftwareIdUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "software_version", params["SoftwareVersionUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "uri", params["UriUpdated"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
+					testCheckFileExists(params["FileName"].(string)),
+				),
+			},
+		},
+	})
+}
+
+const testAccServiceAccount_Org_Roles = `
+data "vcd_role"	"vapp_author" {
+  org  = "{{.Org}}"
+  name = "vApp Author"
+}
+
+data "vcd_role"	"catalog_author" {
+  org  = "{{.Org}}"
+  name = "Catalog Author"
+}
+`
+
+const testAccServiceAccount_Org = testAccServiceAccount_Org_Roles + `
+resource "vcd_service_account" "org_user" {
+  name = "{{.SaName}}"
+  org  = "{{.Org}}"
+
+  role             = data.vcd_role.vapp_author.id
+  software_id      = "{{.SoftwareId}}"
+  software_version = "{{.SoftwareVersion}}"
+  uri              = "{{.Uri}}"
+
+  active = false
+}
+`
+const testAccServiceAccount_Org_Active = testAccServiceAccount_Org_Roles + `
+resource "vcd_service_account" "org_user" {
+  name = "{{.SaName}}"
+  org  = "{{.Org}}"
+
+  role             = data.vcd_role.catalog_author.id
+  software_id      = "{{.SoftwareIdUpdated}}"
+  software_version = "{{.SoftwareVersionUpdated}}"
+  uri              = "{{.UriUpdated}}"
+
+  active   = true
+  file_name = "{{.FileName}}"
+}
+`
+
+func testAccCheckServiceAccountDestroy(orgName, saName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*VCDClient)
+
+		org, err := conn.GetOrgByName(orgName)
+		if err != nil {
+			return fmt.Errorf(errorRetrievingOrg, err)
+		}
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "vcd_service_account" || rs.Primary.Attributes["name"] != saName {
+				continue
+			}
+
+			_, err := org.GetServiceAccountById(rs.Primary.ID)
+			if err == nil {
+				return fmt.Errorf("error: service account still exists post-destroy")
+			}
+
+			return nil
+		}
+
+		return nil
+	}
+}

--- a/vcd/resource_vcd_service_account_test.go
+++ b/vcd/resource_vcd_service_account_test.go
@@ -174,6 +174,13 @@ func TestAccServiceAccount_Org(t *testing.T) {
 					testCheckFileExists(params["FileName"].(string)),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateIdFunc:       importStateIdOrgObject(params["Org"].(string), params["SaName"].(string)),
+				ImportStateVerifyIgnore: []string{"org"},
+			},
 		},
 	})
 }

--- a/vcd/resource_vcd_service_account_test.go
+++ b/vcd/resource_vcd_service_account_test.go
@@ -179,7 +179,7 @@ func TestAccServiceAccount_Org(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateIdFunc:       importStateIdOrgObject(params["Org"].(string), params["SaName"].(string)),
-				ImportStateVerifyIgnore: []string{"org"},
+				ImportStateVerifyIgnore: []string{"org", "file_name", "allow_token_file"},
 			},
 		},
 	})

--- a/website/docs/d/service_account.html.markdown
+++ b/website/docs/d/service_account.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_service_account"
+sidebar_current: "docs-vcd-datasource-service-account"
+description: |-
+  Provides a data source to read DHCP pools for NSX-T Org VDC networks.
+---
+
+# vcd\_service\_account
+
+Provides a data source to read VCD Service Accounts.
+
+## Example Usage 1
+
+```hcl
+data "vcd_service_account" "example" {
+  org  = "my-org"
+  name = "my-parent-network"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `name` - (Required) Name of the Service Account
+
+## Attribute Reference
+
+All the attributes defined in [`vcd_service_account`](/providers/vmware/vcd/latest/docs/resources/service_account)
+resource except `file_name` and `allow_token_file` are available.

--- a/website/docs/r/service_account.html.markdown
+++ b/website/docs/r/service_account.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_service_account"
+sidebar_current: "docs-vcd-resource-service_account"
+description: |-
+  Provides a resource to manage Service Accounts. Service Accounts can have defined roles
+  and act just like a VCD user. Service Accounts, when activated, provide one-time use
+  access tokens for authentication to the VCD API, during which a new access token is generated.
+---
+
+# vcd\_service\_account 
+
+Supported in provider *v3.10+* and VCD 10.4+.
+
+Provides a resource to manage Service Accounts. Service Accounts can have defined roles
+and act just like a VCD user. Service Accounts, when activated, provide one-time use
+access tokens for authentication to the VCD API, during which a new access token is generated.
+Explained in more detail [here].[service-accounts]
+
+## Example Usage 
+
+```hcl
+data "vcd_role" "vapp_author" {
+  org  = "my-org"
+  name = "vApp Author"
+}
+
+resource "vcd_service_account" "example_service" {
+  org  = "my-org"
+  name = "example"
+  role = data.vcd_role.vapp_author.id
+
+  software_id      = "12345678-1234-1234-1234-1234567890ab"
+  software_version = "1.0.0"
+  uri              = "example.com"
+
+  file_name = "example_service.json"
+
+  active = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to use, optional if defined at provider level. Useful
+  when connected as sysadmin working across different organisations.
+* `name` - (Required) A unique name for the Service Account
+* `role` - (Required) ID of a Role.
+* `software_id` - (Required) UUID of the Service Account.
+* `software_version` - (Optional) Version of the service using the Service Account
+* `uri` - (Optional) URI of the service using the Service Account
+* `active` - (Required) Status of the Service Account. Can be set to `false` and back to `true` if
+  the access token was lost to get a new one.
+* `file_name` - (Optional) Required only when `active` is set to `true`. Contains the access token
+  that can be used for authenticating to VCD.
+* `allow_token_file` - (Optional) If set to false, will output a warning about the service account file
+  containing sensitive information.
+
+## Importing
+
+~> The current implementation of Terraform import can only import resources into the state.
+It does not generate configuration. [More information.][docs-import]
+
+An existing service account can be [imported][docs-import] into this resource via supplying
+the full dot separated path. An example is below:
+
+```
+terraform import vcd_service_account.imported my-org.my-service-account 
+```
+
+[service-accounts]: https://blogs.vmware.com/cloudprovider/2022/07/cloud-director-service-accounts.html
+[docs-import]: https://www.terraform.io/docs/import/

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -308,6 +308,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-nsxt-edge-dhcp-forwarding") %>>
               <a href="/docs/providers/vcd/d/nsxt_edgegateway_dhcp_forwarding.html">vcd_nsxt_edgegateway_dhcp_forwarding</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-service-account") %>>
+              <a href="/docs/providers/vcd/d/service_account.html">vcd_service_account</a>
+            </li>
           </ul>
         </li>
         <li<%= sidebar_current("docs-vcd-resource") %>>
@@ -549,6 +552,9 @@
             </li>
             <li<%= sidebar_current("docs-vcd-resource-nsxt-edge-dhcp-forwarding") %>>
               <a href="/docs/providers/vcd/r/nsxt_edgegateway_dhcp_forwarding.html">vcd_nsxt_edgegateway_dhcp_forwarding</a>
+            </li>
+            <li<%= sidebar_current("docs-vcd-resource-service-account") %>>
+              <a href="/docs/providers/vcd/r/service_account.html">vcd_service_account</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR introduces Service Account resource/datasource and API token resource. It doesn't include Authentication updates, which will be addressed in a separate PR to limit the scope of this one.

API Tokens only have read-only fields after creation, so the Update operation is unreachable. Also, they bring no value as datasources, so only resource is provided.

Service Accounts have 4 possible statuses in VCD, `Created`, `Requested`, `Granted` and `Active`, but Service Account manager should only care about Active/Not Active, as all the stages are reachable for a User with `Service Accounts: Manage` rights.

Refresh token file is saved on creation for API tokens, and on activation for Service Accounts.


