### PR TITLE
Use go-vcloud-director v2.22.0-alpha.15 

### DIFF
--- a/.changes/v3.11.0/1164-bug-fixes.md
+++ b/.changes/v3.11.0/1164-bug-fixes.md
@@ -1,2 +1,2 @@
 * Fix a bug in `ignore_metadata_changes` provider configuration block when `conflict_action = warn`, that caused
-  an operation to fail immediately instead of continuing without an error when a conflict was found [GH-1164]
+  an operation to fail immediately instead of continuing without an error when a conflict was found [GH-1164, GH-1173]

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/kr/pretty v0.2.1
-	github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.14
+	github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.15
 )
 
 require (
@@ -65,5 +65,3 @@ require (
 	google.golang.org/grpc v1.57.1 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 )
-
-replace github.com/vmware/go-vcloud-director/v2 => github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20231128085937-c160d9077afc

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95 h1:KLq8BE0KwCL+mmXnjLWEAOYO+2l2AE4YMmqG1ZpZHBs=
 github.com/ProtonMail/go-crypto v0.0.0-20230717121422-5aa5874ade95/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
-github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20231128085937-c160d9077afc h1:IQFPlRurkJgO5+zf+C2pVfkhriiyaktTYesbiv+ODys=
-github.com/adambarreiro/go-vcloud-director/v2 v2.17.0-alpha.1.0.20231128085937-c160d9077afc/go.mod h1:3Q2O2RQcG+t3IOaCCgU1vo4CwI4MvDLBVt3FLsGB4SM=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -126,6 +124,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.15 h1:xBNNRLMWiRk/vifB56ZQfNyMz5aduqv+aVpiK/PJQqY=
+github.com/vmware/go-vcloud-director/v2 v2.22.0-alpha.15/go.mod h1:QPxGFgrUcSyzy9IlpwDE4UNT3tsOy2047tJOPEJ4nlw=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zclconf/go-cty v1.14.0 h1:/Xrd39K7DXbHzlisFP9c4pHao4yyf+/Ug9LEz+Y/yhc=


### PR DESCRIPTION
This PR comes after #1164. It had incorrect SDK version mapping. The only purpose of this PR is to use correctly tagged version of SDK.