### PR TITLE
Test fixes (dhcpv6, (vcd_nsxt_edgegateway_dhcpv6, TestAccDataSourceNotFound, BGP Vrf)

### DIFF
--- a/.changes/v3.10.0/1071-features.md
+++ b/.changes/v3.10.0/1071-features.md
@@ -1,4 +1,4 @@
 * **New Resource:** `vcd_nsxt_edgegateway_dhcpv6` to manage NSX-T Edge Gateway DHCPv6 configuration
-  [GH-1071]
+  [GH-1071,GH-1083]
 * **New Data Source:** `vcd_nsxt_edgegateway_dhcpv6` to read NSX-T Edge Gateway DHCPv6 configuration
-  [GH-1071]
+  [GH-1071,GH-1083]

--- a/.changes/v3.10.0/1083-notes.md
+++ b/.changes/v3.10.0/1083-notes.md
@@ -1,0 +1,2 @@
+* Resource `vcd_nsxt_edgegateway_bgp_configuration` will send existing `GracefulRestart` to avoid
+  API validation errors in VCD 10.5.0+ [GH-1083]

--- a/vcd/datasource_not_found_test.go
+++ b/vcd/datasource_not_found_test.go
@@ -365,7 +365,6 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			templateFields = templateFields + `ip_space_id = "urn:vcloud:ipSpace:90337fee-f332-40f2-a124-96e890eb1522"` + "\n"
 		case "external_network_id":
 			templateFields = templateFields + `external_network_id = "urn:vcloud:network:74804d82-a58f-4714-be84-75c178751ab0"` + "\n"
-			templateFields = templateFields + `rde_type_id = "urn:vcloud:type:notexist:notexist:9.9.9"` + "\n"
 		}
 	}
 

--- a/vcd/ipv6_test.go
+++ b/vcd/ipv6_test.go
@@ -300,7 +300,6 @@ resource "vcd_nsxt_edgegateway_dhcpv6" "test" {
   org             = "{{.Org}}"
   edge_gateway_id = vcd_nsxt_edgegateway.nsxt-edge.id
 
-  enabled = true
   mode    = "DHCPv6"
 }
 

--- a/vcd/resource_vcd_nsxt_edgegateway_bgp_configuration.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_bgp_configuration.go
@@ -107,6 +107,16 @@ func resourceVcdEdgeBgpConfigCreateUpdate(ctx context.Context, d *schema.Resourc
 
 	bgpConfig := getEdgeBgpConfigType(d)
 
+	// If there is no user provided GracefulRestart config, reading BGP configuration as some VCD
+	// (10.5.0+) versions require supplying existing values
+	if bgpConfig.GracefulRestart == nil {
+		existingBgpConfig, err := nsxtEdge.GetBgpConfiguration()
+		if err != nil {
+			return diag.Errorf("error reading BGP config before creation: %s", err)
+		}
+		bgpConfig.GracefulRestart = existingBgpConfig.GracefulRestart
+	}
+
 	_, err = nsxtEdge.UpdateBgpConfiguration(bgpConfig)
 	if err != nil {
 		return diag.Errorf("error updating NSX-T Edge Gateway BGP Configuration: %s", err)

--- a/website/docs/r/nsxt_edgegateway_dhcpv6.html.markdown
+++ b/website/docs/r/nsxt_edgegateway_dhcpv6.html.markdown
@@ -17,8 +17,7 @@ resource "vcd_nsxt_edgegateway_dhcpv6" "dhcpv6-mode" {
   org             = "cloud"
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
 
-  enabled = true
-  mode    = "DHCPv6"
+  mode = "DHCPv6"
 }
 ```
 
@@ -29,7 +28,6 @@ resource "vcd_nsxt_edgegateway_dhcpv6" "slaac-mode" {
   org             = "datacloud"
   edge_gateway_id = data.vcd_nsxt_edgegateway.testing-in-vdc.id
 
-  enabled      = true
   mode         = "SLAAC"
   domain_names = ["non-existing.org.tld", "fake.org.tld"]
   dns_servers  = ["2001:4860:4860::8888", "2001:4860:4860::8844"]


### PR DESCRIPTION
* Removed `enabled` field in test and some sample snippets of website [c5d1073](https://github.com/vmware/terraform-provider-vcd/pull/1083/commits/c5d10730f4925f9b2ab5f1c09ebe9d5934b56231)
```
=== RUN   TestAccVcdIpv6Support
    ipv6_test.go:44: Step 1/1 error: Error running pre-apply refresh: exit status 1

        Error: Unsupported argument

          on terraform_plugin_test.tf line 143, in resource "vcd_nsxt_edgegateway_dhcpv6" "test":                                                               143:   enabled = true
        An argument named "enabled" is not expected here.
--- FAIL: TestAccVcdIpv6Support (2.59s)
```

* Probably was a corrupt merge [1344ad0](https://github.com/vmware/terraform-provider-vcd/pull/1083/commits/1344ad0de21ac4b303ea4f1869ebb50c0f63fc0a)
```
=== RUN   TestAccDataSourceNotFound/vcd_ip_space_uplink
    datasource_not_found_test.go:147: Step 1/1, expected an error with pattern, no match on: Error running pre-apply refresh: exit status 1

        Error: Unsupported argument

          on terraform_plugin_test.tf line 6, in data "vcd_ip_space_uplink" "not-existing":
           6: rde_type_id = "urn:vcloud:type:notexist:notexist:9.9.9"

        An argument named "rde_type_id" is not expected here.
--- FAIL: TestAccDataSourceNotFound (6.73s)
    --- FAIL: TestAccDataSourceNotFound/vcd_ip_space_uplink (0.37s)
```

* `TestAccVcdNsxtEdgeBgpConfigVrf` VCD with API V38.0 requires `GracefulRestart` even if non was presented. The fix is to read existing `GracefulRestart` values and submit them when user does not provide this configuration.  [1522e7a](https://github.com/vmware/terraform-provider-vcd/pull/1083/commits/1522e7a1b2c1c1611738dd4581c0bd0c08d37139)
```
=== RUN   TestAccVcdNsxtEdgeBgpConfigVrf
    resource_vcd_nsxt_edgegateway_bgp_configuration_test.go:339: Step 1/5 error: Error running apply: exit status 1
        
        Error: error updating NSX-T Edge Gateway BGP Configuration: error setting NSX-T Edge Gateway BGP Configuration: error in HTTP PUT request: BAD_REQUEST - [ dd125787-82be-4d80-b83a-b478462dbd84 ] Cannot change graceful restart configuration if using a VRF-Lite backed external network.
        
          with vcd_nsxt_edgegateway_bgp_configuration.testing,
          on terraform_plugin_test.tf line 56, in resource "vcd_nsxt_edgegateway_bgp_configuration" "testing":
          56: resource "vcd_nsxt_edgegateway_bgp_configuration" "testing" {
        
--- FAIL: TestAccVcdNsxtEdgeBgpConfigVrf (52.49s)
```