### PR TITLE
Amend TestAccDataSourceNotFound to admit vcd_rde_behavior_invocation attributes

### DIFF
--- a/.changes/v3.11.0/1117-experimental-features.md
+++ b/.changes/v3.11.0/1117-experimental-features.md
@@ -1,1 +1,1 @@
-* **New Data Source:** `vcd_rde_behavior_invocation` to invoke a Behavior of a given RDE [GH-1117]
+* **New Data Source:** `vcd_rde_behavior_invocation` to invoke a Behavior of a given RDE [GH-1117, GH-XXXX]

--- a/.changes/v3.11.0/1117-experimental-features.md
+++ b/.changes/v3.11.0/1117-experimental-features.md
@@ -1,1 +1,1 @@
-* **New Data Source:** `vcd_rde_behavior_invocation` to invoke a Behavior of a given RDE [GH-1117, GH-XXXX]
+* **New Data Source:** `vcd_rde_behavior_invocation` to invoke a Behavior of a given RDE [GH-1117, GH-1136]

--- a/vcd/datasource_not_found_test.go
+++ b/vcd/datasource_not_found_test.go
@@ -368,6 +368,8 @@ func addMandatoryParams(dataSourceName string, mandatoryFields []string, t *test
 			templateFields = templateFields + `rde_type_id = "urn:vcloud:type:donotexist:donotexist:9.9.9"` + "\n"
 		case "rde_interface_id":
 			templateFields = templateFields + `rde_interface_id = "urn:vcloud:interface:notexist:notexist:9.9.9"` + "\n"
+		case "rde_id":
+			templateFields = templateFields + `rde_id = "urn:vcloud:entity:notexist:notexist:90337fee-f332-40f2-a124-96e890eb1522"` + "\n"
 		case "behavior_id":
 			templateFields = templateFields + `behavior_id = "urn:vcloud:behavior-interface:NotExist:notexist:notexist:9.9.9"` + "\n"
 		case "ip_space_id":


### PR DESCRIPTION
This PR complements #1117 and fixes the broken TestAccDataSourceNotFound, that required to add `rde_id` field to pass.