### PR TITLE
Add property custom_user_ou to vcd_org_ldap

### DIFF
--- a/.changes/v3.11.0/1119-bug-fixes.md
+++ b/.changes/v3.11.0/1119-bug-fixes.md
@@ -1,1 +1,1 @@
-* Fix media item detection in `vcd_resource_list`: it was incorrectly listing also vApp templates [GH-1101]
+* Fix media item detection in `vcd_resource_list`: it was incorrectly listing also vApp templates [GH-1119]

--- a/.changes/v3.11.0/1142-bug-fixes.md
+++ b/.changes/v3.11.0/1142-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix Issue [1134](https://github.com/vmware/terraform-provider-vcd/issues/1134) : Can't use SYSTEM `ldap_mode` [GH-1142]

--- a/.changes/v3.11.0/1142-improvements.md
+++ b/.changes/v3.11.0/1142-improvements.md
@@ -1,0 +1,1 @@
+* Add property `custom_user_ou` to `vcd_org_ldap` to specify custom attributes when `ldap_mode = "SYSTEM"` [GH-1142]

--- a/go.mod
+++ b/go.mod
@@ -65,3 +65,7 @@ require (
 	google.golang.org/grpc v1.56.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )
+
+replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79
+
+// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.8
+	github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.9
 )
 
 require (
@@ -65,7 +65,3 @@ require (
 	google.golang.org/grpc v1.56.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79
-
-// replace github.com/vmware/go-vcloud-director/v2 => ../go-vcloud-director

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79 h1:gDLvsR112oR/W0YgIHPfUW5SOU0V5viCc7BUQFjpfDs=
-github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -125,6 +123,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.9 h1:3cY/rmJVPgdz83+SHZynmNJUP4IqsxxFvHDF6BxkI6s=
+github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.9/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtM
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79 h1:gDLvsR112oR/W0YgIHPfUW5SOU0V5viCc7BUQFjpfDs=
+github.com/dataclouder/go-vcloud-director/v2 v2.17.0-alpha.3.0.20231025153938-20fd2086dd79/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -123,8 +125,6 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.8 h1:SJZtJpYMj+I320FS6PrOQTKlYuQSnUdy0RI+3ZcKvGg=
-github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.8/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/zclconf/go-cty v1.13.2 h1:4GvrUxe/QUDYuJKAav4EYqdM47/kZa672LwmXFmEKT0=
 github.com/zclconf/go-cty v1.13.2/go.mod h1:YKQzy/7pZ7iq2jNFzy5go57xdxdWoLLpaEp4u238AE0=

--- a/vcd/datasource_vcd_org_ldap.go
+++ b/vcd/datasource_vcd_org_ldap.go
@@ -125,6 +125,11 @@ func datasourceVcdOrgLdap() *schema.Resource {
 				Computed:    true,
 				Description: "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
 			},
+			"custom_user_ou": { // CustomUsersOu
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "If ldap_mode is SYSTEM, specifies a LDAP attribute=value pair to use for OU (organizational unit)",
+			},
 			"custom_settings": { // CustomOrgLdapSettings
 				Type:        schema.TypeList,
 				Computed:    true,

--- a/vcd/resource_vcd_org_ldap.go
+++ b/vcd/resource_vcd_org_ldap.go
@@ -142,6 +142,11 @@ func resourceVcdOrgLdap() *schema.Resource {
 				Description:  "Type of LDAP settings (one of NONE, SYSTEM, CUSTOM)",
 				ValidateFunc: validation.StringInSlice([]string{types.LdapModeNone, types.LdapModeSystem, types.LdapModeCustom}, false),
 			},
+			"custom_user_ou": { // CustomUsersOu
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If ldap_mode is SYSTEM, specifies a LDAP attribute=value pair to use for OU (organizational unit)",
+			},
 			"custom_settings": { // CustomOrgLdapSettings
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -261,6 +266,7 @@ func genericVcdOrgLdapRead(ctx context.Context, d *schema.ResourceData, meta int
 
 	dSet(d, "org_id", orgId)
 	dSet(d, "ldap_mode", config.OrgLdapMode)
+	dSet(d, "custom_user_ou", config.CustomUsersOu)
 	d.SetId(adminOrg.AdminOrg.ID)
 
 	if config.OrgLdapMode == "CUSTOM" {
@@ -328,6 +334,11 @@ func resourceVcdOrgLdapDelete(ctx context.Context, d *schema.ResourceData, meta 
 func fillLdapSettings(d *schema.ResourceData) (*types.OrgLdapSettingsType, error) {
 	settings := types.OrgLdapSettingsType{
 		OrgLdapMode: d.Get("ldap_mode").(string),
+	}
+
+	if settings.OrgLdapMode == "SYSTEM" {
+		settings.CustomUsersOu = d.Get("custom_user_ou").(string)
+		return &settings, nil
 	}
 
 	if settings.OrgLdapMode != "CUSTOM" {

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `org_id` - (Required) Org ID: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
 * `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
-* `custom_user_ou` - (Optional; *v3.11+*) If `ldap_mode` is `SYSTEM`, specifies a LDAP `attribute=value` pair to use for OU (organizational unit)
+* `custom_user_ou` - (Optional; *v3.11+*) If `ldap_mode` is `SYSTEM`, specifies an LDAP `attribute=value` pair to use for OU (organizational unit)
 * `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
 
 <a id="custom-settings"></a>

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -14,7 +14,7 @@ Supported in provider *v3.8+*
 
 -> **Note:** This resource requires system administrator privileges.
 
-## Example Usage
+## Example Usage 1 - Custom configuration
 
 ```hcl
 provider "vcd" {
@@ -77,6 +77,20 @@ resource "vcd_org_ldap" "my-org-ldap" {
     # password value does not get returned by GET
     ignore_changes = [custom_settings[0].password]
   }
+}
+```
+
+## Example Usage 2 - Using system configuration
+
+```hcl
+data "vcd_org" "my-org" {
+  name = "my-org"
+}
+
+resource "vcd_org_ldap" "my-org-ldap" {
+  org_id         = data.vcd_org.my-org.id
+  ldap_mode      = "SYSTEM"
+  custom_user_ou = "ou=Foo,dc=domain,dc=local base DN"
 }
 ```
 

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -86,6 +86,7 @@ The following arguments are supported:
 
 * `org_id` - (Required) Org ID: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
 * `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
+* `custom_user_ou` - (Optional) If `ldap_mode` is `SYSTEM`, specifies a LDAP `attribute=value` pair to use for OU (organizational unit)
 * `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
 
 <a id="custom-settings"></a>

--- a/website/docs/r/org_ldap.html.markdown
+++ b/website/docs/r/org_ldap.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 
 * `org_id` - (Required) Org ID: there is only one LDAP configuration available for an organization. Thus, the resource can be identified by the Org.
 * `ldap_mode` - (Required) One of `NONE`, `CUSTOM`, `SYSTEM`. Note that using `NONE` has the effect of removing the LDAP settings
-* `custom_user_ou` - (Optional) If `ldap_mode` is `SYSTEM`, specifies a LDAP `attribute=value` pair to use for OU (organizational unit)
+* `custom_user_ou` - (Optional; *v3.11+*) If `ldap_mode` is `SYSTEM`, specifies a LDAP `attribute=value` pair to use for OU (organizational unit)
 * `custom_settings` - (Optional) LDAP server configuration. Becomes mandatory if `ldap_mode` is set to `CUSTOM`. See [Custom Settings](#custom-settings) below for details
 
 <a id="custom-settings"></a>


### PR DESCRIPTION
Fixes Issue #1134.

The resource `vcd_org_ldap` needs a configuration property when using `ldap_mode = "SYSTEM"`. 
The property `custom_user_ou` serves this purpose