### PR TITLE
Improve media item upload stability

### DIFF
--- a/.changes/v3.13.0/1273-bug-fixes.md
+++ b/.changes/v3.13.0/1273-bug-fixes.md
@@ -1,2 +1,2 @@
 * Fix `vcd_catalog_media` resource so it doesn't wait indefinitely to the upload task to reach 100% progress,
-  by checking also its status, to decide that the upload is complete [GH-1273]
+  by checking also its status, to decide that the upload is complete or aborted [GH-1273]

--- a/.changes/v3.13.0/1273-bug-fixes.md
+++ b/.changes/v3.13.0/1273-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix `vcd_catalog_media` resource so it doesn't hang on successfully completed tasks [GH-1273]

--- a/.changes/v3.13.0/1273-bug-fixes.md
+++ b/.changes/v3.13.0/1273-bug-fixes.md
@@ -1,1 +1,2 @@
-* Fix `vcd_catalog_media` resource so it doesn't hang on successfully completed tasks [GH-1273]
+* Fix `vcd_catalog_media` resource so it doesn't wait indefinitely to the upload task to reach 100% progress,
+  by checking also its status, to decide that the upload is complete [GH-1273]

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -184,9 +184,8 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return diag.FromErr(err)
 			}
 
-			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: Upload progress %s%%\n", mediaName, task.GetUploadProgress()))
-			if task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "success" {
-				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: Upload finished successfully\n", mediaName))
+			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media."+mediaName+": Upload progress "+task.GetUploadProgress()+"%%\n"))
+			if task.GetUploadProgress() == "100.00" {
 				break
 			}
 			time.Sleep(10 * time.Second)

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -184,8 +184,9 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return diag.FromErr(err)
 			}
 
-			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media."+mediaName+": Upload progress "+task.GetUploadProgress()+"%%\n"))
-			if task.GetUploadProgress() == "100.00" {
+			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: Upload progress %s%%\n", mediaName, task.GetUploadProgress()))
+			if task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "success" {
+				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: Upload finished successfully\n", mediaName))
 				break
 			}
 			time.Sleep(10 * time.Second)
@@ -196,11 +197,12 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 		for {
 			progress, err := task.GetTaskProgress()
 			if err != nil {
-				log.Printf("vCD Error importing new catalog item: %s", err)
-				return diag.Errorf("vCD Error importing new catalog item: %s", err)
+				log.Printf("VCD Error importing new catalog item: %s", err)
+				return diag.Errorf("VCD Error importing new catalog item: %s", err)
 			}
-			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media."+mediaName+": vCD import catalog item progress "+progress+"%%\n"))
-			if progress == "100" {
+			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item progress %s%%\n", mediaName, progress))
+			if task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "success" {
+				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item finished successfully\n", mediaName))
 				break
 			}
 			time.Sleep(10 * time.Second)

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -200,7 +200,10 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return diag.Errorf("VCD Error importing new catalog item: %s", err)
 			}
 			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item progress %s%%\n", mediaName, progress))
-			if progress == "100" || (task.Task != nil && task.Task.Task != nil && (task.Task.Task.Status == "success" || task.Task.Task.Status == "aborted")) {
+			if task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "aborted" {
+				return diag.Errorf("VCD Error importing new catalog item: the task %s was aborted", task.Task.Task.ID)
+			}
+			if progress == "100" || (task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "success") {
 				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item finished with status '%s'\n", mediaName, task.Task.Task.Status))
 				break
 			}

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -200,7 +200,7 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return diag.Errorf("VCD Error importing new catalog item: %s", err)
 			}
 			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item progress %s%%\n", mediaName, progress))
-			if task.Task != nil && task.Task.Task != nil && (task.Task.Task.Status == "success" || task.Task.Task.Status == "aborted") {
+			if progress == "100" || (task.Task != nil && task.Task.Task != nil && (task.Task.Task.Status == "success" || task.Task.Task.Status == "aborted")) {
 				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item finished with status '%s'\n", mediaName, task.Task.Task.Status))
 				break
 			}

--- a/vcd/resource_vcd_catalog_media.go
+++ b/vcd/resource_vcd_catalog_media.go
@@ -200,8 +200,8 @@ func resourceVcdMediaCreate(ctx context.Context, d *schema.ResourceData, meta in
 				return diag.Errorf("VCD Error importing new catalog item: %s", err)
 			}
 			logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item progress %s%%\n", mediaName, progress))
-			if task.Task != nil && task.Task.Task != nil && task.Task.Task.Status == "success" {
-				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item finished successfully\n", mediaName))
+			if task.Task != nil && task.Task.Task != nil && (task.Task.Task.Status == "success" || task.Task.Task.Status == "aborted") {
+				logForScreen("vcd_catalog_media", fmt.Sprintf("vcd_catalog_media.%s: VCD import catalog item finished with status '%s'\n", mediaName, task.Task.Task.Status))
 				break
 			}
 			time.Sleep(10 * time.Second)


### PR DESCRIPTION
This PR modifies vcd_catalog_media code to prevent it from hanging when the upload Task completes successfully but for some reason the progress is not 100% (could happen with some glitch in VCD)

### Tests

Run `TestAccVcdCatalogMediaBasic` in a VCD version that has this problem. Without this fix, it never ends.