### PR TITLE
Fix missing test field in TestAccVcdNsxtEdgeGatewayVdcGroupExternalUplink

### DIFF
--- a/.changes/v3.11.0/1111-improvements.md
+++ b/.changes/v3.11.0/1111-improvements.md
@@ -1,2 +1,2 @@
 * Resource and data source `vcd_nsxt_edgegateway` support attachment of NSX-T Segment backed
-  External Networks via `external_network` block [GH-1111]
+  External Networks via `external_network` block [GH-1111, GH-1172]

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -1254,7 +1254,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt-t0" {
 }
 
 resource "vcd_external_network_v2" "segment-backed" {
-  name = "{{.TestName}}"
+  name = "{{.TestName}}-2"
 
   nsxt_network {
     nsxt_manager_id   = data.vcd_nsxt_manager.main.id
@@ -1278,7 +1278,7 @@ resource "vcd_external_network_v2" "segment-backed" {
 }
 
 resource "vcd_external_network_v2" "segment-backed2" {
-  name = "{{.TestName}}-2"
+  name = "{{.TestName}}-3"
 
   nsxt_network {
     nsxt_manager_id   = data.vcd_nsxt_manager.main.id

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -1254,7 +1254,7 @@ resource "vcd_external_network_v2" "ext-net-nsxt-t0" {
 }
 
 resource "vcd_external_network_v2" "segment-backed" {
-  name = "{{.ExternalNetworkName}}"
+  name = "{{.TestName}}"
 
   nsxt_network {
     nsxt_manager_id   = data.vcd_nsxt_manager.main.id
@@ -1278,7 +1278,7 @@ resource "vcd_external_network_v2" "segment-backed" {
 }
 
 resource "vcd_external_network_v2" "segment-backed2" {
-  name = "{{.ExternalNetworkName}}-2"
+  name = "{{.TestName}}-2"
 
   nsxt_network {
     nsxt_manager_id   = data.vcd_nsxt_manager.main.id


### PR DESCRIPTION
This PR patches test config for `TestAccVcdNsxtEdgeGatewayVdcGroupExternalUplink` so that binary test fields are correctly rendered.

Previously it would cause such field names (It worked, but it is not optimal.) - `"*** MISSING FIELD [ExternalNetworkName] from func vcd.TestAccVcdNsxtEdgeGatewayVdcGroupExternalUplink-2"`

