### PR TITLE
Add route advertisement support to vcd_network_routed_v2

### DIFF
--- a/.changes/v3.12.0/1203-improvements.md
+++ b/.changes/v3.12.0/1203-improvements.md
@@ -1,0 +1,2 @@
+* Add route advertisement support to `vcd_network_routed_v2` via field `route_advertisement_enabled`
+  [GH-1203]

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -333,3 +333,4 @@ vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber.tf v3.10.0 "Test was no
 vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-update.tf v3.10.0 "Test was not stable, 3.11 introduce improvements in PR 1101"
 vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-sync.tf v3.10.0 "Test was not stable, 3.11 introduce improvements in PR 1101"
 vcd.TestAccVcdAnyAccessControlGroupsstep1.tf v3.11.0 "Test was not stable in 3.11, 3.12 introduced improvements in PR 1194"
+vcd.ResourceSchema-vcd_network_routed_v2.tf v3.11.0 "Add route_advertisement_enabled field"

--- a/vcd/datasource_vcd_network_routed_v2.go
+++ b/vcd/datasource_vcd_network_routed_v2.go
@@ -134,6 +134,11 @@ func datasourceVcdNetworkRoutedV2() *schema.Resource {
 				Deprecated:  "Use metadata_entry instead",
 			},
 			"metadata_entry": metadataEntryDatasourceSchema("Network"),
+			"route_advertisement_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether this network is advertised so that it can be routed out to the external networks.",
+			},
 		},
 	}
 }

--- a/vcd/resource_vcd_network_routed_v2.go
+++ b/vcd/resource_vcd_network_routed_v2.go
@@ -137,6 +137,12 @@ func resourceVcdNetworkRoutedV2() *schema.Resource {
 				ConflictsWith: []string{"metadata_entry"},
 			},
 			"metadata_entry": metadataEntryResourceSchemaDeprecated("Network"),
+			"route_advertisement_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether this network is advertised so that it can be routed out to the external networks.",
+			},
 		},
 	}
 }
@@ -357,6 +363,12 @@ func setOpenApiOrgVdcRoutedNetworkData(d *schema.ResourceData, orgVdcNetwork *ty
 		dSet(d, "guest_vlan_allowed", false)
 	}
 
+	if orgVdcNetwork.RouteAdvertised != nil {
+		dSet(d, "route_advertisement_enabled", *orgVdcNetwork.RouteAdvertised)
+	} else {
+		dSet(d, "route_advertisement_enabled", false)
+	}
+
 	if orgVdcNetwork.Connection != nil {
 		dSet(d, "edge_gateway_id", orgVdcNetwork.Connection.RouterRef.ID)
 		dSet(d, "interface_type", orgVdcNetwork.Connection.ConnectionType)
@@ -408,6 +420,7 @@ func getOpenApiOrgVdcRoutedNetworkType(d *schema.ResourceData, vcdClient *VCDCli
 		Description:             d.Get("description").(string),
 		OwnerRef:                &types.OpenApiReference{ID: anyEdgeGateway.EdgeGateway.OwnerRef.ID},
 		GuestVlanTaggingAllowed: addrOf(d.Get("guest_vlan_allowed").(bool)),
+		RouteAdvertised:         addrOf(d.Get("route_advertisement_enabled").(bool)),
 
 		NetworkType: types.OrgVdcNetworkTypeRouted,
 

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -215,6 +215,153 @@ resource "vcd_network_routed_v2" "net1" {
 }
 `
 
+func TestAccVcdNetworkRoutedV2NsxtRouteAdvertisement(t *testing.T) {
+	preTestChecks(t)
+
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.1") {
+		t.Skipf("This test tests VCD 10.4.1+ (API V37.1+) features. Skipping.")
+	}
+
+	// String map to fill the template
+	var params = StringMap{
+		"TestName":            t.Name(),
+		"NsxtManager":         testConfig.Nsxt.Manager,
+		"NsxtTier0Router":     testConfig.Nsxt.Tier0router,
+		"ExternalNetworkName": t.Name(),
+		"Org":                 testConfig.VCD.Org,
+		"VDC":                 testConfig.Nsxt.Vdc,
+
+		"Tags": "network nsxt",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testVcdNetworkRoutedV2NsxtRouteAdvertisement, params)
+	debugPrintf("#[DEBUG] CONFIGURATION for step 1: %s", configText)
+
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckOpenApiVcdNetworkDestroy(testConfig.Nsxt.Vdc, t.Name()),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("vcd_network_routed_v2.net1", "id"),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "name", params["TestName"].(string)),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "interface_type", "INTERNAL"),
+					resource.TestCheckResourceAttr("vcd_network_routed_v2.net1", "route_advertisement_enabled", "true"),
+					resourceFieldsEqual("vcd_network_routed_v2.net1", "data.vcd_network_routed_v2.net1", []string{"%"}),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testVcdNetworkRoutedV2NsxtRouteAdvertisement = `
+data "vcd_nsxt_manager" "main" {
+  name = "{{.NsxtManager}}"
+}
+
+data "vcd_nsxt_tier0_router" "router" {
+  name            = "{{.NsxtTier0Router}}"
+  nsxt_manager_id = data.vcd_nsxt_manager.main.id
+}
+
+data "vcd_org" "org1" {
+  name = "{{.Org}}"
+}
+
+data "vcd_org_vdc" "vdc1" {
+  org  = "{{.Org}}"
+  name = "{{.VDC}}"
+}
+
+resource "vcd_ip_space" "space1" {
+  name = "{{.TestName}}"
+  type = "PUBLIC"
+
+  internal_scope = ["192.168.1.0/24", "10.10.10.0/24", "11.11.11.0/24"]
+  external_scope = "0.0.0.0/24"
+
+  route_advertisement_enabled = true
+
+  ip_prefix {
+    default_quota = -1
+
+    prefix {
+      first_ip      = "10.10.10.96"
+      prefix_length = 29
+      prefix_count  = 4
+    }
+  }
+
+  ip_range {
+    start_address = "11.11.11.100"
+    end_address   = "11.11.11.110"
+  }
+}
+
+resource "vcd_external_network_v2" "provider-gateway" {
+  name = "{{.ExternalNetworkName}}"
+
+  nsxt_network {
+    nsxt_manager_id      = data.vcd_nsxt_manager.main.id
+    nsxt_tier0_router_id = data.vcd_nsxt_tier0_router.router.id
+  }
+
+  use_ip_spaces = true
+}
+
+resource "vcd_ip_space_uplink" "u1" {
+  name                = "{{.TestName}}"
+  external_network_id = vcd_external_network_v2.provider-gateway.id
+  ip_space_id         = vcd_ip_space.space1.id
+}
+
+resource "vcd_nsxt_edgegateway" "ip-space" {
+  org                 = "{{.Org}}"
+  name                = "{{.TestName}}"
+  owner_id            = data.vcd_org_vdc.vdc1.id
+  external_network_id = vcd_external_network_v2.provider-gateway.id
+
+  depends_on = [vcd_ip_space_uplink.u1]
+}
+
+resource "vcd_ip_space_ip_allocation" "public-ip-prefix" {
+  org_id        = data.vcd_org.org1.id
+  ip_space_id   = vcd_ip_space.space1.id
+  type          = "IP_PREFIX"
+  prefix_length = 29
+
+  depends_on = [vcd_nsxt_edgegateway.ip-space]
+}
+
+resource "vcd_network_routed_v2" "net1" {
+  org                         = "{{.Org}}"
+  name                        = "{{.TestName}}"
+  edge_gateway_id             = vcd_nsxt_edgegateway.ip-space.id
+  gateway                     = cidrhost(vcd_ip_space_ip_allocation.public-ip-prefix.ip_address, 1)
+  prefix_length               = split("/", vcd_ip_space_ip_allocation.public-ip-prefix.ip_address)[1]
+  route_advertisement_enabled = true
+
+  static_ip_pool {
+    start_address = cidrhost(vcd_ip_space_ip_allocation.public-ip-prefix.ip_address, 2)
+    end_address   = cidrhost(vcd_ip_space_ip_allocation.public-ip-prefix.ip_address, 4)
+  }
+}
+
+data "vcd_network_routed_v2" "net1" {
+  org             = "{{.Org}}"
+  edge_gateway_id = vcd_nsxt_edgegateway.ip-space.id
+  name            = vcd_network_routed_v2.net1.name
+}
+`
+
 // TestAccVcdNetworkRoutedV2NsxtOwnerVdc checks that a routed network can be created without specifying
 // `vdc` field
 func TestAccVcdNetworkRoutedV2NsxtOwnerVdc(t *testing.T) {

--- a/website/docs/r/network_routed_v2.html.markdown
+++ b/website/docs/r/network_routed_v2.html.markdown
@@ -166,6 +166,10 @@ The following arguments are supported:
   virtual machines; see [IP Pools](#ip-pools) below for details.
 * `guest_vlan_allowed` - (Optional) Set to `true` if network should allow guest VLAN tagging.
   Default `false`.
+* `route_advertisement_enabled` - (Optional; *v3.12+*, *VCD 10.4.1+*) Enables route advertising for
+  this network. **Note** This requires Edge Gateway to use IP Spaces and IP Space *must have* [route
+  advertisement](https://registry.terraform.io/providers/vmware/vcd/latest/docs/resources/ip_space#route_advertisement_enabled)
+  enabled.
 * `metadata` - (Deprecated; *v3.6+*) Use `metadata_entry` instead. Key value map of metadata to assign to this network. **Not supported** if the owner edge gateway belongs to a VDC Group.
 * `metadata_entry` - (Optional; *v3.8+*) A set of metadata entries to assign. See [Metadata](#metadata) section for details.
 * `dual_stack_enabled` - (Optional; *v3.10+*) Enables Dual-Stack mode so that one can configure one


### PR DESCRIPTION
This PR adds route advertisement support to `vcd_network_routed_v2` via field `route_advertisement_enabled` which is requested in #1105.

Documentation is updated with details, but this feature can be enabled when IP Spaces are being used in the configuration of parent provider gateway [vcd_external_network_v2] (uses IP Space uplink).

Closes #1105


Tests passed with tags `network` and `nsxt` on 10.5.1. Also all network tests starting with `TestAccVcdNetworkRoutedV2` worked on 10.4.0.