### PR TITLE
Fix resource list usage of "parent" with entities depending on Org 

### DIFF
--- a/vcd/api_test.go
+++ b/vcd/api_test.go
@@ -151,14 +151,3 @@ func getVersionFromFile(fileName string) (string, error) {
 
 	return strings.TrimSpace(string(versionText)), nil
 }
-
-// firstNonEmpty returns the first non empty string from a list
-// If all arguments are empty, returns an empty string
-func firstNonEmpty(args ...string) string {
-	for _, s := range args {
-		if s != "" {
-			return s
-		}
-	}
-	return ""
-}

--- a/vcd/datasource_vcd_resource_list.go
+++ b/vcd/datasource_vcd_resource_list.go
@@ -148,7 +148,7 @@ func getPvdcList(d *schema.ResourceData, meta interface{}) (list []string, err e
 func getVdcGroups(d *schema.ResourceData, meta interface{}) (list []string, err error) {
 	client := meta.(*VCDClient)
 
-	org, err := client.GetAdminOrgByName(d.Get("org").(string))
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -203,7 +203,8 @@ func externalNetworkList(d *schema.ResourceData, meta interface{}) (list []strin
 
 func rightsList(d *schema.ResourceData, meta interface{}) (list []string, err error) {
 	client := meta.(*VCDClient)
-	org, err := client.GetAdminOrg(d.Get("org").(string))
+
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -229,7 +230,7 @@ func rightsList(d *schema.ResourceData, meta interface{}) (list []string, err er
 func rolesList(d *schema.ResourceData, meta interface{}) (list []string, err error) {
 	client := meta.(*VCDClient)
 
-	org, err := client.GetAdminOrg(d.Get("org").(string))
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -276,7 +277,7 @@ func globalRolesList(d *schema.ResourceData, meta interface{}) (list []string, e
 func libraryCertificateList(d *schema.ResourceData, meta interface{}) (list []string, err error) {
 	client := meta.(*VCDClient)
 
-	adminOrg, err := client.GetAdminOrg(d.Get("org").(string))
+	adminOrg, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -332,8 +333,7 @@ func rightsBundlesList(d *schema.ResourceData, meta interface{}) (list []string,
 
 func catalogList(d *schema.ResourceData, meta interface{}, resType string) (list []string, err error) {
 	client := meta.(*VCDClient)
-
-	org, err := client.GetAdminOrg(d.Get("org").(string))
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -449,7 +449,7 @@ func vappTemplateList(d *schema.ResourceData, meta interface{}) (list []string, 
 func vdcList(d *schema.ResourceData, meta interface{}, resType string) (list []string, err error) {
 	client := meta.(*VCDClient)
 
-	org, err := client.GetAdminOrg(d.Get("org").(string))
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}
@@ -469,7 +469,7 @@ func vdcList(d *schema.ResourceData, meta interface{}, resType string) (list []s
 func orgUserList(d *schema.ResourceData, meta interface{}) (list []string, err error) {
 	client := meta.(*VCDClient)
 
-	org, err := client.GetAdminOrg(d.Get("org").(string))
+	org, err := client.GetAdminOrg(firstNonEmpty(d.Get("org").(string), d.Get("parent").(string)))
 	if err != nil {
 		return list, err
 	}

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -154,13 +154,31 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 			"VCD.Vdc` value isn't configured, datasource test using this will be skipped\n")
 	}
 
-	if testConfig.Nsxt.VdcGroup != "" && testConfig.Nsxt.VdcGroupEdgeGateway != "" {
+	if testConfig.Nsxt.VdcGroup != "" {
+		// Retrieves the list of VDC groups, filling the "parent" field
 		lists = append(lists, listDef{
-			name:         "VdcGroupEdge",
-			resourceType: "vcd_nsxt_edgegateway",
-			parent:       testConfig.Nsxt.VdcGroup,
-			knownItem:    testConfig.Nsxt.VdcGroupEdgeGateway,
+			name:         "VdcGroupAsParent",
+			resourceType: "vcd_vdc_group",
+			parent:       testConfig.VCD.Org,
+			knownItem:    testConfig.Nsxt.VdcGroup,
 		})
+
+		// Retrieves the list of VDC groups, filling only the "org" field through the provider
+		lists = append(lists, listDef{
+			name:         "VdcGroupAsOrg",
+			resourceType: "vcd_vdc_group",
+			knownItem:    testConfig.Nsxt.VdcGroup,
+		})
+
+		// Retrieves the list of NSX-T edge gateway belonging to a VDC group
+		if testConfig.Nsxt.VdcGroupEdgeGateway != "" {
+			lists = append(lists, listDef{
+				name:         "VdcGroupEdge",
+				resourceType: "vcd_nsxt_edgegateway",
+				parent:       testConfig.Nsxt.VdcGroup,
+				knownItem:    testConfig.Nsxt.VdcGroupEdgeGateway,
+			})
+		}
 	}
 
 	if testConfig.Nsxt.Vdc != "" {

--- a/vcd/structure.go
+++ b/vcd/structure.go
@@ -349,3 +349,14 @@ func ObjectMap[Input any, Output any](input []Input, f func(Input) Output) []Out
 	}
 	return result
 }
+
+// firstNonEmpty returns the first non empty string from a list
+// If all arguments are empty, returns an empty string
+func firstNonEmpty(args ...string) string {
+	for _, s := range args {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Entities depending directly on an organization should use the `"org"` field to identify its parent.
The `"parent"` field, which is intended for intermediate entities, should not be used for this purpose.
However, if users fill the "parent" field instead of "org", they get an ambiguous error, which doesn't explain what has happened.

This change allows `vcd_resource_list` to consider both `"org"` and `"parent"` fields, as well as the `"org"`  field in the provider block.
The change is transparent for users. If the `"parent"` field was used instead of `"org`", the organization is retrieved without complaints. In case of error, they get a clear message about what is missing.

