### PR TITLE
Add guest_vlan_allowed property for Org VDC networks - vcd_network_routed_v2 and vcd_network_isolated_v2

### DIFF
--- a/.changes/v3.11.0/1080-improvement.md
+++ b/.changes/v3.11.0/1080-improvement.md
@@ -1,0 +1,2 @@
+* Add `guest_vlan_allowed` to `vcd_network_routed_v2` and `vcd_network_isolated_v2` resources and
+  data sources to allow the transport of VLAN-tagged packets on those network types [GH-1080]

--- a/.changes/v3.11.0/1168-improvement.md
+++ b/.changes/v3.11.0/1168-improvement.md
@@ -1,2 +1,2 @@
 * Add `guest_vlan_allowed` to `vcd_network_routed_v2` and `vcd_network_isolated_v2` resources and
-  data sources to allow the transport of VLAN-tagged packets on those network types [GH-1080]
+  data sources to allow the transport of VLAN-tagged packets on those network types [GH-1168]

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -304,3 +304,5 @@ vcd.ResourceSchema-vcd_ip_space_ip_allocation.tf v3.10.0 "Added new field 'value
 vcd.TestAccVcdStandaloneVmCustomizationSettings.tf v3.10.0 "auto_generate_password defaults to true since API v37.0"
 vcd.TestAccVcdVAppVm_Clone.tf v3.10.0 "VCD 10.5.1 autogenerates metadata that raises inconsistent final plans. Fixed by PR 1146"
 vcd.ResourceSchema-vcd_ip_space.tf v3.10.0 "New fields for NAT and Firewall rule auto creation"
+vcd.ResourceSchema-vcd_network_routed_v2.tf v3.10.0 "New field 'guest_vlan_allowed'"
+vcd.ResourceSchema-vcd_network_isolated_v2.tf v3.10.0 "New field 'guest_vlan_allowed'"

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -2,8 +2,9 @@ package vcd
 
 import (
 	"context"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"log"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -121,7 +122,7 @@ func datasourceVcdNetworkIsolatedV2() *schema.Resource {
 			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "True if Network allows guest VLAN tagging",
+				Description: "True if network allows guest VLAN tagging",
 			},
 			"metadata": {
 				Type:        schema.TypeMap,

--- a/vcd/datasource_vcd_network_isolated_v2.go
+++ b/vcd/datasource_vcd_network_isolated_v2.go
@@ -118,6 +118,11 @@ func datasourceVcdNetworkIsolatedV2() *schema.Resource {
 				Description: "IP ranges used for static pool allocation in the network",
 				Elem:        networkV2IpRangeComputed,
 			},
+			"guest_vlan_allowed": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if Network allows guest VLAN tagging",
+			},
 			"metadata": {
 				Type:        schema.TypeMap,
 				Computed:    true,

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -2,8 +2,9 @@ package vcd
 
 import (
 	"context"
-	"github.com/vmware/go-vcloud-director/v2/govcd"
 	"log"
+
+	"github.com/vmware/go-vcloud-director/v2/govcd"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -126,7 +127,7 @@ func datasourceVcdNetworkRoutedV2() *schema.Resource {
 			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Computed:    true,
-				Description: "True if Network allows guest VLAN tagging",
+				Description: "True if network allows guest VLAN tagging",
 			},
 			"metadata": {
 				Type:        schema.TypeMap,

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -123,6 +123,11 @@ func datasourceVcdNetworkRoutedV2() *schema.Resource {
 				Description: "IP ranges used for static pool allocation in the network",
 				Elem:        networkV2IpRangeComputed,
 			},
+			"guest_vlan_allowed": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if Network allows guest VLAN tagging",
+			},
 			"metadata": {
 				Type:        schema.TypeMap,
 				Computed:    true,

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -334,7 +334,11 @@ func setOpenApiOrgVdcIsolatedNetworkData(d *schema.ResourceData, orgVdcNetwork *
 	dSet(d, "dns2", orgVdcNetwork.Subnets.Values[0].DNSServer2)
 	dSet(d, "dns_suffix", orgVdcNetwork.Subnets.Values[0].DNSSuffix)
 	dSet(d, "is_shared", orgVdcNetwork.Shared)
-	dSet(d, "guest_vlan_allowed", orgVdcNetwork.GuestVlanTaggingAllowed)
+	if orgVdcNetwork.GuestVlanTaggingAllowed != nil {
+		dSet(d, "guest_vlan_allowed", *orgVdcNetwork.GuestVlanTaggingAllowed)
+	} else {
+		dSet(d, "guest_vlan_allowed", false)
+	}
 
 	// If any IP ranges are available
 	if len(orgVdcNetwork.Subnets.Values[0].IPRanges.Values) > 0 {
@@ -358,7 +362,6 @@ func getOpenApiOrgVdcIsolatedNetworkType(d *schema.ResourceData, vcdClient *VCDC
 	inheritedVdcField := vcdClient.Vdc
 	vdcField := d.Get("vdc").(string)
 	ownerIdField := d.Get("owner_id").(string)
-	guestVLANAllowed := d.Get("guest_vlan_allowed").(bool)
 
 	ownerId, err := getOwnerId(d, vcdClient, ownerIdField, vdcField, inheritedVdcField)
 	if err != nil {
@@ -372,7 +375,7 @@ func getOpenApiOrgVdcIsolatedNetworkType(d *schema.ResourceData, vcdClient *VCDC
 
 		NetworkType:             types.OrgVdcNetworkTypeIsolated,
 		Shared:                  addrOf(d.Get("is_shared").(bool)),
-		GuestVlanTaggingAllowed: &guestVLANAllowed,
+		GuestVlanTaggingAllowed: addrOf(d.Get("guest_vlan_allowed").(bool)),
 		Subnets: types.OrgVdcNetworkSubnets{
 			Values: []types.OrgVdcNetworkSubnetValues{
 				{

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -120,7 +120,7 @@ func resourceVcdNetworkIsolatedV2() *schema.Resource {
 			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "True if Network allows guest VLAN tagging",
+				Description: "True if network allows guest VLAN tagging",
 			},
 			"metadata": {
 				Type:          schema.TypeMap,

--- a/vcd/resource_vcd_network_isolated_v2.go
+++ b/vcd/resource_vcd_network_isolated_v2.go
@@ -117,6 +117,11 @@ func resourceVcdNetworkIsolatedV2() *schema.Resource {
 				Optional:    true,
 				Description: "DNS suffix",
 			},
+			"guest_vlan_allowed": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "True if Network allows guest VLAN tagging",
+			},
 			"metadata": {
 				Type:          schema.TypeMap,
 				Optional:      true,
@@ -329,6 +334,7 @@ func setOpenApiOrgVdcIsolatedNetworkData(d *schema.ResourceData, orgVdcNetwork *
 	dSet(d, "dns2", orgVdcNetwork.Subnets.Values[0].DNSServer2)
 	dSet(d, "dns_suffix", orgVdcNetwork.Subnets.Values[0].DNSSuffix)
 	dSet(d, "is_shared", orgVdcNetwork.Shared)
+	dSet(d, "guest_vlan_allowed", orgVdcNetwork.GuestVlanTaggingAllowed)
 
 	// If any IP ranges are available
 	if len(orgVdcNetwork.Subnets.Values[0].IPRanges.Values) > 0 {
@@ -352,6 +358,7 @@ func getOpenApiOrgVdcIsolatedNetworkType(d *schema.ResourceData, vcdClient *VCDC
 	inheritedVdcField := vcdClient.Vdc
 	vdcField := d.Get("vdc").(string)
 	ownerIdField := d.Get("owner_id").(string)
+	guestVLANAllowed := d.Get("guest_vlan_allowed").(bool)
 
 	ownerId, err := getOwnerId(d, vcdClient, ownerIdField, vdcField, inheritedVdcField)
 	if err != nil {
@@ -363,9 +370,9 @@ func getOpenApiOrgVdcIsolatedNetworkType(d *schema.ResourceData, vcdClient *VCDC
 		Description: d.Get("description").(string),
 		OwnerRef:    &types.OpenApiReference{ID: ownerId},
 
-		NetworkType: types.OrgVdcNetworkTypeIsolated,
-		Shared:      addrOf(d.Get("is_shared").(bool)),
-
+		NetworkType:             types.OrgVdcNetworkTypeIsolated,
+		Shared:                  addrOf(d.Get("is_shared").(bool)),
+		GuestVlanTaggingAllowed: &guestVLANAllowed,
 		Subnets: types.OrgVdcNetworkSubnets{
 			Values: []types.OrgVdcNetworkSubnetValues{
 				{

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -63,6 +63,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "false"),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
@@ -84,6 +85,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.30",
 						"end_address":   "1.1.1.40",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "true"),
 					resource.TestCheckNoResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 				),
@@ -105,6 +107,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "gateway", "1.1.1.1"),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "prefix_length", "24"),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "static_ip_pool.#", "0"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "false"),
 				),
 			},
 		},
@@ -122,12 +125,13 @@ resource "vcd_network_isolated_v2" "net1" {
 
   gateway       = "1.1.1.1"
   prefix_length = 24
-
+  guest_vlan_allowed = false
+  
   static_ip_pool {
-	start_address = "1.1.1.10"
-	end_address   = "1.1.1.20"
+    start_address = "1.1.1.10"
+    end_address   = "1.1.1.20"
   }
-
+	
   metadata = {
     {{.MetadataKey}} = "{{.MetadataValue}}"
   }
@@ -138,20 +142,21 @@ const testAccVcdNetworkIsolatedV2NsxtStep2 = `
 resource "vcd_network_isolated_v2" "net1" {
   org  = "{{.Org}}"
   vdc  = "{{.NsxtVdc}}"
-  
+
   name        = "{{.NetworkName}}"
   description = "updated NSX-T isolated network test"
 
   gateway       = "1.1.1.1"
   prefix_length = 24
-
+  guest_vlan_allowed = true
+  
   static_ip_pool {
-	start_address = "1.1.1.10"
-	end_address   = "1.1.1.20"
+    start_address = "1.1.1.10"
+    end_address   = "1.1.1.20"
   }
 
   static_ip_pool {
-	start_address = "1.1.1.30"
+    start_address = "1.1.1.30"
 	end_address   = "1.1.1.40"
   }
 

--- a/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_isolated_v2_nsxt_test.go
@@ -63,7 +63,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "false"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "true"),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 				),
 			},
@@ -85,7 +85,7 @@ func TestAccVcdNetworkIsolatedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.30",
 						"end_address":   "1.1.1.40",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "true"),
+					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "guest_vlan_allowed", "false"),
 					resource.TestCheckNoResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKey"].(string)),
 					resource.TestCheckResourceAttr("vcd_network_isolated_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 				),
@@ -123,9 +123,9 @@ resource "vcd_network_isolated_v2" "net1" {
   name        = "nsxt-isolated-test-initial"
   description = "NSX-T isolated network test"
 
-  gateway       = "1.1.1.1"
-  prefix_length = 24
-  guest_vlan_allowed = false
+  gateway            = "1.1.1.1"
+  prefix_length      = 24
+  guest_vlan_allowed = true
   
   static_ip_pool {
     start_address = "1.1.1.10"
@@ -146,9 +146,9 @@ resource "vcd_network_isolated_v2" "net1" {
   name        = "{{.NetworkName}}"
   description = "updated NSX-T isolated network test"
 
-  gateway       = "1.1.1.1"
-  prefix_length = 24
-  guest_vlan_allowed = true
+  gateway            = "1.1.1.1"
+  prefix_length      = 24
+  guest_vlan_allowed = false
   
   static_ip_pool {
     start_address = "1.1.1.10"

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -349,7 +349,11 @@ func setOpenApiOrgVdcRoutedNetworkData(d *schema.ResourceData, orgVdcNetwork *ty
 	dSet(d, "description", orgVdcNetwork.Description)
 	dSet(d, "owner_id", orgVdcNetwork.OwnerRef.ID)
 	dSet(d, "vdc", orgVdcNetwork.OwnerRef.Name)
-	dSet(d, "guest_vlan_allowed", orgVdcNetwork.GuestVlanTaggingAllowed)
+	if orgVdcNetwork.GuestVlanTaggingAllowed != nil {
+		dSet(d, "guest_vlan_allowed", *orgVdcNetwork.GuestVlanTaggingAllowed)
+	} else {
+		dSet(d, "guest_vlan_allowed", false)
+	}
 
 	if orgVdcNetwork.Connection != nil {
 		dSet(d, "edge_gateway_id", orgVdcNetwork.Connection.RouterRef.ID)
@@ -397,13 +401,11 @@ func getOpenApiOrgVdcRoutedNetworkType(d *schema.ResourceData, vcdClient *VCDCli
 		return nil, fmt.Errorf("error retrieving Edge Gateway structure: %s", err)
 	}
 
-	guestVLANAllowed := d.Get("guest_vlan_allowed").(bool)
-
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
 		Name:                    d.Get("name").(string),
 		Description:             d.Get("description").(string),
 		OwnerRef:                &types.OpenApiReference{ID: anyEdgeGateway.EdgeGateway.OwnerRef.ID},
-		GuestVlanTaggingAllowed: &guestVLANAllowed,
+		GuestVlanTaggingAllowed: addrOf(d.Get("guest_vlan_allowed").(bool)),
 
 		NetworkType: types.OrgVdcNetworkTypeRouted,
 

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -124,6 +124,11 @@ func resourceVcdNetworkRoutedV2() *schema.Resource {
 				Optional:    true,
 				Description: "DNS suffix",
 			},
+			"guest_vlan_allowed": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "True if Network allows guest VLAN tagging",
+			},
 			"metadata": {
 				Type:          schema.TypeMap,
 				Optional:      true,
@@ -344,6 +349,7 @@ func setOpenApiOrgVdcRoutedNetworkData(d *schema.ResourceData, orgVdcNetwork *ty
 	dSet(d, "description", orgVdcNetwork.Description)
 	dSet(d, "owner_id", orgVdcNetwork.OwnerRef.ID)
 	dSet(d, "vdc", orgVdcNetwork.OwnerRef.Name)
+	dSet(d, "guest_vlan_allowed", orgVdcNetwork.GuestVlanTaggingAllowed)
 
 	if orgVdcNetwork.Connection != nil {
 		dSet(d, "edge_gateway_id", orgVdcNetwork.Connection.RouterRef.ID)
@@ -391,10 +397,14 @@ func getOpenApiOrgVdcRoutedNetworkType(d *schema.ResourceData, vcdClient *VCDCli
 		return nil, fmt.Errorf("error retrieving Edge Gateway structure: %s", err)
 	}
 
+	guestVLANAllowed := d.Get("guest_vlan_allowed").(bool)
+
 	orgVdcNetworkConfig := &types.OpenApiOrgVdcNetwork{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		OwnerRef:    &types.OpenApiReference{ID: anyEdgeGateway.EdgeGateway.OwnerRef.ID},
+		Name:                    d.Get("name").(string),
+		Description:             d.Get("description").(string),
+		OwnerRef:                &types.OpenApiReference{ID: anyEdgeGateway.EdgeGateway.OwnerRef.ID},
+		GuestVlanTaggingAllowed: &guestVLANAllowed,
+
 		NetworkType: types.OrgVdcNetworkTypeRouted,
 
 		// Connection is used for "routed" network

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -127,7 +127,7 @@ func resourceVcdNetworkRoutedV2() *schema.Resource {
 			"guest_vlan_allowed": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Description: "True if Network allows guest VLAN tagging",
+				Description: "True if network allows guest VLAN tagging",
 			},
 			"metadata": {
 				Type:          schema.TypeMap,

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -65,6 +65,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "false"),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
@@ -94,6 +95,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.60",
 						"end_address":   "1.1.1.70",
 					}),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "true"),
 					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string)),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 
@@ -120,6 +122,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "gateway", "1.1.1.1"),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "prefix_length", "24"),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "static_ip_pool.#", "0"),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "false"),
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
 			},
@@ -149,6 +152,8 @@ resource "vcd_network_routed_v2" "net1" {
     end_address = "1.1.1.20"
   }
 
+  guest_vlan_allowed = false
+
   metadata = {
     {{.MetadataKey}} = "{{.MetadataValue}}"
   }
@@ -170,6 +175,7 @@ resource "vcd_network_routed_v2" "net1" {
 
   gateway = "1.1.1.1"
   prefix_length = 24
+  guest_vlan_allowed = true
 
   static_ip_pool {
 	start_address = "1.1.1.10"

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -65,7 +65,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.10",
 						"end_address":   "1.1.1.20",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "false"),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "true"),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string), params["MetadataValue"].(string)),
 					resource.TestCheckResourceAttrPair("data.vcd_nsxt_edgegateway.existing", "owner_id", "vcd_network_routed_v2.net1", "owner_id"),
 				),
@@ -95,7 +95,7 @@ func TestAccVcdNetworkRoutedV2Nsxt(t *testing.T) {
 						"start_address": "1.1.1.60",
 						"end_address":   "1.1.1.70",
 					}),
-					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "true"),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "guest_vlan_allowed", "false"),
 					resource.TestCheckNoResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKey"].(string)),
 					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "metadata."+params["MetadataKeyUpdated"].(string), params["MetadataValueUpdated"].(string)),
 
@@ -144,15 +144,14 @@ resource "vcd_network_routed_v2" "net1" {
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  gateway = "1.1.1.1"
-  prefix_length = 24
+  gateway            = "1.1.1.1"
+  prefix_length      = 24
+  guest_vlan_allowed = true
 
   static_ip_pool {
 	start_address = "1.1.1.10"
     end_address = "1.1.1.20"
   }
-
-  guest_vlan_allowed = false
 
   metadata = {
     {{.MetadataKey}} = "{{.MetadataValue}}"
@@ -175,7 +174,7 @@ resource "vcd_network_routed_v2" "net1" {
 
   gateway = "1.1.1.1"
   prefix_length = 24
-  guest_vlan_allowed = true
+  guest_vlan_allowed = false
 
   static_ip_pool {
 	start_address = "1.1.1.10"

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -110,11 +110,9 @@ resource "vcd_network_isolated_v2" "nsxv-backed" {
   name        = "nsxv-isolated-network"
   description = "NSX-V isolated network"
 
-  is_shared = true
-
-  gateway       = "1.1.1.1"
-  prefix_length = 24
-
+  is_shared          = true
+  gateway            = "1.1.1.1"
+  prefix_length      = 24
   guest_vlan_allowed = true
 
   static_ip_pool {
@@ -145,7 +143,7 @@ and inherited from provider configuration)
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `guest_vlan_allowed` - (Optional) Set t0 `true` if network should allow guest VLAN tagging.
+* `guest_vlan_allowed` - (Optional) Set to `true` if network should allow guest VLAN tagging.
   Default `false`.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the network belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -145,7 +145,8 @@ and inherited from provider configuration)
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `guest_vlan_allowed` - (Optional) True if Network allows guest VLAN tagging.
+* `guest_vlan_allowed` - (Optional) Set t0 `true` if network should allow guest VLAN tagging.
+  Default `false`.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the network belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.
 * `dual_stack_enabled` - (Optional; *v3.10+*) Enables Dual-Stack mode so that one can configure one

--- a/website/docs/r/network_isolated_v2.html.markdown
+++ b/website/docs/r/network_isolated_v2.html.markdown
@@ -37,6 +37,8 @@ resource "vcd_network_isolated_v2" "nsxt-backed" {
   gateway       = "1.1.1.1"
   prefix_length = 24
 
+  guest_vlan_allowed = true
+
   static_ip_pool {
     start_address = "1.1.1.10"
     end_address   = "1.1.1.20"
@@ -113,6 +115,8 @@ resource "vcd_network_isolated_v2" "nsxv-backed" {
   gateway       = "1.1.1.1"
   prefix_length = 24
 
+  guest_vlan_allowed = true
+
   static_ip_pool {
     start_address = "1.1.1.10"
     end_address   = "1.1.1.20"
@@ -141,6 +145,7 @@ and inherited from provider configuration)
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `guest_vlan_allowed` - (Optional) True if Network allows guest VLAN tagging.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the network belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.
 * `dual_stack_enabled` - (Optional; *v3.10+*) Enables Dual-Stack mode so that one can configure one

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -166,7 +166,8 @@ The following arguments are supported:
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `guest_vlan_allowed` - (Optional) True if Network allows guest VLAN tagging.
+* `guest_vlan_allowed` - (Optional) Set t0 `true` if network should allow guest VLAN tagging.
+  Default `false`.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the owner edge gateway belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.
 * `dual_stack_enabled` - (Optional; *v3.10+*) Enables Dual-Stack mode so that one can configure one

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -30,9 +30,8 @@ resource "vcd_network_routed_v2" "nsxt-backed" {
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  gateway       = "1.1.1.1"
-  prefix_length = 24
-
+  gateway            = "1.1.1.1"
+  prefix_length      = 24
   guest_vlan_allowed = true
 
   static_ip_pool {
@@ -55,10 +54,9 @@ resource "vcd_network_routed_v2" "parent-network" {
 
   edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
 
-  gateway       = "7.1.1.1"
-  prefix_length = 24
-
-  guest_vlan_allowed = true
+  gateway            = "7.1.1.1"
+  prefix_length      = 24
+  guest_vlan_allowed = false
 
   static_ip_pool {
     start_address = "7.1.1.10"
@@ -166,7 +164,7 @@ The following arguments are supported:
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
-* `guest_vlan_allowed` - (Optional) Set t0 `true` if network should allow guest VLAN tagging.
+* `guest_vlan_allowed` - (Optional) Set to `true` if network should allow guest VLAN tagging.
   Default `false`.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the owner edge gateway belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -33,6 +33,8 @@ resource "vcd_network_routed_v2" "nsxt-backed" {
   gateway       = "1.1.1.1"
   prefix_length = 24
 
+  guest_vlan_allowed = true
+
   static_ip_pool {
     start_address = "1.1.1.10"
     end_address   = "1.1.1.20"
@@ -55,6 +57,8 @@ resource "vcd_network_routed_v2" "parent-network" {
 
   gateway       = "7.1.1.1"
   prefix_length = 24
+
+  guest_vlan_allowed = true
 
   static_ip_pool {
     start_address = "7.1.1.10"
@@ -162,6 +166,7 @@ The following arguments are supported:
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for
   virtual machines; see [IP Pools](#ip-pools) below for details.
+* `guest_vlan_allowed` - (Optional) True if Network allows guest VLAN tagging.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the owner edge gateway belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.
 * `dual_stack_enabled` - (Optional; *v3.10+*) Enables Dual-Stack mode so that one can configure one


### PR DESCRIPTION
This PR forks community PR #1080 to address the few issues mentioned in https://github.com/vmware/terraform-provider-vcd/pull/1080#issuecomment-1682115191 while adding `guest_vlan_allowed` property for Org VDC networks - vcd_network_routed_v2 and vcd_network_isolated_v2


Closes #1080

### Testing
Tests with tag `nsxt` passed on 10.4.1, 10.4.2 