### PR TITLE
Fixes: Lock source vApp when VM Copy is used, retry catalog item ID read

### DIFF
--- a/.changes/v3.12.0/1120-improvements.md
+++ b/.changes/v3.12.0/1120-improvements.md
@@ -1,2 +1,2 @@
 * `vcd_vapp_vm` and `vcd_vm` add support for VM Copy operation by using `copy_from_vm_id` field
-  [GH-1210]
+  [GH-1210, GH-1219]

--- a/.changes/v3.12.0/1215-improvements.md
+++ b/.changes/v3.12.0/1215-improvements.md
@@ -2,4 +2,4 @@
 * Resource `vcd_catalog_vapp_template` supports creating templates from existing vApps and
   standalone VMs using new `capture_vapp` configuration block [GH-1215]
 * Resource `vcd_catalog_vapp_template` exposes attribute `catalog_item_id` for related Catalog Item
-  ID [GH-1215]
+  ID [GH-1215, GH-1219]

--- a/vcd/resource_vcd_catalog_vapp_template.go
+++ b/vcd/resource_vcd_catalog_vapp_template.go
@@ -357,7 +357,15 @@ func genericVcdCatalogVappTemplateRead(_ context.Context, d *schema.ResourceData
 
 	d.SetId(vAppTemplate.VAppTemplate.ID)
 
-	catalogItemId, err := vAppTemplate.GetCatalogItemId()
+	catalogItemId, err := runWithRetry("retrieving catalog item ID",
+		"error retrieving Catalog Item ID for vApp template",
+		10*time.Second,
+		func() error {
+			return vAppTemplate.Refresh()
+		},
+		func() (any, error) {
+			return vAppTemplate.GetCatalogItemId()
+		})
 	if err != nil {
 		return diag.Errorf("error retrieving Catalog Item ID for vApp template: %s", err)
 	}

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -739,6 +739,8 @@ func resourceVcdVAppVmCreate(_ context.Context, d *schema.ResourceData, meta int
 
 	// If VM is a copy of another VM (has 'copy_from_vm_id' specified), parent vApp lock of source
 	// VM must also be acquired because when a copy is being made - that vApp becomes busy
+	// For example creating multiple VMs from the same source cannot be done in parallel because VCD
+	// will return VDC_RECOMPOSE_VAPP
 	isVmCopy := d.Get("copy_from_vm_id").(string) != "" // Copy VM functionality
 	if isVmCopy {
 		identifier := d.Get("copy_from_vm_id").(string)

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -1073,33 +1073,6 @@ func createVmFromImage(d *schema.ResourceData, meta interface{}, vmType typeOfVm
 		return nil, err
 	}
 
-	// // For VM Copy lock source image parent vApp as it also becomes busy
-	// if sourceImageType == vmSourceVmCopy {
-	// 	identifier := d.Get("copy_from_vm_id").(string)
-	// 	sourceVm, err := org.QueryVmById(identifier)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("[VM create copy] error retrieving VM %s by ID: %s", identifier, err)
-	// 	}
-
-	// 	parentSourceVapp, err := sourceVm.GetParentVApp()
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-
-	// 	// Parent VDC might different than destination VDC
-	// 	parentSourceVdc, err := sourceVm.GetParentVdc()
-	// 	if err != nil {
-	// 		return nil, err
-	// 	}
-
-	// 	util.Logger.Printf("[DEBUG] [VM create] locking parent vApp for source VM  (Org Name: %s, VDC Name: %s, vApp name: %s, VM Name: %s)",
-	// 		org.Org.Name, parentSourceVdc.Vdc.Name, parentSourceVapp.VApp.Name, sourceVm.VM.Name)
-
-	// 	unlock := vcdClient.lockVappWithName(org.Org.Name, parentSourceVdc.Vdc.Name, parentSourceVapp.VApp.Name)
-	// 	defer unlock()
-
-	// }
-
 	// Look up vApp before setting up network configuration. Having a vApp set, will enable
 	// additional network availability in vApp validations in `networksToConfig` function.
 	// It is only possible for vApp VMs, as empty VMs will get their hidden vApps created after the

--- a/vcd/resource_vcd_vapp_vm.go
+++ b/vcd/resource_vcd_vapp_vm.go
@@ -767,6 +767,7 @@ func resourceVcdVAppVmCreate(_ context.Context, d *schema.ResourceData, meta int
 
 		// Only lock source vApp if its name and parent VDC are different
 		// Parent Org will always be the same because one cannot copy VM from different Org
+		// There may be a case where source and destination vApp names are the same, but VDCs differ
 		if parentSourceVapp.VApp.Name != vappName || parentSourceVdc.Vdc.Name != destinationVdc.Vdc.Name {
 			util.Logger.Printf("[DEBUG] [VM create] locking parent vApp for source VM  (Org Name: '%s', VDC Name: '%s', vApp name: '%s', VM Name: '%s')",
 				destinationOrg.Org.Name, parentSourceVdc.Vdc.Name, parentSourceVapp.VApp.Name, sourceVm.VM.Name)


### PR DESCRIPTION
This PR contains these fixes:
* Failure to retrieve catalog item ID. **The fix is a retry as the vApp template sometimes lags to present it.**
```shell
vcd_catalog_vapp_template.test_vapp_template1: Creation complete after 47s [id=urn:vcloud:vapptemplate:608d09db-48c6-4ce7-bfeb-331c59bfbfa0]
╷
│ Warning: Argument is deprecated
│
│   with data.vcd_catalog_media.test_media_by_catalog_name,
│   on config.tf line 136, in data "vcd_catalog_media" "test_media_by_catalog_name":
│  136:   catalog  = data.vcd_catalog.catalog_org1_from_org2.name
│
│ use catalog_id instead, especially if using a shared catalog
╵
╷
│ Error: error retrieving Catalog Item ID for vApp template: error finding Catalog Item link in vApp template urn:vcloud:vapptemplate:608d09db-48c6-4ce7-bfeb-331c59bfbfa0
```
* Failure of `vcd.TestAccVcdVAppVm_4types_PowerState-step2.tf ` binary test. **Solution: Source vApp must be locked when creating copies of a VM (using `copy_from_vm_id` in `vcd_vapp_vm` and `vcd_vm`)**
```shell
│ Warning: Argument is deprecated
│
│   with data.vcd_catalog_media.test_media_nsxt,
│   on config.tf line 50, in data "vcd_catalog_media" "test_media_nsxt":
│   50:   catalog = data.vcd_catalog.cat-v51-nsxt-backed.name
│
│ use catalog_id instead, especially if using a shared catalog
╵
╷
│ Error: error creating VM copy: [VM creation] error getting VM TestAccVcdVAppVm_4types_PowerState-empty-vapp-vm-copy : error instantiating a new VM:
API Error: 400: [ b85ad5e7-73a3-4c06-b649-bd86763a1968 ] The entity Ref: com.vmware.vcloud.entity.vm:3bd97119-d3fe-460c-a6c2-089c11f2c0e1 is busy comp
leting an operation VDC_RECOMPOSE_VAPP. VDC_RECOMPOSE_VAPP(com.vmware.vcloud.entity.task:71f41622-80bc-41ed-935d-8bc96d30c983)
│
│   with vcd_vapp_vm.empty-vm-copy,
│   on config.tf line 170, in resource "vcd_vapp_vm" "empty-vm-copy":
│  170: resource "vcd_vapp_vm" "empty-vm-copy" {
```