### PR TITLE
Subscribed catalogs and VM boot options test fixes

### DIFF
--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -396,6 +396,8 @@ resource "vcd_subscribed_catalog" "{{.SubscriberCatalog}}" {
 
   sync_on_refresh = true
   {{.SyncWhat}}
+
+  depends_on = [ vcd_catalog.test-publisher, vcd_catalog_media.test-media, vcd_catalog_vapp_template.test-vt ]
 }
 `
 

--- a/vcd/resource_vcd_vapp_vm_boot_options_test.go
+++ b/vcd/resource_vcd_vapp_vm_boot_options_test.go
@@ -281,6 +281,7 @@ data "vcd_catalog_vapp_template" "{{.VappTemplateName}}" {
 `
 
 const testAccCheckVcdVAppVmBootOptions = testSharedBootOptions + `
+"# skip-binary-test: enter_bios_setup_on_next_boot automatically resets to 'false' after boot and causes inconsistent plan"
 resource "vcd_vapp_vm" "{{.VappVMWithTemplateName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"

--- a/vcd/resource_vcd_vapp_vm_boot_options_test.go
+++ b/vcd/resource_vcd_vapp_vm_boot_options_test.go
@@ -281,7 +281,7 @@ data "vcd_catalog_vapp_template" "{{.VappTemplateName}}" {
 `
 
 const testAccCheckVcdVAppVmBootOptions = testSharedBootOptions + `
-"# skip-binary-test: enter_bios_setup_on_next_boot automatically resets to 'false' after boot and causes inconsistent plan"
+# skip-binary-test: enter_bios_setup_on_next_boot automatically resets to 'false' after boot and causes inconsistent plan
 resource "vcd_vapp_vm" "{{.VappVMWithTemplateName}}" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"


### PR DESCRIPTION
* Binary test `vcd.TestAccVcdVAppVmBootOptions.tf` should be skipped because it is expected that field `enter_bios_setup_on_next_boot` resets to `false` after VM boot.
```
      ~ boot_options {
          ~ enter_bios_setup_on_next_boot = false -> true
            # (4 unchanged attributes hidden)
        }
```
* Improve `TestAccVcdSubscribedCatalog` dependency for subscribed catalog so that it is created after the origin catalog is established and all child items are uploaded. This caused flakiness in binary tests `vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-update.tf` and `vcd.TestAccVcdSubscribedCatalog-with-local-copy-subscriber-update.tf` generated by this test and HTTP 500 errors (because of trying to subscribe to catalog too early)