### PR TITLE
Add independent disk to  leftovers removal and vcd_resource_list

### DIFF
--- a/.changes/v3.11.0/1155-improvements.md
+++ b/.changes/v3.11.0/1155-improvements.md
@@ -1,0 +1,1 @@
+* Add `vcd_independent_disk` to the resources retrieved by `vcd_resource_list` [GH-1155]

--- a/vcd/datasource_vcd_resource_list.go
+++ b/vcd/datasource_vcd_resource_list.go
@@ -710,6 +710,34 @@ func getNsxtEdgeGatewayList(d *schema.ResourceData, meta interface{}) (list []st
 	return genericResourceList(d, "vcd_nsxt_edgegateway", ancestors, items)
 }
 
+func diskList(d *schema.ResourceData, meta interface{}) (list []string, err error) {
+	client := meta.(*VCDClient)
+	vdcName, err := getVdcName(client, d)
+	if err != nil {
+		return list, err
+	}
+	org, vdc, err := client.GetOrgAndVdc(d.Get("org").(string), vdcName)
+	if err != nil {
+		return list, err
+	}
+
+	var items []resourceRef
+
+	disks, err := vdc.QueryDisks("*")
+	if err != nil {
+		return list, err
+	}
+	for _, diskRef := range *disks {
+		items = append(items, resourceRef{
+			name:   diskRef.Name,
+			id:     extractUuid(diskRef.HREF),
+			href:   diskRef.HREF,
+			parent: vdc.Vdc.Name,
+		})
+	}
+	return genericResourceList(d, "vcd_independent_disk", []string{org.Org.Name, vdc.Vdc.Name}, items)
+}
+
 func vappList(d *schema.ResourceData, meta interface{}, resType string) (list []string, err error) {
 	client := meta.(*VCDClient)
 	vdcName, err := getVdcName(client, d)
@@ -1114,6 +1142,8 @@ func datasourceVcdResourceListRead(_ context.Context, d *schema.ResourceData, me
 		list, err = vappTemplateList(d, meta)
 	case "vcd_catalog_media", "catalog_media", "media_items", "mediaitems", "mediaitem":
 		list, err = catalogItemList(d, meta, "vcd_catalog_media")
+	case "vcd_independent_disk", "disk", "disks":
+		list, err = diskList(d, meta)
 	case "vcd_vapp", "vapp", "vapps", "vcd_cloned_vapp":
 		list, err = vappList(d, meta, "vcd_vapp")
 	case "vcd_vapp_access_control":

--- a/vcd/remove_leftovers_test.go
+++ b/vcd/remove_leftovers_test.go
@@ -316,7 +316,33 @@ func removeLeftovers(govcdClient *govcd.VCDClient, verbose bool) error {
 				if toBeDeleted {
 					err = netRef.Delete()
 					if err != nil {
-						return fmt.Errorf("error deleting Org VDC '%s': %s", netRef.OpenApiOrgVdcNetwork.Name, err)
+						return fmt.Errorf("error deleting Org VDC network '%s': %s", netRef.OpenApiOrgVdcNetwork.Name, err)
+					}
+				}
+			}
+
+			// --------------------------------------------------------------
+			// Disks
+			// --------------------------------------------------------------
+			disks, err := vdc.QueryDisks("*")
+			if err != nil {
+				return fmt.Errorf("error retrieving Org VDC disk list: %s", err)
+			}
+			for _, diskRef := range *disks {
+				toBeDeleted := shouldDeleteEntity(alsoDelete, doNotDelete, diskRef.Name, "vcd_independent_disk", 2, verbose)
+				if toBeDeleted {
+
+					disk, err := vdc.GetDiskByHref(diskRef.HREF)
+					if err != nil {
+						return fmt.Errorf("error retrieving Org VDC disk '%s': %s", diskRef.Name, err)
+					}
+					task, err := disk.Delete()
+					if err != nil {
+						return fmt.Errorf("error deleting Org VDC disk '%s': %s", diskRef.Name, err)
+					}
+					err = task.WaitTaskCompletion()
+					if err != nil {
+						return fmt.Errorf("error finishing deletion of Org VDC disk '%s': %s", diskRef.Name, err)
 					}
 				}
 			}

--- a/website/docs/d/resource_list.html.markdown
+++ b/website/docs/d/resource_list.html.markdown
@@ -373,6 +373,7 @@ The following arguments are supported:
     * `vcd_vm`      (only standalone VMs)
     * `vcd_org_user`
     * `vcd_edgegateway`
+    * `vcd_independent_disk`
     * `vcd_nsxt_edgegateway`
     * `vcd_lb_server_pool`
     * `vcd_lb_service_monitor`


### PR DESCRIPTION
Added independent disks to the leftover entities that are removed after a failed test.
Also added `vcd_independent_disk` to the resources retrieved by `vcd_resource_list`
