### PR TITLE
VM Copy support

### DIFF
--- a/.changes/v3.12.0/1120-improvements.md
+++ b/.changes/v3.12.0/1120-improvements.md
@@ -1,0 +1,2 @@
+* `vcd_vapp_vm` and `vcd_vm` add support for VM Copy operation by using `copy_from_vm_id` field
+  [GH-1210]

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -333,5 +333,5 @@ vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber.tf v3.10.0 "Test was no
 vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-update.tf v3.10.0 "Test was not stable, 3.11 introduce improvements in PR 1101"
 vcd.TestAccVcdSubscribedCatalog-no-local-copy-subscriber-sync.tf v3.10.0 "Test was not stable, 3.11 introduce improvements in PR 1101"
 vcd.TestAccVcdAnyAccessControlGroupsstep1.tf v3.11.0 "Test was not stable in 3.11, 3.12 introduced improvements in PR 1194"
-vcd.ResourceSchema-vcd_vapp_vm.tf v3.11.0 "New field 'consolidate_disks_on_create'"
-vcd.ResourceSchema-vcd_vm.tf v3.11.0 "New field 'consolidate_disks_on_create'"
+vcd.ResourceSchema-vcd_vapp_vm.tf v3.11.0 "New field 'consolidate_disks_on_create', 'copy_from_vm_id'"
+vcd.ResourceSchema-vcd_vm.tf v3.11.0 "New field 'consolidate_disks_on_create', 'copy_from_vm_id'"

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -757,7 +757,7 @@ func genericResourceVmCreate(d *schema.ResourceData, meta interface{}, vmType ty
 	isVmFromTemplateDeprecated := d.Get("catalog_name").(string) != "" && d.Get("template_name").(string) != ""
 
 	isVmFromTemplate := d.Get("vapp_template_id").(string) != ""
-	isVmCopy := d.Get("copy_from_vm_id").(string) != "" // "Copy VM functionality"
+	isVmCopy := d.Get("copy_from_vm_id").(string) != "" // Copy VM functionality
 	isEmptyVm := !isVmFromTemplate && !isVmFromTemplateDeprecated && !isVmCopy
 
 	////////////////////////////////////////////////////////////////////////////////////////////////
@@ -995,7 +995,7 @@ func genericResourceVmCreate(d *schema.ResourceData, meta interface{}, vmType ty
 //
 // Code flow has 3 layers:
 // 1. Lookup common information, required for both types of VMs (Standalone and vApp child). Things such as
-//   - VM Source Image - Catalog Template or VM (VM Copy operation) to be used
+//   - VM Source Image - Catalog Template or VM (for VM Copy operation) to be used
 //   - Network adapter configuration
 //   - Storage profile configuration
 //   - VM compute policy configuration

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -25,7 +25,7 @@ const (
 	vappVmType       typeOfVm = "vcd_vapp_vm"
 )
 
-// vmImageSource defines if the VM source image is a catalog template or a
+// vmImageSource defines if the VM source image is a catalog template or an existing VM
 type vmImageSource string
 
 const (
@@ -756,6 +756,7 @@ func genericResourceVmCreate(d *schema.ResourceData, meta interface{}, vmType ty
 
 	// Deprecated: If at least Catalog Name and Template name are set - a VM from vApp template is being created
 	isVmFromTemplateDeprecated := d.Get("catalog_name").(string) != "" && d.Get("template_name").(string) != ""
+
 	isVmFromTemplate := d.Get("vapp_template_id").(string) != ""
 	isVmCopy := d.Get("copy_from_vm_id").(string) != "" // "Copy VM functionality"
 	isEmptyVm := !isVmFromTemplate && !isVmFromTemplateDeprecated && !isVmCopy

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -677,7 +677,7 @@ resource "vcd_vm" "template-vm-copy" {
   org  = "{{.Org}}"
   vdc  = "{{.Vdc}}"
 
-  vapp_template_id = data.vcd_catalog_vapp_template.{{.CatalogItem}}.id
+  copy_from_vm_id = vcd_vm.template-vm.id
   
   name        = "{{.TestName}}-template-standalone-vm-copy"
   description = "{{.TestName}}-template-standalone-vm"
@@ -713,9 +713,7 @@ resource "vcd_vm" "empty-vm-copy" {
   cpus   = 1
   memory = 1024
 
-  os_type          = "sles10_64Guest"
-  hardware_version = "vmx-14"
-  boot_image_id    = data.vcd_catalog_media.{{.Media}}.id
+  copy_from_vm_id = vcd_vm.empty-vm.id
 
   network {
 	type               = "org"

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Terraform codebase for VM management is very complicated and is backed by 4 types of VM:
+// Terraform codebase for VM management is very complicated and is backed by 6 types of VM:
 //  * `types.InstantiateVmTemplateParams` (Standalone VM from template)
 //  * `types.ReComposeVAppParams` (vApp VM from template)
 //  * `types.RecomposeVAppParamsForEmptyVm` (Empty vApp VM)
@@ -184,6 +184,116 @@ func TestAccVcdVAppVm_4types(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "status", "8"), // 8 - means POWERED OFF
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "status_text", "POWERED_OFF"),
 					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm", "POWERED_OFF"),
+
+					// VM Copy checks
+
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "status", "1"), // 1 - means RESOLVED
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "status_text", "RESOLVED"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-template-destination", []string{"POWERED_OFF"}),
+
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "status", "1"), // 1 - means RESOLVED
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "status_text", "RESOLVED"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", []string{"POWERED_OFF"}),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "name", t.Name()+"-template-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "description", t.Name()+"-template-vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "prevent_update_power_off", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.#", "2"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.0.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.0.adapter_type", "VMXNET3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.0.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.1.type", "vapp"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.1.adapter_type", "E1000"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.1.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.1.mac", "00:00:00:AA:AC:CC"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-template-destination", t.Name()+"-template-vapp-vm-copy", "POWERED_OFF"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "name", t.Name()+"-empty-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "description", t.Name()+"-empty-vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "computer_name", "vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "os_type", "sles10_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "hardware_version", "vmx-14"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "prevent_update_power_off", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.#", "2"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.0.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.0.adapter_type", "VMXNET3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.0.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.1.type", "vapp"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.1.adapter_type", "E1000"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.1.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.1.mac", "00:00:00:AA:BB:FC"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", t.Name()+"-empty-vapp-vm-copy", "POWERED_OFF"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "name", t.Name()+"-template-standalone-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "description", t.Name()+"-template-standalone-vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "prevent_update_power_off", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.#", "2"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.0.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.0.adapter_type", "VMXNET3"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.0.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.1.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.1.adapter_type", "E1000E"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.1.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.1.mac", "00:00:00:11:FF:33"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-template-standalone-vm-copy", "POWERED_OFF"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "name", t.Name()+"-empty-standalone-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "description", t.Name()+"-standalone"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "os_type", "sles10_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "hardware_version", "vmx-14"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "prevent_update_power_off", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.#", "2"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.0.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.0.adapter_type", "VMXNET3"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.0.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.1.type", "org"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.1.adapter_type", "E1000E"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.1.ip_allocation_mode", "POOL"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.1.mac", "00:00:00:22:33:44"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm-copy", "POWERED_OFF"),
 				),
 			},
 		},
@@ -232,7 +342,7 @@ resource "vcd_network_routed_v2" "nsxt-backed" {
 
   static_ip_pool {
     start_address = "1.1.1.10"
-    end_address   = "1.1.1.20"
+    end_address   = "1.1.1.40"
   }
 }
 
@@ -441,12 +551,62 @@ resource "vcd_vapp" "vm-copy-destination-template-vm" {
   power_on    = false
 }
 
+resource "vcd_vapp_network" "template-copy" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.TestName}}-template-vm-copy"
+
+  vapp_name          = vcd_vapp.vm-copy-destination-template-vm.name
+  gateway            = "192.168.3.1"
+  netmask            = "255.255.255.0"
+
+  static_ip_pool {
+	start_address = "192.168.3.51"
+	end_address   = "192.168.3.100"
+  }
+
+  depends_on = [vcd_vapp.template-vm]
+}
+
+resource "vcd_vapp_org_network" "template-vapp-copy" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  vapp_name        = vcd_vapp.vm-copy-destination-template-vm.name
+  org_network_name = (vcd_network_routed_v2.nsxt-backed.id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed.name)
+}
+
 resource "vcd_vapp" "vm-copy-destination-empty-vm" {
   org         = "{{.Org}}"
   vdc         = "{{.Vdc}}"
   name        = "{{.TestName}}-vm-copy-empty-destination"
   description = "vApp destination for VM Copy"
   power_on    = false
+}
+
+resource "vcd_vapp_network" "empty-vm-copy" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.TestName}}-empty-vm-copy"
+
+  vapp_name          = vcd_vapp.vm-copy-destination-empty-vm.name
+  gateway            = "192.168.2.1"
+  netmask            = "255.255.255.0"
+
+  static_ip_pool {
+	start_address = "192.168.2.51"
+	end_address   = "192.168.2.100"
+  }
+
+  depends_on = [vcd_vapp.empty-vm]
+}
+
+resource "vcd_vapp_org_network" "empty-vapp-copy" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  vapp_name        = vcd_vapp.vm-copy-destination-empty-vm.name
+  org_network_name = (vcd_network_routed_v2.nsxt-backed.id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed.name)
 }
 
 resource "vcd_vapp_vm" "template-vm-copy" {
@@ -459,24 +619,24 @@ resource "vcd_vapp_vm" "template-vm-copy" {
   description     = "{{.TestName}}-template-vapp-vm"
   power_on        = false
 
-  #network {
-#	type               = "org"
-#	name               = (vcd_vapp_org_network.template-vapp.id == "always-not-equal" ? null : vcd_vapp_org_network.template-vapp.org_network_name)
-#	adapter_type       = "VMXNET3"
-#	ip_allocation_mode = "POOL"
-  #}
-#
-  #network {
-#	type               = "vapp"
-#	name               = (vcd_vapp_network.template.id == "always-not-equal" ? null : vcd_vapp_network.template.name)
-#	adapter_type       = "E1000"
-#	ip_allocation_mode = "POOL"
-#	mac                = "00:00:00:AA:BB:CC"
-  #}
+  network {
+	type               = "org"
+	name               = vcd_vapp_org_network.template-vapp-copy.org_network_name
+	adapter_type       = "VMXNET3"
+	ip_allocation_mode = "POOL"
+  }
 
-  depends_on = [vcd_vapp_network.template]
+  network {
+	type               = "vapp"
+	name               = vcd_vapp_network.template-copy.name
+	adapter_type       = "E1000"
+	ip_allocation_mode = "POOL"
+	mac                = "00:00:00:AA:AC:CC"
+  }
 
   prevent_update_power_off = true
+
+  depends_on = [vcd_vapp_org_network.template-vapp-copy, vcd_vapp_network.template-copy]
 }
 
 resource "vcd_vapp_vm" "empty-vm-copy" {
@@ -494,24 +654,23 @@ resource "vcd_vapp_vm" "empty-vm-copy" {
 
   copy_from_vm_id = vcd_vapp_vm.empty-vm.id
 
-#  network {
-#	type               = "org"
-#	name               = (vcd_vapp_org_network.empty-vapp.id == "always-not-equal" ? null : vcd_vapp_org_network.empty-vapp.org_network_name)
-#	adapter_type       = "VMXNET3"
-#	ip_allocation_mode = "POOL"
-#  }
-#
-#  network {
-#	type               = "vapp"
-#	name               = (vcd_vapp_network.empty-vm.id == "always-not-equal" ? null : vcd_vapp_network.empty-vm.name)
-#	adapter_type       = "E1000"
-#	ip_allocation_mode = "POOL"
-#	mac                = "00:00:00:BB:AA:CC"
-#  }
+  network {
+	type               = "org"
+	name               = vcd_vapp_org_network.empty-vapp-copy.org_network_name
+	adapter_type       = "VMXNET3"
+	ip_allocation_mode = "POOL"
+  }
 
-  depends_on = [vcd_vapp_network.empty-vm]
+  network {
+	type               = "vapp"
+	name               = vcd_vapp_network.empty-vm-copy.name
+	adapter_type       = "E1000"
+	ip_allocation_mode = "POOL"
+	mac                = "00:00:00:AA:BB:FC"
+  }
 
   prevent_update_power_off = true
+  depends_on = [vcd_vapp_org_network.template-vapp-copy, vcd_vapp_network.template-copy]
 }
 
 resource "vcd_vm" "template-vm-copy" {
@@ -536,7 +695,7 @@ resource "vcd_vm" "template-vm-copy" {
 	name               = (vcd_network_routed_v2.nsxt-backed.id == "always-not-equal" ? null : vcd_network_routed_v2.nsxt-backed.name)
 	adapter_type       = "E1000E"
 	ip_allocation_mode = "POOL"
-	mac                = "00:00:00:11:22:33"
+	mac                = "00:00:00:11:FF:33"
   }
 
   prevent_update_power_off = true
@@ -710,6 +869,102 @@ func TestAccVcdVAppVm_4types_storage_profile(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", `guest_properties.guest.another.subkey`, "another-value"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "network.#", "0"),
 					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm", "POWERED_ON"),
+
+					// VM Copy checks
+
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "status", "4"), // 4 - means POWERED_ON
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "status_text", "POWERED_ON"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-template-destination", []string{"POWERED_ON"}),
+
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "status", "4"), // 4 - means POWERED_ON
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "status_text", "POWERED_ON"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", []string{"POWERED_ON"}),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "name", t.Name()+"-template-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "description", t.Name()+"-template-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "storage_profile", params["StorageProfile"].(string)),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "computer_name", "comp-name"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "expose_hardware_virtualization", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "metadata.vm1", "VM Metadata"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "metadata.vm2", "VM Metadata2"),
+					testMatchResourceAttrWhenVersionMatches("vcd_vapp_vm.template-vm-copy", "inherited_metadata.vm.origin.id", regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`), ">= 38.1"),
+					testCheckResourceAttrSetWhenVersionMatches("vcd_vapp_vm.template-vm-copy", "inherited_metadata.vm.origin.name", ">= 38.1"),
+					testMatchResourceAttrWhenVersionMatches("vcd_vapp_vm.template-vm-copy", "inherited_metadata.vm.origin.type", regexp.MustCompile(`^com\.vmware\.vcloud\.entity\.\w+$`), ">= 38.1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", `guest_properties.guest.hostname`, "test-host"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", `guest_properties.guest.another.subkey`, "another-value"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "network.#", "0"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-template-destination", t.Name()+"-template-vapp-vm-copy", "POWERED_ON"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "name", t.Name()+"-empty-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "description", ""),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "computer_name", "comp-name"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "os_type", "rhel8_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "hardware_version", "vmx-17"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "storage_profile", params["StorageProfile"].(string)),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "computer_name", "comp-name"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "expose_hardware_virtualization", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "metadata.vm1", "VM Metadata"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "metadata.vm2", "VM Metadata2"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", `guest_properties.guest.hostname`, "test-host"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", `guest_properties.guest.another.subkey`, "another-value"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "network.#", "0"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", t.Name()+"-empty-vapp-vm-copy", "POWERED_ON"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "name", t.Name()+"-template-standalone-vm-copy"),
+					resource.TestCheckResourceAttrSet("vcd_vm.template-vm-copy", "description"), //  Inherited from vApp template
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "storage_profile", params["StorageProfile"].(string)),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "computer_name", "comp-name"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "expose_hardware_virtualization", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "metadata.vm1", "VM Metadata"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "metadata.vm2", "VM Metadata2"),
+					testMatchResourceAttrWhenVersionMatches("vcd_vm.template-vm-copy", "inherited_metadata.vm.origin.id", regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`), ">= 38.1"),
+					testCheckResourceAttrSetWhenVersionMatches("vcd_vm.template-vm-copy", "inherited_metadata.vm.origin.name", ">= 38.1"),
+					testMatchResourceAttrWhenVersionMatches("vcd_vm.template-vm-copy", "inherited_metadata.vm.origin.type", regexp.MustCompile(`^com\.vmware\.vcloud\.entity\.\w+$`), ">= 38.1"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", `guest_properties.guest.hostname`, "test-host"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", `guest_properties.guest.another.subkey`, "another-value"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "network.#", "0"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-template-standalone-vm-copy", "POWERED_ON"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "name", t.Name()+"-empty-standalone-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "description", ""),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "os_type", "rhel8_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "hardware_version", "vmx-17"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "storage_profile", params["StorageProfile"].(string)),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "computer_name", "comp-name"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_hot_add_enabled", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "expose_hardware_virtualization", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "metadata.vm1", "VM Metadata"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "metadata.vm2", "VM Metadata2"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", `guest_properties.guest.hostname`, "test-host"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", `guest_properties.guest.another.subkey`, "another-value"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "network.#", "0"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm-copy", "POWERED_ON"),
 				),
 			},
 		},
@@ -875,7 +1130,7 @@ resource "vcd_vapp" "vm-copy-destination-template-vm" {
   vdc         = "{{.Vdc}}"
   name        = "{{.TestName}}-vm-copy-template-destination"
   description = "vApp destination for VM Copy"
-  power_on    = false
+  power_on    = true
 }
 
 resource "vcd_vapp" "vm-copy-destination-empty-vm" {
@@ -883,7 +1138,7 @@ resource "vcd_vapp" "vm-copy-destination-empty-vm" {
   vdc         = "{{.Vdc}}"
   name        = "{{.TestName}}-vm-copy-empty-destination"
   description = "vApp destination for VM Copy"
-  power_on    = false
+  power_on    = true
 }
 
 resource "vcd_vapp_vm" "template-vm-copy" {
@@ -892,6 +1147,7 @@ resource "vcd_vapp_vm" "template-vm-copy" {
 
   copy_from_vm_id = vcd_vapp_vm.template-vm.id
   computer_name    = "comp-name"
+  description      = "{{.TestName}}-template-vapp-vm-copy"
   
   vapp_name   = vcd_vapp.vm-copy-destination-template-vm.name
   name        = "{{.TestName}}-template-vapp-vm-copy"
@@ -1027,8 +1283,8 @@ func TestAccVcdVAppVm_4types_sizing_min(t *testing.T) {
 		"Limit":                     "24000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
-		"MemoryGuaranteed":          "0.5",
-		"CpuGuaranteed":             "0.6",
+		"MemoryGuaranteed":          "0.1",
+		"CpuGuaranteed":             "0.1",
 		// The parameters below are for Flex allocation model
 		// Part of HCL is created dynamically and these parameters with values result in the Flex part of the template being filled:
 		"equalsChar":                   "=",
@@ -1085,6 +1341,29 @@ func TestAccVcdVAppVm_4types_sizing_min(t *testing.T) {
 					// Standalone empty VM checks
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm", "sizing_policy_id", "vcd_vm_sizing_policy.minSize", "id"),
+
+					// VM copy checks
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.minSize", "id"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.minSize", "id"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.minSize", "id"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.minSize", "id"),
 				),
 			},
 		},
@@ -1106,7 +1385,7 @@ resource "vcd_vm_sizing_policy" "size_cpu" {
     count                 = "3"
     speed_in_mhz          = "1500"
     cores_per_socket      = "1"
-    reservation_guarantee = "0.45"
+    reservation_guarantee = "{{.CpuGuaranteed}}"
   }
 }
 
@@ -1115,18 +1394,18 @@ resource "vcd_vm_sizing_policy" "size_full" {
 
   cpu {
     shares                = "886"
-    limit_in_mhz          = "2400"
+    limit_in_mhz          = "2700"
     count                 = "3"
     speed_in_mhz          = "1500"
     cores_per_socket      = "3"
-    reservation_guarantee = "0.45"
+    reservation_guarantee = "{{.CpuGuaranteed}}"
   }
 
   memory {
     shares                = "1580"
     size_in_mb            = "2048"
     limit_in_mb           = "4800"
-    reservation_guarantee = "0.5"
+    reservation_guarantee = "{{.MemoryGuaranteed}}"
   }
 }
 
@@ -1390,13 +1669,13 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 		"NetworkPool": testConfig.VCD.NsxtProviderVdc.NetworkPool,
 
 		"AllocationModel":           "Flex",
-		"Allocated":                 "24000",
+		"Allocated":                 "40000",
 		"Reserved":                  "0",
-		"Limit":                     "24000",
+		"Limit":                     "40000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
-		"MemoryGuaranteed":          "0.5",
-		"CpuGuaranteed":             "0.6",
+		"MemoryGuaranteed":          "0.3",
+		"CpuGuaranteed":             "0.2",
 		// The parameters below are for Flex allocation model
 		// Part of HCL is created dynamically and these parameters with values result in the Flex part of the template being filled:
 		"equalsChar":                   "=",
@@ -1465,6 +1744,41 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpu_cores", "3"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "memory", "2048"),
 					resource.TestCheckResourceAttrPair("vcd_vm.empty-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
+
+					// VM copy checks
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_cores", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_cores", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_cores", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_cores", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 				),
 			},
 		},
@@ -1669,13 +1983,13 @@ func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 		"NetworkPool": testConfig.VCD.NsxtProviderVdc.NetworkPool,
 
 		"AllocationModel":           "Flex",
-		"Allocated":                 "24000",
+		"Allocated":                 "30000",
 		"Reserved":                  "0",
-		"Limit":                     "24000",
+		"Limit":                     "32000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
 		"MemoryGuaranteed":          "0.5",
-		"CpuGuaranteed":             "0.6",
+		"CpuGuaranteed":             "0.2",
 		// The parameters below are for Flex allocation model
 		// Part of HCL is created dynamically and these parameters with values result in the Flex part of the template being filled:
 		"equalsChar":                   "=",
@@ -1744,6 +2058,41 @@ func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpu_cores", "1"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "memory", "1024"),
 					resource.TestCheckResourceAttrPair("vcd_vm.empty-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_cpu", "id"),
+
+					// VM copy checks
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_cores", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_cpu", "id"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_cores", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_cpu", "id"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_cores", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_cpu", "id"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "3"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_cores", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_cpu", "id"),
 				),
 			},
 		},
@@ -2068,6 +2417,94 @@ func TestAccVcdVAppVm_4typesAdvancedComputeSettings(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpu_limit", "1000"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpus", "1"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "memory", "1024"),
+
+					// VM copy checks
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "description", "vApp destination for VM Copy"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "description", "vApp destination for VM Copy"),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "name", t.Name()+"-template-vapp-vm-copy"),
+					resource.TestCheckResourceAttrSet("vcd_vapp_vm.template-vm-copy", "description"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_shares", "480"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_reservation", "8"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory_limit", "48"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_shares", "512"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_reservation", "200"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_limit", "1000"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory", "1024"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "name", t.Name()+"-empty-vapp-vm-copy"),
+					resource.TestCheckResourceAttrSet("vcd_vapp_vm.empty-vm-copy", "description"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "computer_name", "vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "os_type", "sles10_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "hardware_version", "vmx-14"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_shares", "480"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_reservation", "8"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory_limit", "48"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_shares", "512"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_reservation", "200"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_limit", "1000"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "1024"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "name", t.Name()+"-template-standalone-vm-copy"),
+					resource.TestCheckResourceAttrSet("vcd_vm.template-vm-copy", "description"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_shares", "480"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_reservation", "8"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory_limit", "48"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_shares", "512"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_reservation", "200"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_limit", "1000"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory", "1024"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "name", t.Name()+"-empty-standalone-vm-copy"),
+					resource.TestCheckResourceAttrSet("vcd_vm.empty-vm-copy", "description"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "1024"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "os_type", "sles10_64Guest"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "hardware_version", "vmx-14"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_hot_add_enabled", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "expose_hardware_virtualization", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_shares", "480"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_reservation", "8"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory_limit", "48"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_priority", "CUSTOM"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_shares", "512"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_reservation", "200"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_limit", "1000"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "1"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "1024"),
 				),
 			},
 		},
@@ -2436,6 +2873,55 @@ func TestAccVcdVAppVm_4types_PowerState(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "status", "8"), // 8 - means POWERED OFF
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "status_text", "POWERED_OFF"),
 					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm", "POWERED_OFF"),
+
+					// VM copy checks
+					// vApp checks
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "name", t.Name()+"-vm-copy-template-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-template-vm", "power_on", "true"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-template-destination", []string{"MIXED", "POWERED_OFF"}),
+
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "name", t.Name()+"-vm-copy-empty-destination"),
+					resource.TestCheckResourceAttr("vcd_vapp.vm-copy-destination-empty-vm", "power_on", "true"),
+					testAccCheckVcdVappPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", []string{"MIXED", "POWERED_OFF"}),
+
+					// Template vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "name", t.Name()+"-template-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc,
+						t.Name()+"-vm-copy-template-destination",
+						t.Name()+"-template-vapp-vm-copy",
+						"POWERED_OFF"),
+
+					// Empty vApp VM checks
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "name", t.Name()+"-empty-vapp-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "description", t.Name()+"-empty-vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "computer_name", "vapp-vm"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, t.Name()+"-vm-copy-empty-destination", t.Name()+"-empty-vapp-vm-copy", "POWERED_OFF"),
+
+					// Standalone template VM checks
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "name", t.Name()+"-template-standalone-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "description", t.Name()+"-template-standalone-vm"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-template-standalone-vm-copy", "POWERED_OFF"),
+
+					// Standalone empty VM checks
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "name", t.Name()+"-empty-standalone-vm-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "description", t.Name()+"-standalone-copy"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "status", "8"), // 8 - means POWERED OFF
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "status_text", "POWERED_OFF"),
+					testAccCheckVcdVMPowerState(testConfig.VCD.Org, testConfig.Nsxt.Vdc, "", t.Name()+"-empty-standalone-vm-copy", "POWERED_OFF"),
 				),
 			},
 			{
@@ -2625,7 +3111,7 @@ resource "vcd_vapp" "vm-copy-destination-template-vm" {
   vdc         = "{{.Vdc}}"
   name        = "{{.TestName}}-vm-copy-template-destination"
   description = "vApp destination for VM Copy"
-  power_on    = true
+  power_on    = vcd_vapp.template-vm.power_on
 }
 
 resource "vcd_vapp" "vm-copy-destination-empty-vm" {
@@ -2633,7 +3119,7 @@ resource "vcd_vapp" "vm-copy-destination-empty-vm" {
   vdc         = "{{.Vdc}}"
   name        = "{{.TestName}}-vm-copy-empty-destination"
   description = "vApp destination for VM Copy"
-  power_on    = true
+  power_on    = vcd_vapp.empty-vm.power_on
 }
 
 resource "vcd_vapp_vm" "template-vm-copy" {
@@ -2644,19 +3130,10 @@ resource "vcd_vapp_vm" "template-vm-copy" {
   vapp_name       = vcd_vapp.vm-copy-destination-template-vm.name
   name            = "{{.TestName}}-template-vapp-vm-copy"
   description     = "{{.TestName}}-template-vapp-vm"
+  power_on        = vcd_vapp_vm.template-vm.power_on
 
   cpus   = 1
   memory = 1024
-
-  memory_priority    = "CUSTOM"
-  memory_shares      = "480"
-  memory_reservation = "8"
-  memory_limit       = "48"
-
-  cpu_priority    = "CUSTOM"
-  cpu_shares      = "512"
-  cpu_reservation = "200"
-  cpu_limit       = "1000"
 }
 
 resource "vcd_vapp_vm" "empty-vm-copy" {
@@ -2668,23 +3145,10 @@ resource "vcd_vapp_vm" "empty-vm-copy" {
   name            = "{{.TestName}}-empty-vapp-vm-copy"
   description     = "{{.TestName}}-empty-vapp-vm"
   computer_name   = "vapp-vm"
+  power_on        = vcd_vapp_vm.empty-vm.power_on
 
   cpus   = 1
   memory = 1024
-
-  memory_priority    = "CUSTOM"
-  memory_shares      = "480"
-  memory_reservation = "8"
-  memory_limit       = "48"
-
-  cpu_priority    = "CUSTOM"
-  cpu_shares      = "512"
-  cpu_reservation = "200"
-  cpu_limit       = "1000"
-
-  os_type          = "sles10_64Guest"
-  hardware_version = "vmx-14"
-  boot_image_id    = data.vcd_catalog_media.{{.Media}}.id
 }
 
 resource "vcd_vm" "template-vm-copy" {
@@ -2694,19 +3158,10 @@ resource "vcd_vm" "template-vm-copy" {
   copy_from_vm_id = vcd_vm.template-vm.id
   name            = "{{.TestName}}-template-standalone-vm-copy"
   description     = "{{.TestName}}-template-standalone-vm"
+  power_on        = vcd_vm.template-vm.power_on
 
   cpus   = 1
   memory = 1024
-
-  memory_priority    = "CUSTOM"
-  memory_shares      = "480"
-  memory_reservation = "8"
-  memory_limit       = "48"
-
-  cpu_priority    = "CUSTOM"
-  cpu_shares      = "512"
-  cpu_reservation = "200"
-  cpu_limit       = "1000"
 }
 
 resource "vcd_vm" "empty-vm-copy" {
@@ -2715,25 +3170,12 @@ resource "vcd_vm" "empty-vm-copy" {
 
   copy_from_vm_id = vcd_vm.empty-vm.id
   name            = "{{.TestName}}-empty-standalone-vm-copy"
-  description     = "{{.TestName}}-standalone"
+  description     = "{{.TestName}}-standalone-copy"
   computer_name   = "standalone"
+  power_on        = vcd_vm.empty-vm.power_on
 
   cpus   = 1
   memory = 1024
-
-  memory_priority    = "CUSTOM"
-  memory_shares      = "480"
-  memory_reservation = "8"
-  memory_limit       = "48"
-
-  cpu_priority    = "CUSTOM"
-  cpu_shares      = "512"
-  cpu_reservation = "200"
-  cpu_limit       = "1000"
-
-  os_type          = "sles10_64Guest"
-  hardware_version = "vmx-14"
-  boot_image_id    = data.vcd_catalog_media.{{.Media}}.id
 }
 `
 

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -13,9 +13,9 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-// Terraform codebase for VM management is very complicated and is backed by 6 types of VM:
-//  * `types.InstantiateVmTemplateParams` (Standalone VM from template)
-//  * `types.ReComposeVAppParams` (vApp VM from template)
+// Terraform codebase for VM management is very complicated and is backed by 4 SDK types of VM:
+//  * `types.InstantiateVmTemplateParams` (Standalone VM from template or copy of another VM)
+//  * `types.ReComposeVAppParams` (vApp VM from template or copy of another VM)
 //  * `types.RecomposeVAppParamsForEmptyVm` (Empty vApp VM)
 //  * `types.CreateVmParams` (Empty Standalone VM)
 //

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -1988,8 +1988,8 @@ func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 		"Limit":                     "32000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
-		"MemoryGuaranteed":          "0.5",
-		"CpuGuaranteed":             "0.2",
+		"MemoryGuaranteed":          "0.3",
+		"CpuGuaranteed":             "0.1",
 		// The parameters below are for Flex allocation model
 		// Part of HCL is created dynamically and these parameters with values result in the Flex part of the template being filled:
 		"equalsChar":                   "=",

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -49,7 +49,7 @@ func TestAccVcdVAppVm_4types(t *testing.T) {
 		"Org":             testConfig.VCD.Org,
 		"Vdc":             testConfig.Nsxt.Vdc,
 		"Catalog":         testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":     testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":     testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":           testConfig.Media.NsxtBackedMediaName,
 		"NsxtEdgeGateway": testConfig.Nsxt.EdgeGateway,
 
@@ -752,7 +752,7 @@ func TestAccVcdVAppVm_4types_storage_profile(t *testing.T) {
 		"Org":            testConfig.VCD.Org,
 		"Vdc":            testConfig.Nsxt.Vdc,
 		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":    testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":          testConfig.Media.NsxtBackedMediaName,
 		"StorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile2,
 
@@ -792,7 +792,7 @@ func TestAccVcdVAppVm_4types_storage_profile(t *testing.T) {
 					// Template vApp VM checks
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "name", t.Name()+"-template-vapp-vm"),
-					resource.TestCheckResourceAttrSet("vcd_vapp_vm.template-vm", "description"), // Inherited from vApp template
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "description", ""),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "storage_profile", params["StorageProfile"].(string)),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "computer_name", "comp-name"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "cpu_hot_add_enabled", "true"),
@@ -832,7 +832,7 @@ func TestAccVcdVAppVm_4types_storage_profile(t *testing.T) {
 					// Standalone template VM checks
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "name", t.Name()+"-template-standalone-vm"),
-					resource.TestCheckResourceAttrSet("vcd_vm.template-vm", "description"), //  Inherited from vApp template
+					resource.TestCheckResourceAttr("vcd_vm.template-vm", "description", ""), //  Inherited from vApp template
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "storage_profile", params["StorageProfile"].(string)),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "computer_name", "comp-name"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "cpu_hot_add_enabled", "true"),
@@ -928,7 +928,7 @@ func TestAccVcdVAppVm_4types_storage_profile(t *testing.T) {
 					// Standalone template VM checks
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "name", t.Name()+"-template-standalone-vm-copy"),
-					resource.TestCheckResourceAttrSet("vcd_vm.template-vm-copy", "description"), //  Inherited from vApp template
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "description", ""), //  Inherited from vApp template
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "storage_profile", params["StorageProfile"].(string)),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "computer_name", "comp-name"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_hot_add_enabled", "true"),
@@ -1268,7 +1268,7 @@ func TestAccVcdVAppVm_4types_sizing_min(t *testing.T) {
 		"Org":            testConfig.VCD.Org,
 		"Vdc":            testConfig.Nsxt.Vdc,
 		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":    testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":          testConfig.Media.NsxtBackedMediaName,
 		"StorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile2,
 
@@ -1659,7 +1659,7 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 		"Org":            testConfig.VCD.Org,
 		"Vdc":            testConfig.Nsxt.Vdc,
 		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":    testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":          testConfig.Media.NsxtBackedMediaName,
 		"StorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile2,
 
@@ -1973,7 +1973,7 @@ func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 		"Org":            testConfig.VCD.Org,
 		"Vdc":            testConfig.Nsxt.Vdc,
 		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":    testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":          testConfig.Media.NsxtBackedMediaName,
 		"StorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile2,
 
@@ -2301,7 +2301,7 @@ func TestAccVcdVAppVm_4typesAdvancedComputeSettings(t *testing.T) {
 		"Org":         testConfig.VCD.Org,
 		"Vdc":         testConfig.Nsxt.Vdc,
 		"Catalog":     testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem": testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem": testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":       testConfig.Media.NsxtBackedMediaName,
 
 		"Tags": "vapp vm",
@@ -2338,7 +2338,7 @@ func TestAccVcdVAppVm_4typesAdvancedComputeSettings(t *testing.T) {
 					// Template vApp VM checks
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "name", t.Name()+"-template-vapp-vm"),
-					resource.TestCheckResourceAttrSet("vcd_vapp_vm.template-vm", "description"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "description", ""),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "cpu_hot_add_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "memory_hot_add_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "expose_hardware_virtualization", "false"),
@@ -2379,7 +2379,7 @@ func TestAccVcdVAppVm_4typesAdvancedComputeSettings(t *testing.T) {
 					// Standalone template VM checks
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "name", t.Name()+"-template-standalone-vm"),
-					resource.TestCheckResourceAttrSet("vcd_vm.template-vm", "description"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm", "description", ""),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "cpu_hot_add_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "memory_hot_add_enabled", "false"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "expose_hardware_virtualization", "false"),
@@ -2777,7 +2777,7 @@ func TestAccVcdVAppVm_4types_PowerState(t *testing.T) {
 		"Org":             testConfig.VCD.Org,
 		"Vdc":             testConfig.Nsxt.Vdc,
 		"Catalog":         testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":     testConfig.VCD.Catalog.NsxtCatalogItem,
+		"CatalogItem":     testConfig.VCD.Catalog.CatalogItemWithMultiVms,
 		"Media":           testConfig.Media.NsxtBackedMediaName,
 		"NsxtEdgeGateway": testConfig.Nsxt.EdgeGateway,
 

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -1674,8 +1674,8 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 		"Limit":                     "40000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
-		"MemoryGuaranteed":          "0.3",
-		"CpuGuaranteed":             "0.2",
+		"MemoryGuaranteed":          "0.2",
+		"CpuGuaranteed":             "0.1",
 		// The parameters below are for Flex allocation model
 		// Part of HCL is created dynamically and these parameters with values result in the Flex part of the template being filled:
 		"equalsChar":                   "=",

--- a/vcd/resource_vcd_vapp_vm_copy_test.go
+++ b/vcd/resource_vcd_vapp_vm_copy_test.go
@@ -12,23 +12,23 @@ func init() {
 	testingTags["vm"] = "resource_vcd_vapp_vm_copy_test.go"
 }
 
-func TestAccVcdVAppVm_BasicCopySameVdc(t *testing.T) {
+func TestAccVcdVAppVmCopyBasic(t *testing.T) {
 	preTestChecks(t)
 
 	var params = StringMap{
-		"TestName": t.Name(),
-		"Org":      testConfig.VCD.Org,
-		"Vdc":      testConfig.Nsxt.Vdc,
+		"TestName":      t.Name(),
+		"Org":           testConfig.VCD.Org,
+		"Vdc":           testConfig.Nsxt.Vdc,
+		"RoutedNetwork": testConfig.Nsxt.RoutedNetwork,
 
-		"VappName":     vappName2,
-		"VmName":       vmName,
-		"ComputerName": vmName + "-unique",
+		"VappName":     t.Name() + "-dest-vapp",
+		"ComputerName": "ComputerName",
 
 		"Tags": "vapp vm",
 	}
 	testParamsNotEmpty(t, params)
 
-	configText := templateFill(testAccCheckVcdVAppVm_basicCopy, params)
+	configText := templateFill(testAccVcdVAppVmCopyBasic, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -37,16 +37,22 @@ func TestAccVcdVAppVm_BasicCopySameVdc(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
+		CheckDestroy:      testAccCheckVcdNsxtVAppVmDestroy(params["VappName"].(string)),
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
-				Check:  resource.ComposeTestCheckFunc(
-				// testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "name", vmName),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "computer_name", vmName+"-unique"),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "power_on", "false"),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vcd_vm.source", "name", t.Name()+"-source"),
+					resource.TestCheckResourceAttr("vcd_vm.source", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.source", "network.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_vapp.destination", "power_on", "false"),
+
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "network.#", "1"),
+
+					resource.TestCheckResourceAttr("vcd_vm.copy", "power_on", "false"),
+					resource.TestCheckResourceAttr("vcd_vm.copy", "network.#", "1"),
 				),
 			},
 		},
@@ -54,15 +60,13 @@ func TestAccVcdVAppVm_BasicCopySameVdc(t *testing.T) {
 	postTestChecks(t)
 }
 
-const testAccCheckVcdVAppVm_basicCopy = `
+const testAccVcdVAppVmCopyBasic = `
 resource "vcd_vm" "source" {
   org = "{{.Org}}"
   vdc = "{{.Vdc}}"
 
-  # You cannot remove NICs from an active virtual machine on which no operating system is installed.
   power_on = false
 
-  description = "test empty VM"
   name        = "{{.TestName}}-source"
   memory      = 512
   cpus        = 2
@@ -74,7 +78,7 @@ resource "vcd_vm" "source" {
 }
 
 resource "vcd_vapp" "destination" {
-  name     = "{{.VappName}}-dest"
+  name     = "{{.VappName}}"
   org      = "{{.Org}}"
   vdc      = "{{.Vdc}}"
   power_on = false
@@ -128,22 +132,26 @@ resource "vcd_vm" "copy" {
   cpus             = 2
   cpu_cores        = 1
 
-  #network {
-  #  type               = "vapp"
-  #  name               = vcd_vapp_network.vappNet.name
-  #  ip_allocation_mode = "POOL"
-  #}
+  network {
+    type               = "org"
+    name               = "{{.RoutedNetwork}}"
+    ip_allocation_mode = "POOL"
+  }
 }
 `
 
-func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
+// TestAccVcdVAppVm_BasicCopySameVdc_ShrinkNics checks if having less networks on
+// VM copies than in the source VM does not break the code.
+func TestAccVcdVAppVmCopyShrinkNics(t *testing.T) {
 	preTestChecks(t)
 
 	var params = StringMap{
-		"TestName":  t.Name(),
-		"Org":       testConfig.VCD.Org,
-		"Vdc":       testConfig.Nsxt.Vdc,
-		"SourceVdc": testConfig.Nsxt.Vdc + "-group-member-0",
+		"TestName":        t.Name(),
+		"Org":             testConfig.VCD.Org,
+		"Vdc":             testConfig.Nsxt.Vdc,
+		"RoutedNetwork":   testConfig.Nsxt.RoutedNetwork,
+		"IsolatedNetwork": testConfig.Nsxt.IsolatedNetwork,
+		"EdgeGateway":     testConfig.Nsxt.EdgeGateway,
 
 		"VappName":     vappName2,
 		"VmName":       vmName,
@@ -153,7 +161,7 @@ func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
 	}
 	testParamsNotEmpty(t, params)
 
-	configText := templateFill(testAccCheckVcdVAppVm_basicCopy_Vdcs, params)
+	configText := templateFill(testAccVcdVAppVmCopyShrinkNics, params)
 	if vcdShortTest {
 		t.Skip(acceptanceTestsSkipped)
 		return
@@ -166,12 +174,18 @@ func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
-				Check:  resource.ComposeTestCheckFunc(
-				// testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "name", vmName),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "computer_name", vmName+"-unique"),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "power_on", "false"),
-				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vcd_vm.source", "name", t.Name()+"-source"),
+					resource.TestCheckResourceAttr("vcd_vm.source", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.source", "network.#", "2"),
+
+					resource.TestCheckResourceAttr("vcd_vapp.destination", "power_on", "true"),
+
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "network.#", "1"),
+
+					resource.TestCheckResourceAttr("vcd_vm.copy", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.copy", "network.#", "1"),
 				),
 			},
 		},
@@ -179,15 +193,235 @@ func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
 	postTestChecks(t)
 }
 
-const testAccCheckVcdVAppVm_basicCopy_Vdcs = `
+const testAccVcdVAppVmCopyShrinkNics = `
+data "vcd_org_vdc" "main" {
+  org  = "{{.Org}}"
+  name = "{{.Vdc}}"
+}
+
+data "vcd_nsxt_edgegateway" "main" {
+  org  = "{{.Org}}"
+  name = "{{.EdgeGateway}}"
+}
+
+data "vcd_network_isolated_v2" "net" {
+  org      = "{{.Org}}"
+  owner_id = data.vcd_org_vdc.main.id
+  name     = "{{.IsolatedNetwork}}"
+}
+
+data "vcd_network_routed_v2" "net" {
+  org             = "{{.Org}}"
+  edge_gateway_id = data.vcd_nsxt_edgegateway.main.id
+  name            = "{{.RoutedNetwork}}"
+}
+
 resource "vcd_vm" "source" {
   org = "{{.Org}}"
-  vdc = "{{.SourceVdc}}"
+  vdc = "{{.Vdc}}"
+
+  power_on = true
+
+  description = "test empty VM"
+  name        = "{{.TestName}}-source"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+
+  os_type          = "sles11_64Guest"
+  hardware_version = "vmx-13"
+  computer_name    = "compName"
+
+  network {
+    type               = "org"
+    name               = data.vcd_network_isolated_v2.net.name
+    ip_allocation_mode = "POOL"
+  }
+
+  network {
+    type               = "org"
+    name               = data.vcd_network_routed_v2.net.name
+    ip_allocation_mode = "POOL"
+  }
+}
+
+resource "vcd_vapp" "destination" {
+  name     = "{{.VappName}}-dest"
+  org      = "{{.Org}}"
+  vdc      = "{{.Vdc}}"
+  power_on = true
+}
+
+resource "vcd_vapp_network" "vappNet" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  name                   = "{{.TestName}}-vapp-network"
+  vapp_name              = vcd_vapp.destination.name
+  gateway                = "192.168.2.1"
+  prefix_length          = "24"
+  reboot_vapp_on_removal = true
+
+  static_ip_pool {
+    start_address = "192.168.2.51"
+    end_address   = "192.168.2.100"
+  }
+}
+
+resource "vcd_vapp_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.destination.name
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = true
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  network {
+    type               = "vapp"
+    name               = vcd_vapp_network.vappNet.name
+    ip_allocation_mode = "POOL"
+  }
+}
+
+resource "vcd_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = true
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  network {
+    type               = "org"
+    name               = data.vcd_network_isolated_v2.net.name
+    ip_allocation_mode = "POOL"
+  }
+}
+`
+
+func TestAccVcdVAppVmCopyDifferentVdc(t *testing.T) {
+	preTestChecks(t)
+
+	var params = StringMap{
+		"TestName":       t.Name(),
+		"Org":            testConfig.VCD.Org,
+		"Vdc":            testConfig.Nsxt.Vdc,
+		"DestinationVdc": t.Name() + "-vdc",
+		"ProviderVdc":    testConfig.VCD.NsxtProviderVdc.Name,
+		"NetworkPool":    testConfig.VCD.NsxtProviderVdc.NetworkPool,
+		"StorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile2,
+
+		"VappName":     vappName2,
+		"VmName":       vmName,
+		"ComputerName": vmName + "-unique",
+
+		"Tags": "vapp vm",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccVcdVAppVmCopyDifferentVdc, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vcd_vapp_vm.source", "vdc", params["Vdc"].(string)),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.source", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.source", "network.#", "0"),
+
+					resource.TestCheckResourceAttr("vcd_vapp.destination", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp.destination", "vdc", params["DestinationVdc"].(string)),
+
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "network.#", "1"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.copy", "vdc", params["DestinationVdc"].(string)),
+
+					resource.TestCheckResourceAttr("vcd_vm.copy", "power_on", "true"),
+					resource.TestCheckResourceAttr("vcd_vm.copy", "network.#", "0"),
+					resource.TestCheckResourceAttr("vcd_vm.copy", "vdc", params["DestinationVdc"].(string)),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccVcdVAppVmCopyDifferentVdc = `
+resource "vcd_vm_sizing_policy" "minSize" {
+  name = "min-size"
+}
+
+resource "vcd_org_vdc" "sizing-policy" {
+  org  = "{{.Org}}"
+  name = "{{.TestName}}-vdc"
+
+  allocation_model  = "Flex"
+  network_pool_name = "{{.NetworkPool}}"
+  provider_vdc_name = "{{.ProviderVdc}}"
+
+  compute_capacity {
+    cpu {
+      allocated = "0"
+      limit     = "24000"
+    }
+
+    memory {
+      allocated = "0"
+      limit     = "24000"
+    }
+  }
+
+  storage_profile {
+    name     = "{{.StorageProfile}}"
+    enabled  = true
+    limit    = 90240
+    default  = true
+  }
+
+  enabled                    = true
+  enable_thin_provisioning   = true
+  enable_fast_provisioning   = true
+  delete_force               = true
+  delete_recursive           = true
+  elasticity                 = true
+  include_vm_memory_overhead = false
+  network_quota              = 100
+  default_compute_policy_id   = vcd_vm_sizing_policy.minSize.id
+  vm_sizing_policy_ids        = [vcd_vm_sizing_policy.minSize.id]
+}
+
+resource "vcd_vapp" "source" {
+  org  = "{{.Org}}"
+  vdc  = "{{.Vdc}}"
+  name = "{{.TestName}}"
+}
+
+resource "vcd_vapp_vm" "source" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
 
   # You cannot remove NICs from an active virtual machine on which no operating system is installed.
   power_on = true
 
   description = "test empty VM"
+  vapp_name   = vcd_vapp.source.name
   name        = "{{.TestName}}-source"
   memory      = 512
   cpus        = 2
@@ -201,13 +435,15 @@ resource "vcd_vm" "source" {
 resource "vcd_vapp" "destination" {
   name     = "{{.VappName}}-dest"
   org      = "{{.Org}}"
-  vdc      = "{{.Vdc}}"
+  vdc      = vcd_org_vdc.sizing-policy.name
   power_on = true
+
+  depends_on = [vcd_org_vdc.sizing-policy]
 }
 
 resource "vcd_vapp_network" "vappNet" {
   org = "{{.Org}}"
-  vdc = "{{.Vdc}}"
+  vdc = vcd_org_vdc.sizing-policy.name
 
   name                   = "{{.TestName}}-vapp-network"
   vapp_name              = vcd_vapp.destination.name
@@ -223,18 +459,18 @@ resource "vcd_vapp_network" "vappNet" {
 
 data "vcd_org_vdc" "source" {
   org  = "{{.Org}}"
-  name = "{{.SourceVdc}}"
+  name = "{{.Vdc}}"
 }
 
 resource "vcd_vapp_vm" "copy" {
   org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
+  vdc           = vcd_org_vdc.sizing-policy.name
   vapp_name     = vcd_vapp.destination.name
   name          = "{{.TestName}}-dest"
   computer_name = "{{.ComputerName}}"
 
   copy_from_vdc_id = data.vcd_org_vdc.source.id
-  copy_from_vm_id  = vcd_vm.source.id
+  copy_from_vm_id  = vcd_vapp_vm.source.id
   power_on         = true
   memory           = 1024
   cpus             = 2
@@ -249,21 +485,17 @@ resource "vcd_vapp_vm" "copy" {
 
 resource "vcd_vm" "copy" {
   org           = "{{.Org}}"
-  vdc           = "{{.Vdc}}"
+  vdc           = vcd_org_vdc.sizing-policy.name
   name          = "{{.TestName}}-dest"
   computer_name = "{{.ComputerName}}"
 
   copy_from_vdc_id = data.vcd_org_vdc.source.id
-  copy_from_vm_id  = vcd_vm.source.id
+  copy_from_vm_id  = vcd_vapp_vm.source.id
   power_on         = true
   memory           = 1024
   cpus             = 2
   cpu_cores        = 1
 
-  #network {
-  #  type               = "vapp"
-  #  name               = vcd_vapp_network.vappNet.name
-  #  ip_allocation_mode = "POOL"
-  #}
+  sizing_policy_id = vcd_vm_sizing_policy.minSize.id
 }
 `

--- a/vcd/resource_vcd_vapp_vm_copy_test.go
+++ b/vcd/resource_vcd_vapp_vm_copy_test.go
@@ -1,0 +1,230 @@
+//go:build vapp || vm || ALL || functional
+
+package vcd
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func init() {
+	testingTags["vm"] = "resource_vcd_vapp_vm_copy_test.go"
+}
+
+func TestAccVcdVAppVm_BasicCopySameVdc(t *testing.T) {
+	preTestChecks(t)
+
+	var params = StringMap{
+		"TestName": t.Name(),
+		"Org":      testConfig.VCD.Org,
+		"Vdc":      testConfig.Nsxt.Vdc,
+
+		"VappName":     vappName2,
+		"VmName":       vmName,
+		"ComputerName": vmName + "-unique",
+
+		"Tags": "vapp vm",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccCheckVcdVAppVm_basicCopy, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check:  resource.ComposeTestCheckFunc(
+				// testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "name", vmName),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "computer_name", vmName+"-unique"),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "power_on", "false"),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccCheckVcdVAppVm_basicCopy = `
+resource "vcd_vm" "source" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  # You cannot remove NICs from an active virtual machine on which no operating system is installed.
+  power_on = false
+
+  description = "test empty VM"
+  name        = "{{.TestName}}-source"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+
+  os_type          = "sles11_64Guest"
+  hardware_version = "vmx-13"
+  computer_name    = "compName"
+}
+
+resource "vcd_vapp" "destination" {
+  name     = "{{.VappName}}-dest"
+  org      = "{{.Org}}"
+  vdc      = "{{.Vdc}}"
+  power_on = false
+}
+
+resource "vcd_vapp_network" "vappNet" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  name                   = "{{.TestName}}-vapp-network"
+  vapp_name              = vcd_vapp.destination.name
+  gateway                = "192.168.2.1"
+  prefix_length          = "24"
+  reboot_vapp_on_removal = true
+
+  static_ip_pool {
+    start_address = "192.168.2.51"
+    end_address   = "192.168.2.100"
+  }
+}
+
+resource "vcd_vapp_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.destination.name
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = false
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  network {
+    type               = "vapp"
+    name               = vcd_vapp_network.vappNet.name
+    ip_allocation_mode = "POOL"
+  }
+}
+`
+
+func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
+	preTestChecks(t)
+
+	var params = StringMap{
+		"TestName":  t.Name(),
+		"Org":       testConfig.VCD.Org,
+		"Vdc":       testConfig.Nsxt.Vdc,
+		"SourceVdc": testConfig.Nsxt.Vdc + "-group-member-0",
+
+		"VappName":     vappName2,
+		"VmName":       vmName,
+		"ComputerName": vmName + "-unique",
+
+		"Tags": "vapp vm",
+	}
+	testParamsNotEmpty(t, params)
+
+	configText := templateFill(testAccCheckVcdVAppVm_basicCopy_Vdcs, params)
+	if vcdShortTest {
+		t.Skip(acceptanceTestsSkipped)
+		return
+	}
+
+	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckVcdVAppVmDestroy(vappName2),
+		Steps: []resource.TestStep{
+			{
+				Config: configText,
+				Check:  resource.ComposeTestCheckFunc(
+				// testAccCheckVcdVAppVmExists(vappName2, vmName, "vcd_vapp_vm."+vmName, &vapp, &vm),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "name", vmName),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "computer_name", vmName+"-unique"),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "power_on", "false"),
+				// resource.TestCheckResourceAttr("vcd_vapp_vm."+vmName, "metadata.vm_metadata", "VM Metadata."),
+				),
+			},
+		},
+	})
+	postTestChecks(t)
+}
+
+const testAccCheckVcdVAppVm_basicCopy_Vdcs = `
+resource "vcd_vm" "source" {
+  org = "{{.Org}}"
+  vdc = "{{.SourceVdc}}"
+
+  # You cannot remove NICs from an active virtual machine on which no operating system is installed.
+  power_on = true
+
+  description = "test empty VM"
+  name        = "{{.TestName}}-source"
+  memory      = 512
+  cpus        = 2
+  cpu_cores   = 1
+
+  os_type          = "sles11_64Guest"
+  hardware_version = "vmx-13"
+  computer_name    = "compName"
+}
+
+resource "vcd_vapp" "destination" {
+  name     = "{{.VappName}}-dest"
+  org      = "{{.Org}}"
+  vdc      = "{{.Vdc}}"
+  power_on = true
+}
+
+resource "vcd_vapp_network" "vappNet" {
+  org = "{{.Org}}"
+  vdc = "{{.Vdc}}"
+
+  name                   = "{{.TestName}}-vapp-network"
+  vapp_name              = vcd_vapp.destination.name
+  gateway                = "192.168.2.1"
+  prefix_length          = "24"
+  reboot_vapp_on_removal = true
+
+  static_ip_pool {
+    start_address = "192.168.2.51"
+    end_address   = "192.168.2.100"
+  }
+}
+
+data "vcd_org_vdc" "source" {
+  org  = "{{.Org}}"
+  name = "{{.SourceVdc}}"
+}
+
+resource "vcd_vapp_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  vapp_name     = vcd_vapp.destination.name
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vdc_id = data.vcd_org_vdc.source.id
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = true
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  network {
+    type               = "vapp"
+    name               = vcd_vapp_network.vappNet.name
+    ip_allocation_mode = "POOL"
+  }
+}
+`

--- a/vcd/resource_vcd_vapp_vm_copy_test.go
+++ b/vcd/resource_vcd_vapp_vm_copy_test.go
@@ -115,6 +115,25 @@ resource "vcd_vapp_vm" "copy" {
     ip_allocation_mode = "POOL"
   }
 }
+
+resource "vcd_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = false
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  #network {
+  #  type               = "vapp"
+  #  name               = vcd_vapp_network.vappNet.name
+  #  ip_allocation_mode = "POOL"
+  #}
+}
 `
 
 func TestAccVcdVAppVm_BasicCopyDifferentVdc(t *testing.T) {
@@ -226,5 +245,25 @@ resource "vcd_vapp_vm" "copy" {
     name               = vcd_vapp_network.vappNet.name
     ip_allocation_mode = "POOL"
   }
+}
+
+resource "vcd_vm" "copy" {
+  org           = "{{.Org}}"
+  vdc           = "{{.Vdc}}"
+  name          = "{{.TestName}}-dest"
+  computer_name = "{{.ComputerName}}"
+
+  copy_from_vdc_id = data.vcd_org_vdc.source.id
+  copy_from_vm_id  = vcd_vm.source.id
+  power_on         = true
+  memory           = 1024
+  cpus             = 2
+  cpu_cores        = 1
+
+  #network {
+  #  type               = "vapp"
+  #  name               = vcd_vapp_network.vappNet.name
+  #  ip_allocation_mode = "POOL"
+  #}
 }
 `

--- a/vcd/resource_vcd_vapp_vm_copy_test.go
+++ b/vcd/resource_vcd_vapp_vm_copy_test.go
@@ -469,7 +469,6 @@ resource "vcd_vapp_vm" "copy" {
   name          = "{{.TestName}}-dest"
   computer_name = "{{.ComputerName}}"
 
-  copy_from_vdc_id = data.vcd_org_vdc.source.id
   copy_from_vm_id  = vcd_vapp_vm.source.id
   power_on         = true
   memory           = 1024
@@ -489,7 +488,6 @@ resource "vcd_vm" "copy" {
   name          = "{{.TestName}}-dest"
   computer_name = "{{.ComputerName}}"
 
-  copy_from_vdc_id = data.vcd_org_vdc.source.id
   copy_from_vm_id  = vcd_vapp_vm.source.id
   power_on         = true
   memory           = 1024

--- a/vcd/resource_vcd_vapp_vm_tools.go
+++ b/vcd/resource_vcd_vapp_vm_tools.go
@@ -25,7 +25,7 @@ import (
 
 // getVmSourceImage retrieves non-empty VM source image reference. It can be one of:
 // * Catalog VM template (regular way for creating VMs)
-// * Already running VM templates (VM Copy). The VM must be within the same Org
+// * Already running VM templates (for VM Copy). The VM must be within the same Org
 // There is no difference in how these VMs are created apart from having different source image
 func getVmSourceImage(sourceImageType vmImageSource, d *schema.ResourceData, vcdClient *VCDClient, org *govcd.Org, vdc *govcd.Vdc) (*types.Reference, error) {
 	// Source image is a catalog template

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -485,6 +485,10 @@ The following arguments are supported:
 * `computer_name` - (Optional; *v2.5+*) Computer name to assign to this virtual machine.
 * `vapp_template_id` - (Optional; *v3.8+*) The URN of the vApp Template to use. You can fetch it using a [`vcd_catalog_vapp_template`](/providers/vmware/vcd/latest/docs/data-sources/catalog_vapp_template) data source.
 * `vm_name_in_template` - (Optional; *v2.9+*) The name of the VM in vApp Template to use. For cases when vApp template has more than one VM.
+* `copy_from_vm_id` - (Optional; *v3.12+*) The ID of existing VM to make a copy of it. The source VM
+  *must be in the same Org* (but can be in different VDC). *Note:* `sizing_policy_id` must be
+  specified when creating a standalone VM (using `vcd_vm` resource) and using different
+  source/destination VDCs.
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the VM. If `memory_hot_add_enabled` is true, then memory will be increased without VM power off
 * `memory_reservation` - The amount of RAM (in MB) reservation on the underlying virtualization infrastructure
 * `memory_priority` - Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -462,7 +462,7 @@ resource "vcd_vapp_vm" "vm-copy" {
   org = "org"
   vdc = "vdc"
 
-  copy_from_vm_id = data.vcd_vapp_vm.existing.id        # source VM ID
+  copy_from_vm_id = data.vcd_vapp_vm.existing.id # source VM ID
   vapp_name       = data.vcd_vapp_vm.existing.vapp_name
   name            = "VM Copy"
   power_on        = false

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -445,27 +445,31 @@ resource "vcd_vapp_vm" "advancedVM" {
 ```
 
 ## Example Usage (VM copy)
-This example shows how to create a VM copy from existing VM
+This example shows how to create a copy of an existing VM
 
 ```hcl
-
 data "vcd_vapp_vm" "existing" {
   vapp_name = data.vcd_vapp.web.name
   name      = "web1"
+}
+
+data "vcd_vapp_org_network" "net1" {
+  vapp_name        = web1
+  org_network_name = "my-vapp-org-network"
 }
 
 resource "vcd_vapp_vm" "vm-copy" {
   org = "org"
   vdc = "vdc"
 
-  copy_from_vm_id = data.vcd_vapp_vm.existing.id # source VM ID
-  vapp_name       = vcd_vapp.vm-copy-destination-template-vm.name
+  copy_from_vm_id = data.vcd_vapp_vm.existing.id        # source VM ID
+  vapp_name       = data.vcd_vapp_vm.existing.vapp_name
   name            = "VM Copy"
   power_on        = false
 
   network {
     type               = "org"
-    name               = vcd_vapp_org_network.template-vapp-copy.org_network_name
+    name               = data.vcd_vapp_org_network.net1.org_network_name
     adapter_type       = "VMXNET3"
     ip_allocation_mode = "POOL"
   }
@@ -485,10 +489,10 @@ The following arguments are supported:
 * `computer_name` - (Optional; *v2.5+*) Computer name to assign to this virtual machine.
 * `vapp_template_id` - (Optional; *v3.8+*) The URN of the vApp Template to use. You can fetch it using a [`vcd_catalog_vapp_template`](/providers/vmware/vcd/latest/docs/data-sources/catalog_vapp_template) data source.
 * `vm_name_in_template` - (Optional; *v2.9+*) The name of the VM in vApp Template to use. For cases when vApp template has more than one VM.
-* `copy_from_vm_id` - (Optional; *v3.12+*) The ID of existing VM to make a copy of it. The source VM
-  *must be in the same Org* (but can be in different VDC). *Note:* `sizing_policy_id` must be
-  specified when creating a standalone VM (using `vcd_vm` resource) and using different
-  source/destination VDCs.
+* `copy_from_vm_id` - (Optional; *v3.12+*) The ID of *an existing VM* to make a copy of it (it
+  cannot be a vApp template). The source VM *must be in the same Org* (but can be in different VDC).
+  *Note:* `sizing_policy_id` must be specified when creating a standalone VM (using `vcd_vm`
+  resource) and using different source/destination VDCs.
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the VM. If `memory_hot_add_enabled` is true, then memory will be increased without VM power off
 * `memory_reservation` - The amount of RAM (in MB) reservation on the underlying virtualization infrastructure
 * `memory_priority` - Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -442,7 +442,36 @@ resource "vcd_vapp_vm" "advancedVM" {
   cpu_reservation = "200"
   cpu_limit       = "1000"
 }
+```
 
+## Example Usage (VM copy)
+This example shows how to create a VM copy from existing VM
+
+```hcl
+
+data "vcd_vapp_vm" "existing" {
+  vapp_name = data.vcd_vapp.web.name
+  name      = "web1"
+}
+
+resource "vcd_vapp_vm" "vm-copy" {
+  org = "org"
+  vdc = "vdc"
+
+  copy_from_vm_id = data.vcd_vapp_vm.existing.id # source VM ID
+  vapp_name       = vcd_vapp.vm-copy-destination-template-vm.name
+  name            = "VM Copy"
+  power_on        = false
+
+  network {
+    type               = "org"
+    name               = vcd_vapp_org_network.template-vapp-copy.org_network_name
+    adapter_type       = "VMXNET3"
+    ip_allocation_mode = "POOL"
+  }
+
+  prevent_update_power_off = true
+}
 ```
 
 ## Argument Reference
@@ -456,10 +485,6 @@ The following arguments are supported:
 * `computer_name` - (Optional; *v2.5+*) Computer name to assign to this virtual machine.
 * `vapp_template_id` - (Optional; *v3.8+*) The URN of the vApp Template to use. You can fetch it using a [`vcd_catalog_vapp_template`](/providers/vmware/vcd/latest/docs/data-sources/catalog_vapp_template) data source.
 * `vm_name_in_template` - (Optional; *v2.9+*) The name of the VM in vApp Template to use. For cases when vApp template has more than one VM.
-* `copy_from_vm_id` - (Optional; *v3.12+*) The ID of existing VM to make a copy of it. The source VM
-  *must be in the same Org* (but can be in different VDC). *Note:* `sizing_policy_id` must be
-  specified when creating a standalone VM (using `vcd_vm` resource) and using different
-  source/destination VDCs.
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the VM. If `memory_hot_add_enabled` is true, then memory will be increased without VM power off
 * `memory_reservation` - The amount of RAM (in MB) reservation on the underlying virtualization infrastructure
 * `memory_priority` - Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload

--- a/website/docs/r/vapp_vm.html.markdown
+++ b/website/docs/r/vapp_vm.html.markdown
@@ -456,6 +456,10 @@ The following arguments are supported:
 * `computer_name` - (Optional; *v2.5+*) Computer name to assign to this virtual machine.
 * `vapp_template_id` - (Optional; *v3.8+*) The URN of the vApp Template to use. You can fetch it using a [`vcd_catalog_vapp_template`](/providers/vmware/vcd/latest/docs/data-sources/catalog_vapp_template) data source.
 * `vm_name_in_template` - (Optional; *v2.9+*) The name of the VM in vApp Template to use. For cases when vApp template has more than one VM.
+* `copy_from_vm_id` - (Optional; *v3.12+*) The ID of existing VM to make a copy of it. The source VM
+  *must be in the same Org* (but can be in different VDC). *Note:* `sizing_policy_id` must be
+  specified when creating a standalone VM (using `vcd_vm` resource) and using different
+  source/destination VDCs.
 * `memory` - (Optional) The amount of RAM (in MB) to allocate to the VM. If `memory_hot_add_enabled` is true, then memory will be increased without VM power off
 * `memory_reservation` - The amount of RAM (in MB) reservation on the underlying virtualization infrastructure
 * `memory_priority` - Pre-determined relative priorities according to which the non-reserved portion of this resource is made available to the virtualized workload


### PR DESCRIPTION
This PR adds support for "VM Copy" operation. This allows users to create VMs from from existing VMs. This works by adding `copy_from_vm_id` in `vcd_vapp_vm` and `vcd_vm` resources.

There is one caveat due to a known VCD bug - when creating a Standalone VM copy and source VM is in different VDC, - destination VM must have a `sizing_policy_id` specified, as otherwise it will return an error (this is also highlighted in docs)



Flow diagram for `create` functions of `vcd_vapp_vm` and `vcd_vm` (updated from PR #901 version to reflect latest changes)
* Purple shows the main flow of code for `Create`
* Green blocks signify API call definition for each of VM types that are being created.
* Yellow blocks signify where additional code can be hooked up for particular scope

```mermaid
flowchart TD
    S[VM Create]
    S ==> AAAA
    AAAA{Standanlone or vApp VM?}
    AAAA --> |resource vcd_vm| AA{vApp VM or Standalone}
    AAAA --> |resource vcd_vapp_vm| A{vApp VM or Standalone}

    AA[func resourceVcdStandaloneVmCreate] --> B[func genericResourceVmCreate]
    A[func resourceVcdVAppVmCreate] -->|lock parent vApp\n defer unlock| B[func genericResourceVmCreate]

    BB{Is template, empty, or VM Copy}

    B --> BB

    BB -->|"isVmFromTemplate || isVmCopy"| D[func createVmFromImage]
    D --> D3[func lookupSourceImage]
    D3 -->|"isVmFromTemplate"| D4[func lookupSourceCatalogTemplate]
    D3 -->|"isVmCopy"| D5[func lookupSourceVm]

    D4 --> D7[Source Image Identified]
    D5 --> D7

    BB -->|isEmptyVm| E[func createVmEmpty]

    DDD([vApp VM from template])
    DDDD(Standalone VM from template)
    

    EEE(Empty vApp VM)
    EEEE(Empty Standalone VM)

    DD([Optionally perform template VM specific actions])
    EE([Optionally perform empty VM specific actions])


   DDOPTIONAL1([Optionally perform vApp VM template specific actions])
   DDOPTIONAL2([Optionally perform Standalone VM template specific actions])

   EEOPTIONAL1([Optionally perform Empty vApp VM specific actions])
   EEOPTIONAL2([Optionally perform Empty Standalone VM specific actions])


    D7 --> |Is vApp VM| DDD
    D7 --> |Is Standalone VM| DDDD

    E --> |Is vApp VM| EEE
    E --> |Is Standalone VM| EEEE

    DDD --> DDOPTIONAL1
    DDOPTIONAL1 --> DD
    DDDD --> DDOPTIONAL2
    DDOPTIONAL2 --> DD

    EEE --> EEOPTIONAL1
    EEOPTIONAL1 --> EE
    EEEE --> EEOPTIONAL2
    EEOPTIONAL2 --> EE


    F[func genericResourceVmCreate \n'Common API calls for ALL VMs' ]
    DD --> F
    EE --> F


    F ==> G
    G ==> Z
    
    G[func genericResourceVmCreate\nlast step -> power on]

    Z[VM Created]

style DDD fill:#45f248,stroke:#333,stroke-width:4px
style DDDD fill:#45f248,stroke:#333,stroke-width:4px
style EEE fill:#45f248,stroke:#333,stroke-width:4px
style EEEE fill:#45f248,stroke:#333,stroke-width:4px


style F fill:#F1EE8E,stroke:#333,stroke-width:4px
style DD fill:#F1EE8E,stroke:#333,stroke-width:4px
style EE fill:#F1EE8E,stroke:#333,stroke-width:4px
style DDOPTIONAL1 fill:#F1EE8E,stroke:#333,stroke-width:4px
style DDOPTIONAL2 fill:#F1EE8E,stroke:#333,stroke-width:4px

style EEOPTIONAL1 fill:#F1EE8E,stroke:#333,stroke-width:4px
style EEOPTIONAL2 fill:#F1EE8E,stroke:#333,stroke-width:4px
```


Closes #562 

Acceptance tests passed in 10.4.0 and 10.5.1