### PR TITLE
Fix edgegateway retrieval from VDC group

### DIFF
--- a/.changes/v3.11.0/1129-bug-fixes.md
+++ b/.changes/v3.11.0/1129-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix Issue [#1127](https://github.com/vmware/terraform-provider-vcd/issues/1127) (Incorrect behavior of vcd_resource_list, which can retrieve edge gateways belonging to a VDC, but not belonging to a VDC group) [GH-1129]

--- a/.changes/v3.11.0/1129-bug-fixes.md
+++ b/.changes/v3.11.0/1129-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix Issue [#1127](https://github.com/vmware/terraform-provider-vcd/issues/1127) (Incorrect behavior of vcd_resource_list, which can retrieve edge gateways belonging to a VDC, but not belonging to a VDC group) [GH-1129]
+* Fix Issue [#1127](https://github.com/vmware/terraform-provider-vcd/issues/1127) (Incorrect behavior of vcd_resource_list, which can retrieve Edge Gateways belonging to a VDC, but not belonging to a VDC Group) [GH-1129]

--- a/scripts/gosec-config.sh
+++ b/scripts/gosec-config.sh
@@ -1,0 +1,4 @@
+# GOSEC_URL is the address of the gosec installation script
+export GOSEC_URL=https://raw.githubusercontent.com/securego/gosec/master/install.sh
+# NOTE: if we want to get the latest version, we set the variable below to empty ("")
+export GOSEC_VERSION=v2.17.0

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -18,6 +18,8 @@ then
     exit 1
 fi
 
+source ./scripts/gosec-config.sh
+
 function exists_in_path {
     what=$1
     for dir in $(echo $PATH | tr ':' ' ')

--- a/scripts/gosec.sh
+++ b/scripts/gosec.sh
@@ -12,6 +12,12 @@ then
     exit 1
 fi
 
+if [ ! -f ./scripts/gosec-config.sh ]
+then
+    echo "file ./scripts/gosec-config.sh not found"
+    exit 1
+fi
+
 function exists_in_path {
     what=$1
     for dir in $(echo $PATH | tr ':' ' ')
@@ -35,14 +41,14 @@ function get_gosec {
             echo "'curl' executable not found - Skipping gosec"
             exit 0
         fi
-        $curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh
+        $curl -sfL $GOSEC_URL > gosec_install.sh
         exit_code=$?
         if [ "$exit_code" != "0" ]
         then
           echo "Error downloading gosec installer"
           exit $exit_code
         fi
-        sh -x gosec_install.sh > gosec_install.log 2>&1
+        sh -x gosec_install.sh $GOSEC_VERSION > gosec_install.log 2>&1
         if [ "$exit_code" != "0" ]
         then
           echo "Error installing gosec"

--- a/vcd/datasource_vcd_resource_list.go
+++ b/vcd/datasource_vcd_resource_list.go
@@ -671,7 +671,7 @@ func getNsxtEdgeGatewayList(d *schema.ResourceData, meta interface{}) (list []st
 					return nil, fmt.Errorf("neither a VDC or a VDC group found with name '%s'", parentName)
 				}
 			} else {
-				return nil, fmt.Errorf(" error retrieving VDC group '%s': %s", parentName, err)
+				return nil, fmt.Errorf("error retrieving VDC group '%s': %s", parentName, err)
 			}
 		}
 	}

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -127,13 +127,40 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 		if testConfig.Networking.EdgeGateway != "" {
 			// entities belonging to a VDC don't require an explicit parent, as it is given from the VDC passed in the provider
 			// For each resource, we test with and without and explicit parent
-			lists = append(lists, listDef{name: "edge_gateway-parent", resourceType: "vcd_edgegateway", parent: testConfig.VCD.Vdc, knownItem: testConfig.Networking.EdgeGateway, vdc: testConfig.VCD.Vdc})
+			lists = append(lists, listDef{
+				name:         "edge_gateway-parent-vdc",
+				resourceType: "vcd_edgegateway",
+				parent:       testConfig.VCD.Vdc,
+				knownItem:    testConfig.Networking.EdgeGateway,
+				vdc:          testConfig.VCD.Vdc,
+			})
+			lists = append(lists, listDef{
+				name:         "edge_gateway-parent",
+				resourceType: "vcd_edgegateway",
+				parent:       testConfig.VCD.Vdc,
+				knownItem:    testConfig.Networking.EdgeGateway,
+			})
+			lists = append(lists, listDef{
+				name:         "edge_gateway-vdc",
+				resourceType: "vcd_edgegateway",
+				knownItem:    testConfig.Networking.EdgeGateway,
+				vdc:          testConfig.VCD.Vdc,
+			})
 		} else {
 			fmt.Print("`Networking.EdgeGateway` value isn't configured, datasource test using this will be skipped\n")
 		}
 	} else {
 		fmt.Print("`" +
 			"VCD.Vdc` value isn't configured, datasource test using this will be skipped\n")
+	}
+
+	if testConfig.Nsxt.VdcGroup != "" && testConfig.Nsxt.VdcGroupEdgeGateway != "" {
+		lists = append(lists, listDef{
+			name:         "VdcGroupEdge",
+			resourceType: "vcd_nsxt_edgegateway",
+			parent:       testConfig.Nsxt.VdcGroup,
+			knownItem:    testConfig.Nsxt.VdcGroupEdgeGateway,
+		})
 	}
 
 	if testConfig.Nsxt.Vdc != "" {
@@ -148,6 +175,26 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 		lists = append(lists, listDef{name: "vapp-parent", resourceType: "vcd_vapp", parent: testConfig.Nsxt.Vdc})
 
 		lists = append(lists, listDef{name: "vapp", resourceType: "vcd_vapp"})
+
+		lists = append(lists, listDef{
+			name:         "vdc-nsxt-edge-parent",
+			resourceType: "vcd_nsxt_edgegateway",
+			parent:       testConfig.Nsxt.Vdc, // no explicit VDC given
+			knownItem:    testConfig.Nsxt.EdgeGateway,
+		})
+		lists = append(lists, listDef{
+			name:         "vdc-nsxt-edge-vdc",
+			resourceType: "vcd_nsxt_edgegateway",
+			vdc:          testConfig.Nsxt.Vdc, // explicit VDC. No parent given
+			knownItem:    testConfig.Nsxt.EdgeGateway,
+		})
+		lists = append(lists, listDef{
+			name:         "vdc-nsxt-edge-parent-vdc",
+			resourceType: "vcd_nsxt_edgegateway",
+			vdc:          testConfig.VCD.Vdc, // this is the wrong VDC. Parent field gets precedence
+			parent:       testConfig.Nsxt.Vdc,
+			knownItem:    testConfig.Nsxt.EdgeGateway,
+		})
 	} else {
 		fmt.Print("`Nsxt.Vdc` value isn't configured, datasource test using this will be skipped\n")
 	}


### PR DESCRIPTION
Address Issue #1127

Fix incorrect behavior of `vcd_resource_list`, which can retrieve edge gateways belonging to a VDC, but not belonging to a VDC group.