### PR TITLE
Documentation only - fix incorrect vcd_nsxt_edgegateway_bgp_ip_prefix_list data source documentation

### DIFF
--- a/.changes/v3.11.0/1169-bug-fixes.md
+++ b/.changes/v3.11.0/1169-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fix usage example for datasource `vcd_nsxt_edgegateway_bgp_ip_prefix_list` in registry
+  documentation [GH-1169]

--- a/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
+++ b/website/docs/d/nsxt_edgegateway_bgp_ip_prefix_list.html.markdown
@@ -19,18 +19,23 @@ for route advertisement.
 ## Example Usage
 
 ```hcl
-data "vcd_nsxt_edgegateway" "existing" {
-  org = "my-org"
-  vdc = "nsxt-vdc"
-
-  name = "nsxt-gw"
+data "vcd_vdc_group" "g1" {
+  org  = "my-org"
+  name = "my-vdc-group"
 }
 
-data "vcd_nsxt_alb_settings" "test" {
-  org = "my-org"
-  vdc = "nsxt-vdc"
+data "vcd_nsxt_edgegateway" "testing" {
+  org      = "my-org"
+  owner_id = data.vcd_vdc_group.g1.id
 
-  edge_gateway_id = data.vcd_nsxt_edgegateway.existing.id
+  name = "my-edge-gateway"
+}
+
+data "vcd_nsxt_edgegateway_bgp_ip_prefix_list" "testing" {
+  org             = "my-org"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.testing.id
+
+  name = "my-bgp-prefix-list"
 }
 ```
 


### PR DESCRIPTION
This is **docs only** PR. It puts correct usage example for `vcd_nsxt_edgegateway_bgp_ip_prefix_list` data source.

Closes #1162
