### PR TITLE
Improvements and fixes in CSE 4.1 guide/examples

### DIFF
--- a/.changes/v3.12.0/1182-notes.md
+++ b/.changes/v3.12.0/1182-notes.md
@@ -1,0 +1,1 @@
+* Improve the Container Service Extension guide section that explains how to update the Kubernetes clusters [GH-1182]

--- a/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
+++ b/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
@@ -157,7 +157,7 @@ resource "vcd_rde" "k8s_cluster_instance" {
 # Some useful outputs to monitor TKGm cluster creation process.
 locals {
   k8s_cluster_computed       = jsondecode(vcd_rde.k8s_cluster_instance.computed_entity)
-  being_deleted              = tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["markForDelete"]) || tobool(vcd_rde.k8s_cluster_instance.input_entity["spec"]["vcdKe"]["forceDelete"])
+  being_deleted              = tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["markForDelete"]) || tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["forceDelete"])
   has_status                 = lookup(local.k8s_cluster_computed, "status", null) != null
 }
 

--- a/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
+++ b/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
@@ -153,7 +153,7 @@ resource "vcd_rde" "k8s_cluster_instance" {
     auto_repair_on_errors = var.auto_repair_on_errors
   })
 
-  # Careful, updating "input_entity" will make the cluster unstable if not done correctly.
+  # Be careful, updating "input_entity" will make the cluster unstable if not done correctly.
   # CSE requires sending back the cluster status that is saved into the "computed_entity" attribute once it is created.
   # Read more: https://registry.terraform.io/providers/vmware/vcd/latest/docs/guides/container_service_extension_4_x_cluster_management#updating-a-kubernetes-cluster
   # You can remove this lifecycle constraint once the "input_entity" JSON contains the cluster status and other generated attributes that were not present

--- a/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
+++ b/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
@@ -152,6 +152,15 @@ resource "vcd_rde" "k8s_cluster_instance" {
     force_delete          = false # Make this true to forcefully delete the cluster
     auto_repair_on_errors = var.auto_repair_on_errors
   })
+
+  # Careful, updating "input_entity" will make the cluster unstable if not done correctly.
+  # CSE requires sending back the cluster status that is saved into the "computed_entity" attribute once it is created.
+  # Read more: https://registry.terraform.io/providers/vmware/vcd/latest/docs/guides/container_service_extension_4_x_cluster_management#updating-a-kubernetes-cluster
+  # You can remove this lifecycle constraint once the "input_entity" JSON contains the cluster status and other generated attributes that were not present
+  # in the initial payload.
+  lifecycle {
+    ignore_changes = [ input_entity ]
+  }
 }
 
 # Some useful outputs to monitor TKGm cluster creation process.

--- a/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
+++ b/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
@@ -153,7 +153,7 @@ resource "vcd_rde" "k8s_cluster_instance" {
     auto_repair_on_errors = var.auto_repair_on_errors
   })
 
-  # Be careful, updating "input_entity" will make the cluster unstable if not done correctly.
+  # Be careful, as updating "input_entity" will make the cluster unstable if not done correctly.
   # CSE requires sending back the cluster status that is saved into the "computed_entity" attribute once it is created.
   # Read more: https://registry.terraform.io/providers/vmware/vcd/latest/docs/guides/container_service_extension_4_x_cluster_management#updating-a-kubernetes-cluster
   # You can remove this lifecycle constraint once the "input_entity" JSON contains the cluster status and other generated attributes that were not present

--- a/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
+++ b/examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf
@@ -157,7 +157,7 @@ resource "vcd_rde" "k8s_cluster_instance" {
 # Some useful outputs to monitor TKGm cluster creation process.
 locals {
   k8s_cluster_computed       = jsondecode(vcd_rde.k8s_cluster_instance.computed_entity)
-  being_deleted              = tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["markForDelete"]) || tobool(local.k8s_cluster_computed["spec"]["vcdKe"]["forceDelete"])
+  being_deleted              = tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["markForDelete"]) || tobool(vcd_rde.k8s_cluster_instance.input_entity["spec"]["vcdKe"]["forceDelete"])
   has_status                 = lookup(local.k8s_cluster_computed, "status", null) != null
 }
 

--- a/website/docs/d/rde_type_behavior_acl.html.markdown
+++ b/website/docs/d/rde_type_behavior_acl.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides the capability of fetching the RDE Type Behavior Access Levels from VMware Cloud Director.
 ---
 
-# vcd\_rde\_type\_behavior
+# vcd\_rde\_type\_behavior\_acl
 
 Provides the capability of fetching the RDE Type Behavior Access Levels from VMware Cloud Director.
 

--- a/website/docs/guides/container_service_extension_4_x_cluster_management.html.markdown
+++ b/website/docs/guides/container_service_extension_4_x_cluster_management.html.markdown
@@ -312,7 +312,7 @@ the RDE contents (which is reflected in the `computed_entity` attribute) that we
 If this information is not sent back, **the cluster will be broken**.
 
 To apply a correct update, we need to take the most recent state of the TKGm cluster, which is reflected in the contents of
-the `computed_entity` attribute. You can leverage using this output for that matter:
+the `computed_entity` attribute. You can leverage this output for that purpose:
 
 ```hcl
 output "computed_k8s_cluster" {
@@ -327,7 +327,7 @@ terraform output -json computed_k8s_cluster > computed_cluster.json
 ```
 
 Before applying an update, please verify that the cluster is in `provisioned` state, otherwise it can't be updated. In the examples,
-there is an output that shows this information:
+there is an `output` that shows this information:
 
 ```shell
 terraform output computed_k8s_cluster_status

--- a/website/docs/guides/container_service_extension_4_x_cluster_management.html.markdown
+++ b/website/docs/guides/container_service_extension_4_x_cluster_management.html.markdown
@@ -307,13 +307,57 @@ We can perform a Terraform update to resize a TKGm cluster, for example. In orde
 [`vcd_rde`][rde] resource works. We should read [its documentation][rde_input_vs_computed] to better understand how updates work
 in this specific case.
 
-To apply a correct update, we need to take the most recent state of the TKGm cluster, which is reflected in the contents of
-the `computed_entity` attribute. Copy the value of this attribute, edit the properties that we would like to modify, and place the
-final result inside `input_entity`. Now the changes can be applied with `terraform apply`.
-
 ~> Do **NOT** use the initial `input_entity` contents to perform an update, as the CSE Server puts vital information in
 the RDE contents (which is reflected in the `computed_entity` attribute) that were not in the first JSON payload.
 If this information is not sent back, **the cluster will be broken**.
+
+To apply a correct update, we need to take the most recent state of the TKGm cluster, which is reflected in the contents of
+the `computed_entity` attribute. You can leverage using this output for that matter:
+
+```hcl
+output "computed_k8s_cluster" {
+  value = vcd_rde.k8s_cluster_instance.computed_entity # References the created cluster
+}
+```
+
+And obtain the required data with the command:
+
+```shell
+terraform output -json computed_k8s_cluster > computed_cluster.json
+```
+
+Before applying an update, please verify that the cluster is in `provisioned` state, otherwise it can't be updated. In the examples,
+there is an output that shows this information:
+
+```shell
+terraform output computed_k8s_cluster_status
+```
+
+Open the created `computed_cluster.json` file and copy the whole `"status"` object from the JSON.
+This status is vital to avoid losing information of the cluster on updates, so you need to put it back
+in the file that serves as RDE input in `input_entity`, which is `tkgmcluster.json.template` in the examples.
+
+This file should look like this once updated:
+
+```
+{
+  "apiVersion": "capvcd.vmware.com/v1.1",
+  "kind": "CAPVCDCluster",
+  "name": "${name}",
+  "metadata": {
+     ...omitted
+  },
+  "spec": {
+    "vcdKe": {
+      ...omitted
+    },
+    "capiYaml": ${capi_yaml}
+  },
+  "status": { ... } <-- The object from the 'computed_entity' attribute that we need
+}
+```
+
+After that, you can perform the update of the cluster with `terraform apply`.
 
 Upgradeable items:
 
@@ -321,7 +365,7 @@ Upgradeable items:
 * Number of worker nodes. Remember this must be higher than 0.
 * Number of control plane nodes. Remember this must be an odd number and higher than 0.
 
-### Upgrade a cluster to CSE v4.1
+## Upgrade a cluster to CSE v4.1
 
 To upgrade a cluster from CSE v4.0 to v4.1, first of all you need to change the RDE Type that the TKGm cluster `vcd_rde` uses:
 


### PR DESCRIPTION
- Fixes a typo in `examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf`, where `tobool(local.k8s_cluster_computed["spec"]["vcdKe"]["forceDelete"])` should be `tobool(jsondecode(vcd_rde.k8s_cluster_instance.input_entity)["spec"]["vcdKe"]["forceDelete"])`

- Added a "security latch" in the `vcd_rde` that represents a K8s Cluster in `examples/container-service-extension/v4.1/cluster/3.11-cluster-creation.tf`, using `ignore_changes` to avoid an accidental update that doesn't follow the Update guidelines stated in the documentation.

- Improves the Update cluster section with more detailed and explicit instructions.