### PR TITLE
Add RDE Type hooks

### DIFF
--- a/.changes/v3.11.0/1122-improvements.md
+++ b/.changes/v3.11.0/1122-improvements.md
@@ -1,0 +1,3 @@
+* Resource `vcd_rde_type` supports Behavior hooks with the new `hook` blocks, that allow to automatically invoke
+  Behaviors on certain RDE lifecycle events [GH-1122]
+* Data source `vcd_rde_type` supports reading Behavior hooks from VCD and store their information in the new `hook` blocks [GH-1122]

--- a/vcd/datasource_vcd_rde_type.go
+++ b/vcd/datasource_vcd_rde_type.go
@@ -54,6 +54,26 @@ func datasourceVcdRdeType() *schema.Resource {
 				Computed:    true,
 				Description: "An external entity's ID that this definition may apply to",
 			},
+			"hook": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Description: "Blocks that map RDE lifecycle events to existing Behaviors, that are" +
+					"automatically invoked when the corresponding event is triggered",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"event": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
+						},
+						"behavior_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Existing Behavior that will be automatically invoked when the RDE of this RDE Type triggers the event",
+						},
+					},
+				},
+			},
 			"inherited_version": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/vcd/datasource_vcd_rde_type.go
+++ b/vcd/datasource_vcd_rde_type.go
@@ -59,20 +59,7 @@ func datasourceVcdRdeType() *schema.Resource {
 				Computed: true,
 				Description: "Blocks that map RDE lifecycle events to existing Behaviors, that are" +
 					"automatically invoked when the corresponding event is triggered",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"event": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
-						},
-						"behavior_id": {
-							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Existing Behavior that will be automatically invoked when the RDE of this RDE Type triggers the event",
-						},
-					},
-				},
+				Elem: getRdeTypeHookSchema(true),
 			},
 			"inherited_version": {
 				Type:     schema.TypeString,

--- a/vcd/resource_vcd_rde_type.go
+++ b/vcd/resource_vcd_rde_type.go
@@ -169,11 +169,11 @@ func resourceVcdRdeTypeCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func getRdeTypeHooksFromSchema(d *schema.ResourceData) map[string]string {
-	if _, ok := d.GetOk("hooks"); !ok {
+	if _, ok := d.GetOk("hook"); !ok {
 		return nil
 	}
 	hooks := map[string]string{}
-	rawHooks := d.Get("hooks").(*schema.Set).List()
+	rawHooks := d.Get("hook").(*schema.Set).List()
 	for _, h := range rawHooks {
 		hookBlock := h.(map[string]interface{})
 		hooks[hookBlock["event"].(string)] = hookBlock["behavior_id"].(string)

--- a/vcd/resource_vcd_rde_type.go
+++ b/vcd/resource_vcd_rde_type.go
@@ -16,19 +16,23 @@ import (
 	"github.com/vmware/go-vcloud-director/v2/util"
 )
 
-var rdeTypeHook = &schema.Resource{
-	Schema: map[string]*schema.Schema{
-		"event": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
+func getRdeTypeHookSchema(computed bool) *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"event": {
+				Type:        schema.TypeString,
+				Required:    !computed,
+				Computed:    computed,
+				Description: "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
+			},
+			"behavior_id": {
+				Type:        schema.TypeString,
+				Required:    !computed,
+				Computed:    computed,
+				Description: "Existing Behavior that will be automatically invoked when the RDE of this RDE Type triggers the event",
+			},
 		},
-		"behavior_id": {
-			Type:        schema.TypeString,
-			Required:    true,
-			Description: "Existing Behavior that will be automatically invoked when the RDE of this RDE Type triggers the event",
-		},
-	},
+	}
 }
 
 func resourceVcdRdeType() *schema.Resource {
@@ -104,7 +108,7 @@ func resourceVcdRdeType() *schema.Resource {
 				Optional: true,
 				Description: "Optional blocks that map RDE lifecycle events to existing Behaviors, that will be " +
 					"automatically invoked when the corresponding event is triggered",
-				Elem: rdeTypeHook,
+				Elem: getRdeTypeHookSchema(false),
 			},
 			"inherited_version": {
 				Type:     schema.TypeString,
@@ -286,7 +290,7 @@ func genericVcdRdeTypeRead(_ context.Context, d *schema.ResourceData, meta inter
 		hook["behavior_id"] = behaviorId
 		hooks = append(hooks, hook)
 	}
-	hookSet := schema.NewSet(schema.HashResource(rdeTypeHook), hooks)
+	hookSet := schema.NewSet(schema.HashResource(getRdeTypeHookSchema(false)), hooks)
 	err = d.Set("hook", hookSet)
 	if err != nil {
 		return diag.Errorf("error setting RDE Type Hooks: %s", err)

--- a/vcd/resource_vcd_rde_type.go
+++ b/vcd/resource_vcd_rde_type.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"io"
 	"log"
 	"net/http"
@@ -17,13 +18,18 @@ import (
 )
 
 func getRdeTypeHookSchema(computed bool) *schema.Resource {
+	validateFunc := validation.StringInSlice([]string{"PostCreate", "PostUpdate", "PreDelete", "PostDelete"}, false)
+	if computed {
+		validateFunc = nil
+	}
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"event": {
-				Type:        schema.TypeString,
-				Required:    !computed,
-				Computed:    computed,
-				Description: "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
+				Type:         schema.TypeString,
+				Required:     !computed,
+				Computed:     computed,
+				Description:  "Event that will invoke the Behavior, one of PostCreate, PostUpdate, PreDelete, PostDelete",
+				ValidateFunc: validateFunc,
 			},
 			"behavior_id": {
 				Type:        schema.TypeString,

--- a/vcd/resource_vcd_rde_type_behavior_and_acl_test.go
+++ b/vcd/resource_vcd_rde_type_behavior_and_acl_test.go
@@ -228,7 +228,7 @@ resource "vcd_rde_type" "type_with_hooks" {
   description   = "{{.Description}}Hooks"
   interface_ids = [vcd_rde_interface.interface.id]
   schema        = file("{{.SchemaPath}}")
-  hooks {
+  hook {
     event       = "{{.HookEvent}}"
     behavior_id = vcd_rde_interface_behavior.behavior1.id
   }

--- a/website/docs/r/rde_type.html.markdown
+++ b/website/docs/r/rde_type.html.markdown
@@ -138,11 +138,11 @@ The following arguments are supported:
   The referenced JSON schema will be downloaded on every read operation, and it will break Terraform operations if these contents are no longer present on the remote site.
   If you can't guarantee this, it is safer to use `schema`.
 * `external_id` - (Optional) An external entity's ID that this Runtime Defined Entity Type may apply to.
-* `hook` - (Optional; *v3.11+*) Optional blocks that map [RDE](/providers/vmware/vcd/latest/docs/resources/rde) lifecycle events
+* `hook` - (Optional; *v3.11+*) Each block maps a lifecycle event of [RDEs](/providers/vmware/vcd/latest/docs/resources/rde)  
   to existing [Behaviors](/providers/vmware/vcd/latest/docs/resources/rde_interface_behavior), that will be
   automatically invoked when the corresponding event is triggered. These blocks have the following properties:
   * `event`: Event that will invoke the Behavior, one of `PostCreate`, `PostUpdate`, `PreDelete`, `PostDelete`.
-  * `behavior_id`: Existing Behavior that will be automatically invoked when the RDE of this RDE Type triggers the event.
+  * `behavior_id`: Existing Behavior that will be automatically invoked when any RDE of this RDE Type triggers the event.
 * `inherited_version` - (Optional) To be used when creating a new version of a Runtime Defined Entity Type.
   Specifies the version of the type that will be the template for the authorization configuration of the new version.
   The Type ACLs and the access requirements of the Type Behaviors of the new version will be copied from those of the inherited version.

--- a/website/docs/r/rde_type.html.markdown
+++ b/website/docs/r/rde_type.html.markdown
@@ -111,8 +111,9 @@ resource "vcd_rde_type" "my_rde_type" {
   name          = "My VMware RDE Type"
   interface_ids = [data.vcd_rde_interface.my_interface.id]
   schema_url    = "https://just.an-example.com/schemas/my-type-schema.json"
+  
   hook {
-    event = "PostCreate" # Every RDE of this Type that is created will invoke the Behavior automatically
+    event       = "PostCreate" # Every RDE of this Type that is created will invoke the Behavior automatically
     behavior_id = vcd_rde_interface_behavior.my_behavior.id
   }
   # depends_on is not needed in this specific case, because the hook already forces the dependency on the Interface Behavior

--- a/website/docs/r/rde_type.html.markdown
+++ b/website/docs/r/rde_type.html.markdown
@@ -97,7 +97,7 @@ data "vcd_rde_interface" "my_interface" {
 resource "vcd_rde_interface_behavior" "my_behavior" {
   interface_id = vcd_rde_interface.my_interface.id
   name         = "MyBehavior"
-  description  = "Adds a node to the cluster.\nParameters:\n  clusterId: the ID of the cluster\n  node: The node address\n"
+  description  = "Calls an example Behavior.\nParameters:\n  parameter1: the first param\n  parameter2: the second param\n"
   execution = {
     "id" : "MyExecution"
     "type" : "Activity"

--- a/website/docs/r/rde_type.html.markdown
+++ b/website/docs/r/rde_type.html.markdown
@@ -111,7 +111,7 @@ resource "vcd_rde_type" "my_rde_type" {
   name          = "My VMware RDE Type"
   interface_ids = [data.vcd_rde_interface.my_interface.id]
   schema_url    = "https://just.an-example.com/schemas/my-type-schema.json"
-  
+
   hook {
     event       = "PostCreate" # Every RDE of this Type that is created will invoke the Behavior automatically
     behavior_id = vcd_rde_interface_behavior.my_behavior.id


### PR DESCRIPTION
## Overview

This PR adds a new feature to existing `vcd_rde_type` resource and data source: The `hook` blocks.

A `hook` block maps a lifecycle event of a given Runtime Defined Entity (`vcd_rde`), one of:
- `PostCreate`: After the RDE of this type is created
- `PostUpdate`: After the RDE of this type is updated
- `PreDelete`: Before the RDE of this type is deleted
- `PostDelete`: After the RDE of this type is deleted

with an existing Behavior. This allows customers to automatically invoke the desired Behavior when these lifecycle events are triggered.

For example, let's imagine there's a Behavior that calls a webhook to send a message to a Slack channel.
If we have an RDE Type with the new block:
```
hook {
 event = "PostCreate"
 behavior_id = ... # my "send to Slack" behavior ID
}
```

Whenever a RDE **of that Type** is created, it will send a message to Slack!

## Implementation details

A new block `hook` is added to `vcd_rde_type` resource and data source. This has the sub-properties `event` (the lifecycle event) and `behavior_id`.

The Behavior referenced by the ID must exist already.

## Tests

Tests passed in VCD 10.5.0