### PR TITLE
Patch VM customization tests for correct settings

### DIFF
--- a/.changes/v3.11.0/1113-notes.md
+++ b/.changes/v3.11.0/1113-notes.md
@@ -1,0 +1,2 @@
+* Patch tests `TestAccVcdVAppVmCustomizationSettings` and
+  `TestAccVcdStandaloneVmCustomizationSettings` to use valid guest customization settings [GH-1113]

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -449,7 +449,8 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.#", "1"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.enabled", "true"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.change_sid", "true"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.allow_local_admin_password", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.allow_local_admin_password", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.auto_generate_password", "true"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.must_change_password_on_first_login", "true"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.test-vm", "customization.0.number_of_auto_logons", "4"),
 				),
@@ -517,7 +518,7 @@ resource "vcd_vapp_vm" "test-vm" {
   customization {
 	enabled                             = true
 	change_sid                          = true
-	allow_local_admin_password          = false
+	allow_local_admin_password          = true
 	must_change_password_on_first_login = true
 	auto_generate_password              = true
 	number_of_auto_logons               = 4
@@ -540,11 +541,12 @@ resource "vcd_vapp_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-	enabled                = false
-	admin_password         = "some password"
-	auto_generate_password = false
-	join_domain            = true
-	join_org_domain        = true
+	enabled                    = false
+	allow_local_admin_password = true
+	admin_password             = "some password"
+	auto_generate_password     = false
+	join_domain                = true
+	join_org_domain            = true
   }
 }
 `

--- a/vcd/resource_vcd_vm_customization_test.go
+++ b/vcd/resource_vcd_vm_customization_test.go
@@ -287,7 +287,8 @@ func TestAccVcdStandaloneVmCustomizationSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.#", "1"),
 					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.enabled", "true"),
 					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.change_sid", "true"),
-					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.allow_local_admin_password", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.allow_local_admin_password", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.auto_generate_password", "true"),
 					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.must_change_password_on_first_login", "true"),
 					resource.TestCheckResourceAttr("vcd_vm.test-vm", "customization.0.number_of_auto_logons", "4"),
 				),
@@ -353,7 +354,7 @@ resource "vcd_vm" "test-vm" {
   customization {
 	enabled                             = true
 	change_sid                          = true
-	allow_local_admin_password          = false
+	allow_local_admin_password          = true
 	must_change_password_on_first_login = true
 	auto_generate_password              = true
 	number_of_auto_logons               = 4
@@ -375,11 +376,12 @@ resource "vcd_vm" "test-vm-step2" {
   cpu_cores     = 1
 
   customization {
-	enabled         = false
-	admin_password  = "some password"
-	auto_generate_password = false
-	join_domain     = true
-	join_org_domain = true
+	enabled                    = false
+	allow_local_admin_password = true
+	admin_password             = "some password"
+	auto_generate_password     = false
+	join_domain                = true
+	join_org_domain            = true
   }
 }
 `

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -620,7 +620,9 @@ This option should be selected for **Power on and Force re-customization to work
 * `change_sid` (Optional; *v2.7+*) Allows to change SID (security identifier). Only applicable for Windows operating systems.
 * `allow_local_admin_password` (Optional; *v2.7+*) Allow local administrator password.
 * `must_change_password_on_first_login` (Optional; *v2.7+*) Require Administrator to change password on first login.
-* `auto_generate_password` (Optional; *v2.7+*) Auto generate password.
+* `auto_generate_password` (Optional; *v2.7+*) Auto generate password. **Note:**
+  `allow_local_admin_password` must be enabled, otherwise next plan will be inconsistent and report
+  `auto_generate_password=false`
 * `admin_password` (Optional; *v2.7+*) Manually specify Administrator password.
 * `number_of_auto_logons` (Optional; *v2.7+*) Number of times to log on automatically. `0` means disabled.
 * `join_domain` (Optional; *v2.7+*) Enable this VM to join a domain.


### PR DESCRIPTION
### About

This PR attempts to fix tests (sample error at the bottom):
* TestAccVcdVAppVmCustomizationSettings
* TestAccVcdStandaloneVmCustomizationSettings

Both of these tests are identical, except that one tests vApp VM, other tests standalone VM.

### Problem

These tests look to attempt setting incorrect configuration which gets rejected by VCD.

UI does not allow setting "Auto generate password" when "Allow local administrator password" is not enabled (the option is greyed out), but currently our tests attempt to do it. As a result - the test gets inconsistent plan. This PR attempts to change tests so that they perform valid actions.

Impossible to set "Auto Generate Password"
![image](https://github.com/vmware/terraform-provider-vcd/assets/15804230/da01493f-7a0f-4955-9418-ca86408d105f)

"Auto Generate Password" can be set when "Allow local administrator password" is enabled
![image](https://github.com/vmware/terraform-provider-vcd/assets/15804230/f235867e-8fd2-4689-b38d-b0dd2ff05c90)

### Testing

Ran these tests
* Acceptance 10.4.0, 10.4.1, 10.4.2, 10.5.0
* Binary - attempted to run all 6 generated files on 10.5.0 (but not all of them are designed to be run in this mode) - no failures

#### Sample error

```
=== RUN   TestAccVcdVAppVmCustomizationSettings
    resource_vcd_vapp_vm_customization_test.go:437: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:


        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place

        Terraform will perform the following actions:

          # vcd_vapp_vm.test-vm will be updated in-place
          ~ resource "vcd_vapp_vm" "test-vm" {
                id                             = "urn:vcloud:vm:11999d4b-6822-4733-a0fd-75c293005b7e"
                name                           = "TestAccVcdVAppVmCustomizationSettingsVM"
                # (35 unchanged attributes hidden)

              ~ customization {
                  ~ auto_generate_password              = false -> true
                    # (8 unchanged attributes hidden)
                }
            }

        Plan: 0 to add, 1 to change, 0 to destroy.
   ...

--- FAIL: TestAccVcdVAppVmCustomizationSettings (257.85s)

```