### PR TITLE
Improve providerConfigure logs

### DIFF
--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -389,6 +389,7 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	maxRetryTimeout := d.Get("max_retry_timeout").(int)
 
 	if err := validateProviderSchema(d); err != nil {
+		util.Logger.Printf("[ERROR] Error validating provider: %s - Call Stack: %s", err, util.FuncNameCallStack())
 		return nil, diag.Errorf("[provider validation] :%s", err)
 	}
 


### PR DESCRIPTION
This PR just adds some simple logging in the `providerConfigure` function that will help troubleshooting any strange failure like the following:

```
=== RUN   TestAccVcdVmPlacementPolicyInVdc
    testing_new.go:85: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: [provider validation] :both "org" and "sysorg" properties are empty
        
          with provider["registry.terraform.io/hashicorp/vcd"].orguser,
          on terraform_plugin_test.tf line 55, in provider "vcd":
          55: provider "vcd" {
```

I can't reproduce it, and it seems a bit odd. Either `configStruct.Provider.SysOrg`/ `configStruct.VCD.Org` are empty at a given moment or `VCD_SYS_ORG` / `VCD_ORG` are. This PR should help to diagnose what is going on.

