### PR TITLE
Reduce test connections

### DIFF
--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -310,7 +310,8 @@ const (
 # comment {{.Comment}}
 # date {{.Timestamp}}
 # file {{.CallerFileName}}
-#
+# VCD version {{.VcdVersion}}
+# API version {{.ApiVersion}}
 
 provider "vcd" {
   user                 = "{{.PrUser}}"
@@ -325,7 +326,6 @@ provider "vcd" {
   vdc                  = "{{.PrVdc}}"
   allow_unverified_ssl = "{{.AllowInsecure}}"
   max_retry_timeout    = {{.MaxRetryTimeout}}
-  #version             = "~> {{.VersionRequired}}"
   logging              = {{.Logging}}
   logging_file         = "{{.LoggingFile}}"
   {{.IgnoreMetadataBlock}}
@@ -479,6 +479,8 @@ func templateFill(tmpl string, data StringMap) string {
 		data["CallerFileName"] = callerFileName
 	}
 	data["Timestamp"] = time.Now().Format("2006-01-02 15:04")
+	data["VcdVersion"] = testConfig.Provider.VcdVersion
+	data["ApiVersion"] = testConfig.Provider.ApiVersion
 
 	// Creates a template. The template gets the same name of the calling function, to generate a better
 	// error message in case of failure

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/hashicorp/go-version"
 
+	semver "github.com/hashicorp/go-version"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -67,6 +69,8 @@ type TestConfig struct {
 		ApiToken                string `json:"api_token,omitempty"`
 		ApiTokenFile            string `json:"api_token_file,omitempty"`
 		ServiceAccountTokenFile string `json:"service_account_token_file,omitempty"`
+		VcdVersion              string `json:"vcdVersion,omitempty"`
+		ApiVersion              string `json:"apiVersion,omitempty"`
 
 		// UseSamlAdfs specifies if SAML auth is used for authenticating vCD instead of local login.
 		// The above `User` and `Password` will be used to authenticate against ADFS IdP when true.
@@ -1629,4 +1633,40 @@ func logState(label string) resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+// checkVersion checks a given version against a version constraint
+// for example:
+// version "37.2" ; constraint "< 36.1" ; returns false
+// version "37.2" ; constraint "> 36.0" ; returns true
+// The function returns false in case of errors, but it is chatty in such instances, because it means
+// an error in the test configuration that should be rectified
+func checkVersion(version, versionConstraint string) bool {
+	caller := util.CallFuncName()
+	if version == "" {
+		util.Logger.Printf("[INFO-%s] provided version is empty: can't be compared with constraints '%s'\n", caller, versionConstraint)
+		fmt.Printf("[INFO-%s] provided version is empty: can't be compared with constraints '%s'\n", caller, versionConstraint)
+		return false
+	}
+	checkVer, err := semver.NewVersion(version)
+	if err != nil {
+		util.Logger.Printf("[INFO-%s] error getting a semver object from version '%s': '%s'\n", caller, version, err)
+		fmt.Printf("[INFO-%s] error getting a semver object from version '%s': '%s'\n", caller, version, err)
+		return false
+	}
+	// Create a constraint to check against the provided version
+	constraints, err := semver.NewConstraint(versionConstraint)
+	if err != nil {
+		util.Logger.Printf("[INFO-%s] error getting a constraint object from versionConstraint '%s': '%s'\n", caller, versionConstraint, err)
+		fmt.Printf("[INFO-%s] error getting a constraint object from versionConstraint '%s': '%s'\n", caller, versionConstraint, err)
+		return false
+	}
+	// No screen message below this line: what follows is a legitimate boolean result
+	if constraints.Check(checkVer) {
+		util.Logger.Printf("[INFO-%s] version '%s' satisfies constraints '%s'\n", caller, checkVer, constraints)
+		return true
+	}
+
+	util.Logger.Printf("[TRACE-%s] version '%s' does not satisfy constraints '%s'\n", caller, checkVer, constraints)
+	return false
 }

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -67,8 +67,11 @@ type TestConfig struct {
 		ApiToken                string `json:"api_token,omitempty"`
 		ApiTokenFile            string `json:"api_token_file,omitempty"`
 		ServiceAccountTokenFile string `json:"service_account_token_file,omitempty"`
-		VcdVersion              string `json:"vcdVersion,omitempty"`
-		ApiVersion              string `json:"apiVersion,omitempty"`
+
+		// Versions are filled by the VCD provisioning task, and allow tests to
+		// check for compatibility without using an extra connection
+		VcdVersion string `json:"vcdVersion,omitempty"`
+		ApiVersion string `json:"apiVersion,omitempty"`
 
 		// UseSamlAdfs specifies if SAML auth is used for authenticating vCD instead of local login.
 		// The above `User` and `Password` will be used to authenticate against ADFS IdP when true.

--- a/vcd/config_test.go
+++ b/vcd/config_test.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/kr/pretty"
 
-	"github.com/hashicorp/go-version"
-
 	semver "github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -1564,7 +1562,7 @@ func skipTestForVcdExactVersion(t *testing.T, exactSkipVersion, skipReason strin
 		t.Fatalf("Could not determine VCD version")
 	}
 
-	expectedVersion, err := version.NewVersion(exactSkipVersion)
+	expectedVersion, err := semver.NewVersion(exactSkipVersion)
 	if err != nil {
 		t.Fatalf("could not process versions")
 	}

--- a/vcd/datasource_vcd_nsxt_edgegateway_dhcp_forwarding_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_dhcp_forwarding_test.go
@@ -14,11 +14,7 @@ func TestAccVcdDataSourceNsxtEdgeDhcpForwarding(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.1") {
 		t.Skipf("This test tests VCD 10.3.1+ (API V36.1+) features. Skipping.")
 	}
 

--- a/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_qos_profile_test.go
@@ -15,11 +15,9 @@ func TestAccVcdDatasourceNsxtGatewayQosProfile(t *testing.T) {
 	}
 
 	skipIfNotSysAdmin(t)
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
-
 	var params = StringMap{
 		"FuncName":           t.Name(),
 		"NsxtManager":        testConfig.Nsxt.Manager,

--- a/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/datasource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -15,11 +15,7 @@ func TestAccVcdDataSourceNsxtEdgeRateLimiting(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 

--- a/vcd/datasource_vcd_nsxt_network_imported_test.go
+++ b/vcd/datasource_vcd_nsxt_network_imported_test.go
@@ -15,11 +15,7 @@ func TestAccVcdNsxtNetworkImportedDS(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can create Imported networks")
-	}
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/vcd/resource_vcd_api_token_test.go
+++ b/vcd/resource_vcd_api_token_test.go
@@ -16,12 +16,7 @@ func TestAccVcdApiToken(t *testing.T) {
 	preTestChecks(t)
 	skipTestForServiceAccountAndApiToken(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.1") {
 		t.Skipf("API tokens require VCD 10.3.1+ (API v36.1+)")
 	}
 

--- a/vcd/resource_vcd_external_network_v2_test.go
+++ b/vcd/resource_vcd_external_network_v2_test.go
@@ -1059,14 +1059,9 @@ data "vcd_network_direct" "net" {
 func TestAccVcdExternalNetworkV2NsxtIpSpace(t *testing.T) {
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
-
 	var params = StringMap{
 		"Org":                 testConfig.VCD.Org,
 		"NsxtManager":         testConfig.Nsxt.Manager,

--- a/vcd/resource_vcd_independent_disk_test.go
+++ b/vcd/resource_vcd_independent_disk_test.go
@@ -178,8 +178,7 @@ func TestAccVcdIndependentDiskBasicWithUpdates(t *testing.T) {
 	// The test is being skipped due to a known bug in the current versions of VCD
 	// when updating the disk resources, thus the test will only be run on versions
 	// released after v10.4.1.
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("<= 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "<= 37.1") {
 		t.Skip("This test may fail on versions up to VCD 10.4.1 (API V37.1) because of a known bug. Skipping.")
 	}
 

--- a/vcd/resource_vcd_ip_space_custom_quota_test.go
+++ b/vcd/resource_vcd_ip_space_custom_quota_test.go
@@ -13,11 +13,7 @@ func TestAccVcdIpSpaceCustomQuota(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_ip_space_ip_allocation_test.go
+++ b/vcd/resource_vcd_ip_space_ip_allocation_test.go
@@ -15,11 +15,7 @@ func TestAccVcdIpSpaceIpAllocation(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_ip_space_test.go
+++ b/vcd/resource_vcd_ip_space_test.go
@@ -14,11 +14,7 @@ func TestAccVcdIpSpacePublic(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_ip_space_uplink_test.go
+++ b/vcd/resource_vcd_ip_space_uplink_test.go
@@ -12,11 +12,7 @@ func TestAccVcdIpSpaceUplink(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_alb_settings_test.go
+++ b/vcd/resource_vcd_nsxt_alb_settings_test.go
@@ -204,8 +204,7 @@ func TestAccVcdNsxtAlbSettingsTransparentMode(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 	skipNoNsxtAlbConfiguration(t)
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 
@@ -315,8 +314,7 @@ func TestAccVcdNsxtAlbSettingsDualStackMode(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 	skipNoNsxtAlbConfiguration(t)
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
+++ b/vcd/resource_vcd_nsxt_alb_virtual_service_test.go
@@ -757,8 +757,7 @@ func TestAccVcdNsxtAlbVirtualServiceTransparentMode(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 
@@ -980,8 +979,7 @@ func TestAccVcdNsxtAlbVirtualServiceIPv6(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skipf("This test tests VCD 10.4.0+ (API V37.0+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_app_port_profile_test.go
+++ b/vcd/resource_vcd_nsxt_app_port_profile_test.go
@@ -131,10 +131,7 @@ func TestAccVcdNsxtAppPortProfileProvider(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can create Provider scoped Application Port Profiles")
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":         "System",
@@ -391,10 +388,7 @@ func TestAccVcdNsxtAppPortProfileProviderContext(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can create Provider scoped Application Port Profiles")
-	}
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
 		"Org":         "System",

--- a/vcd/resource_vcd_nsxt_distributed_firewall_rule_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_rule_test.go
@@ -312,8 +312,7 @@ func TestAccVcdDistributedFirewallRuleVCD10_3_2(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_distributed_firewall_test.go
+++ b/vcd/resource_vcd_nsxt_distributed_firewall_test.go
@@ -465,8 +465,7 @@ func TestAccVcdDistributedFirewallVCD10_3_2(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_dhcp_forwarding_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_dhcp_forwarding_test.go
@@ -13,13 +13,7 @@ import (
 func TestAccVcdNsxtEdgeDhcpForwarding(t *testing.T) {
 	preTestChecks(t)
 
-	// Requires VCD 10.3.1+
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.1") {
 		t.Skipf("NSX-T Edge Gateway DHCP forwarding requires VCD 10.3.1+ (API v36.1+)")
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_dhcpv6_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_dhcpv6_test.go
@@ -13,11 +13,7 @@ import (
 func TestAccVcdNsxtEdgeDhcpV6(t *testing.T) {
 	preTestChecks(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_rate_limiting_test.go
@@ -14,11 +14,7 @@ func TestAccVcdNsxtEdgeRateLimiting(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skip(acceptanceTestsSkipped)
-	}
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.2") {
 		t.Skipf("This test tests VCD 10.3.2+ (API V36.2+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_static_route_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_static_route_test.go
@@ -21,12 +21,7 @@ func TestAccVcdNsxtEdgeStaticRoute(t *testing.T) {
 	}
 
 	// Requires VCD 10.4.0+
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skipf("NSX-T Edge Gateway Static Routing requires VCD 10.4.0+ (API v37.0+)")
 	}
 

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -370,12 +370,6 @@ func TestAccVcdNsxtEdgeGatewayVdcGroupMigration(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can run test of VDC Group")
-	}
-
 	// String map to fill the template
 	var params = StringMap{
 		"Org":                       testConfig.VCD.Org,

--- a/vcd/resource_vcd_nsxt_network_dhcp_test.go
+++ b/vcd/resource_vcd_nsxt_network_dhcp_test.go
@@ -36,16 +36,16 @@ func TestAccVcdOpenApiDhcpNsxtRouted(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(true)
 	vcdVersionIsLowerThan1031 := func() (bool, error) {
-		if vcdClient != nil && vcdClient.Client.APIVCDMaxVersionIs(">= 36.1") {
+		if checkVersion(testConfig.Provider.ApiVersion, ">= 36.1") {
+
 			return false, nil
 		}
 		return true, nil
 	}
 
 	// This case is specific for VCD 10.3.1 onwards since dns servers are not present in previous versions
-	if vcdClient != nil && vcdClient.Client.APIVCDMaxVersionIs(">= 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, ">= 36.1") {
 		params["SkipTest"] = "# skip-binary-test: VCD 10.3.1 onwards dns servers are not present in previous versions"
 	}
 	params["FuncName"] = t.Name() + "-step2"
@@ -358,8 +358,7 @@ func TestAccVcdOpenApiDhcpNsxtIsolated(t *testing.T) {
 	skipIfNotSysAdmin(t) // creates its own VDC
 
 	// Requires VCD 10.3.1+
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil || vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.1") {
 		t.Skipf("NSX-T Isolated network DHCP requires VCD 10.3.1+ (API v36.1+)")
 	}
 
@@ -763,12 +762,7 @@ func TestAccVcdOpenApiDhcpNsxtRoutedRelay(t *testing.T) {
 	preTestChecks(t)
 
 	// Requires VCD 10.3.1+
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 36.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 36.1") {
 		t.Skipf("NSX-T Isolated network DHCP requires VCD 10.3.1+ (API v36.1+)")
 	}
 

--- a/vcd/resource_vcd_nsxt_vapp_raw_test.go
+++ b/vcd/resource_vcd_nsxt_vapp_raw_test.go
@@ -14,15 +14,7 @@ import (
 
 func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 	preTestChecks(t)
-	if vcdShortTest {
-		t.Skip(acceptanceTestsSkipped)
-		return
-	}
-
-	vcdClient := createTemporaryVCDConnection(false)
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can create Imported networks")
-	}
+	skipIfNotSysAdmin(t)
 
 	var vapp govcd.VApp
 
@@ -52,6 +44,10 @@ func TestAccVcdNsxtVAppRawAllNsxtNetworks(t *testing.T) {
 
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText2)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,

--- a/vcd/resource_vcd_org_test.go
+++ b/vcd/resource_vcd_org_test.go
@@ -66,8 +66,7 @@ func TestAccVcdOrgFull(t *testing.T) {
 	skipIfNotSysAdmin(t)
 
 	createEnabledOrg := false
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("= 37.2") {
+	if checkVersion(testConfig.Provider.ApiVersion, "= 37.2") {
 		// TODO revisit once bug is fixed in VCD
 		fmt.Println("VCD 10.4.2 has a bug that prevents creating a disabled Org")
 		createEnabledOrg = true

--- a/vcd/resource_vcd_service_account_test.go
+++ b/vcd/resource_vcd_service_account_test.go
@@ -15,12 +15,7 @@ func TestAccServiceAccount_SysOrg(t *testing.T) {
 	skipTestForServiceAccountAndApiToken(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skipf("Service Accounts require VCD 10.4.0+ (API v37.0+)")
 	}
 
@@ -146,12 +141,7 @@ func TestAccServiceAccount_Org(t *testing.T) {
 	preTestChecks(t)
 	skipTestForServiceAccountAndApiToken(t)
 
-	vcdClient := createTemporaryVCDConnection(true)
-	if vcdClient == nil {
-		t.Skipf(t.Name() + " requires a connection to set the tests")
-	}
-
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skipf("Service Accounts require VCD 10.4.0+ (API v37.0+)")
 	}
 

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -24,8 +24,7 @@ func TestAccVcdVsphereSubscriber(t *testing.T) {
 		t.Skip("vSphereSubscribedCatalog was not defined")
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skip("This test may fail with versions prior to 10.4.0 because of side effects from other operations. Skipping.")
 	}
 
@@ -75,8 +74,7 @@ func TestAccVcdSubscribedCatalog(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.0") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.0") {
 		t.Skip("This test may fail with versions prior to 10.4.0 because of side effects from other operations. Skipping.")
 	}
 

--- a/vcd/resource_vcd_vapp_network_test.go
+++ b/vcd/resource_vcd_vapp_network_test.go
@@ -1133,8 +1133,7 @@ func TestAccVcdNsxtVappNetworkRemovalFails(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-	if vcdClient.Client.APIVCDMaxVersionIs("< 37.1") {
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
 		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
 	}
 

--- a/vcd/resource_vcd_vdc_group_common_test.go
+++ b/vcd/resource_vcd_vdc_group_common_test.go
@@ -607,11 +607,7 @@ func TestAccVcdNsxVdcGroupResources(t *testing.T) {
 		return
 	}
 
-	vcdClient := createTemporaryVCDConnection(false)
-
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can run test of VDC Group")
-	}
+	skipIfNotSysAdmin(t)
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.VCD.NsxtProviderVdc.Name == "" ||
 		testConfig.VCD.NsxtProviderVdc.NetworkPool == "" || testConfig.VCD.ProviderVdc.StorageProfile == "" {

--- a/vcd/resource_vcd_vdc_group_test.go
+++ b/vcd/resource_vcd_vdc_group_test.go
@@ -13,18 +13,13 @@ import (
 // TestAccVcdVdcGroupResource tests that VDC Group can be managed
 func TestAccVcdVdcGroupResource(t *testing.T) {
 	preTestChecks(t)
+	skipIfNotSysAdmin(t)
 
 	// This test requires access to the vCD before filling templates
 	// Thus it won't run in the short test
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
-	}
-
-	vcdClient := createTemporaryVCDConnection(false)
-
-	if !vcdClient.Client.IsSysAdmin {
-		t.Skip(t.Name() + " only System Administrator can run test of VDC Group")
 	}
 
 	if testConfig.Nsxt.Vdc == "" || testConfig.VCD.NsxtProviderVdc.Name == "" ||


### PR DESCRIPTION
This PR tries to reduce temporary connections, by using the VCD version and API version that are placed in the test configuration file during VCD provisioning.
