### PR TITLE
GitHub Actions: Detect Go version from go.mod instead of hardcoding

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
 
     - name: vet
       run: make vet

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version-file: 'go.mod'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
-        go-version: ^1.17
+        go-version-file: 'go.mod'
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Required to have tag information available
 

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -16,15 +16,15 @@ jobs:
 
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v3
-      with:
-        go-version-file: 'go.mod'
-
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3
       with:
         fetch-depth: 0  # Required to have tag information available
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: 'go.mod'
 
     - name: Get latest released version
       run: echo "PROVIDER_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -9,8 +9,8 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version-file: 'go.mod'
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: gosec
         run: make security

--- a/.github/workflows/check-security.yml
+++ b/.github/workflows/check-security.yml
@@ -6,11 +6,13 @@ jobs:
     env:
       GO111MODULE: on
     steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - name: Checkout Source
-        uses: actions/checkout@v3
+
       - name: gosec
         run: make security


### PR DESCRIPTION
This PR does a tiny change in the GitHub Actions workflows so the Go version is not hardcoded, but calculated by reading go.mod.
This way we don't need to update it manually in the 3 files (that you can see were not in sync, by the way).

As this is a trivial change, I did not add a changelog entry.