### PR TITLE
Fix RDE test

### DIFF
--- a/.changes/v3.13.0/1278-notes.md
+++ b/.changes/v3.13.0/1278-notes.md
@@ -1,1 +1,3 @@
-* Amend the test `TestAccVcdRdeDuplicate` so it doesn't fail on VCD 10.6+ [GH-1278]
+* Amend the test `TestAccVcdRdeDuplicate` so it doesn't fail on VCD 10.6+. Since this version, whenever a RDE is created
+  in a tenant by the System Administrator, the owner is not `"administrator"` anymore, but `"system"`.
+  If the RDE is created in System organization, the owner is still `"administrator"` [GH-1278]

--- a/.changes/v3.13.0/1278-notes.md
+++ b/.changes/v3.13.0/1278-notes.md
@@ -1,3 +1,2 @@
 * Amend the test `TestAccVcdRdeDuplicate` so it doesn't fail on VCD 10.6+. Since this version, whenever a RDE is created
-  in a tenant by the System Administrator, the owner is not `"administrator"` anymore, but `"system"`.
-  If the RDE is created in System organization, the owner is still `"administrator"` [GH-1278]
+  in a tenant by the System Administrator, the owner is not `"administrator"` anymore, but `"system"` [GH-1278]

--- a/.changes/v3.13.0/1278-notes.md
+++ b/.changes/v3.13.0/1278-notes.md
@@ -1,0 +1,1 @@
+* Amend the test `TestAccVcdRdeDuplicate` so it doesn't fail on VCD 10.6+ [GH-1278]

--- a/vcd/resource_vcd_rde_duplicate_test.go
+++ b/vcd/resource_vcd_rde_duplicate_test.go
@@ -48,7 +48,6 @@ func TestAccVcdRdeDuplicate(t *testing.T) {
 	if vcdClient.VCDClient.Client.APIVCDMaxVersionIs(">= 39.0") {
 		// Since API >= 39.0, whenever a RDE is created in a tenant by the System Administrator,
 		// the owner is not "administrator" anymore, but "system".
-		// If the RDE is created in System organization, the owner is still "administrator".
 		fieldsNotEqual = []string{"id", "org", "org_id", "owner_name", "owner_user_id"}
 	}
 

--- a/vcd/resource_vcd_rde_duplicate_test.go
+++ b/vcd/resource_vcd_rde_duplicate_test.go
@@ -46,8 +46,9 @@ func TestAccVcdRdeDuplicate(t *testing.T) {
 	fieldsNotEqual := []string{"id", "org", "org_id"}
 	vcdClient := createSystemTemporaryVCDConnection()
 	if vcdClient.VCDClient.Client.APIVCDMaxVersionIs(">= 39.0") {
-		// Since API >= 39.0, if a RDE is created as the System Administrator in a tenant, the owner is not "administrator"
-		// anymore, but "system". If the RDE is created in System org, the owner is still "administrator".
+		// Since API >= 39.0, whenever a RDE is created in a tenant by the System Administrator,
+		// the owner is not "administrator" anymore, but "system".
+		// If the RDE is created in System organization, the owner is still "administrator".
 		fieldsNotEqual = []string{"id", "org", "org_id", "owner_name", "owner_user_id"}
 	}
 

--- a/vcd/resource_vcd_rde_duplicate_test.go
+++ b/vcd/resource_vcd_rde_duplicate_test.go
@@ -43,6 +43,14 @@ func TestAccVcdRdeDuplicate(t *testing.T) {
 	rde3Tenant := "vcd_rde.rde3_tenant"
 	fetchedSystem := "data.vcd_rde.fetch_rde_system"
 
+	fieldsNotEqual := []string{"id", "org", "org_id"}
+	vcdClient := createSystemTemporaryVCDConnection()
+	if vcdClient.VCDClient.Client.APIVCDMaxVersionIs(">= 39.0") {
+		// Since API >= 39.0, if a RDE is created as the System Administrator in a tenant, the owner is not "administrator"
+		// anymore, but "system". If the RDE is created in System org, the owner is still "administrator".
+		fieldsNotEqual = []string{"id", "org", "org_id", "owner_name", "owner_user_id"}
+	}
+
 	// We will cache some RDE identifiers, so we can use them later
 	cachedIds := make([]testCachedFieldValue, 2)
 
@@ -56,7 +64,7 @@ func TestAccVcdRdeDuplicate(t *testing.T) {
 				Config: step1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resourceFieldsEqual(rde2Tenant, rde3Tenant, []string{"id"}),
-					resourceFieldsEqual(rde1System, rde3Tenant, []string{"id", "org", "org_id"}),
+					resourceFieldsEqual(rde1System, rde3Tenant, fieldsNotEqual),
 					// We cache some IDs to use it on later steps
 					cachedIds[0].cacheTestResourceFieldValue(rde2Tenant, "id"),
 					cachedIds[1].cacheTestResourceFieldValue(rde3Tenant, "id"),


### PR DESCRIPTION
This PR fixes the `TestAccVcdRdeDuplicate`, that fails in VCD 10.6.0.

The `owner` information of RDEs is changed since this version, so the changes adapt to this.