### PR TITLE
Specify 'memory_guaranteed' when 'include_vm_memory_overhead=true' in `vcd_org_vdc`

### DIFF
--- a/.changes/v3.13.0/1281-notes.md
+++ b/.changes/v3.13.0/1281-notes.md
@@ -1,0 +1,2 @@
+* Tests for FLEX Org VDC must set `memory_guaranteed` when `include_vm_memory_overhead=true`
+  [GH-1281]

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -665,8 +665,9 @@ resource "vcd_org_vdc" "newVdc" {
 	  }
   
 	  memory {
-		allocated = "1024"
-		limit     = "1024"
+		allocated             = "1024"
+		limit                 = "1024"
+		reservation_guarantee = "1.0"
 	  }
 	}
   

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -665,8 +665,8 @@ resource "vcd_org_vdc" "newVdc" {
 	  }
   
 	  memory {
-		allocated             = "1024"
-		limit                 = "1024"
+		allocated = "1024"
+		limit     = "1024"
 	  }
 	}
   
@@ -682,7 +682,7 @@ resource "vcd_org_vdc" "newVdc" {
 	enable_fast_provisioning   = true
 	delete_force               = true
 	delete_recursive           = true
-	elasticity      		   = true
+	elasticity                 = true
 	include_vm_memory_overhead = true
 	memory_guaranteed          = 1.0
 }

--- a/vcd/resource_vcd_nsxt_edgegateway_test.go
+++ b/vcd/resource_vcd_nsxt_edgegateway_test.go
@@ -667,7 +667,6 @@ resource "vcd_org_vdc" "newVdc" {
 	  memory {
 		allocated             = "1024"
 		limit                 = "1024"
-		reservation_guarantee = "1.0"
 	  }
 	}
   
@@ -685,6 +684,7 @@ resource "vcd_org_vdc" "newVdc" {
 	delete_recursive           = true
 	elasticity      		   = true
 	include_vm_memory_overhead = true
+	memory_guaranteed          = 1.0
 }
 `
 

--- a/vcd/resource_vcd_vdc_group_test.go
+++ b/vcd/resource_vcd_vdc_group_test.go
@@ -468,6 +468,7 @@ resource "vcd_org_vdc" "newVdc" {
   delete_recursive           = true
   elasticity      			 = true
   include_vm_memory_overhead = true
+  memory_guaranteed          = 1.0
 }
 `
 const testAccVcdVdcGroupOrgProvider = testAccVcdVdcGroupNewVdc + `

--- a/vcd/resource_vcd_vdc_group_test.go
+++ b/vcd/resource_vcd_vdc_group_test.go
@@ -444,8 +444,9 @@ resource "vcd_org_vdc" "newVdc" {
     }
 
     memory {
-      allocated = "{{.Allocated}}"
-      limit     = "{{.Limit}}"
+      allocated             = "{{.Allocated}}"
+      limit                 = "{{.Limit}}"
+	  reservation_guarantee = "1.0"
     }
   }
 

--- a/vcd/resource_vcd_vdc_group_test.go
+++ b/vcd/resource_vcd_vdc_group_test.go
@@ -444,9 +444,8 @@ resource "vcd_org_vdc" "newVdc" {
     }
 
     memory {
-      allocated             = "{{.Allocated}}"
-      limit                 = "{{.Limit}}"
-	  reservation_guarantee = "1.0"
+      allocated = "{{.Allocated}}"
+      limit     = "{{.Limit}}"
     }
   }
 
@@ -466,7 +465,7 @@ resource "vcd_org_vdc" "newVdc" {
   enable_fast_provisioning   = true
   delete_force               = true
   delete_recursive           = true
-  elasticity      			 = true
+  elasticity                 = true
   include_vm_memory_overhead = true
   memory_guaranteed          = 1.0
 }

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -56,6 +56,7 @@ resource "vcd_org_vdc" "newVdc" {
   delete_recursive           = true
   include_vm_memory_overhead = true
   elasticity                 = true
+  memory_guaranteed          = 1.0
 }
 
 resource "vcd_vdc_group" "test1" {

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -34,9 +34,8 @@ resource "vcd_org_vdc" "newVdc" {
     }
 
     memory {
-      allocated             = "1024"
-      limit                 = "1024"
-      reservation_guarantee = "1.0"
+      allocated = "1024"
+      limit     = "1024"
     }
   }
 

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -34,8 +34,9 @@ resource "vcd_org_vdc" "newVdc" {
     }
 
     memory {
-      allocated = "1024"
-      limit     = "1024"
+      allocated             = "1024"
+      limit                 = "1024"
+      reservation_guarantee = "1.0"
     }
   }
 

--- a/website/docs/r/org_vdc.html.markdown
+++ b/website/docs/r/org_vdc.html.markdown
@@ -234,7 +234,7 @@ The following arguments are supported:
 * `allow_over_commit` - (Optional) Set to false to disallow creation of the VDC if the `allocation_model` is AllocationPool or ReservationPool and the ComputeCapacity you specified is greater than what the backing Provider VDC can supply. Default is true.
 * `enable_vm_discovery` - (Optional) If true, discovery of vCenter VMs is enabled for resource pools backing this VDC. If false, discovery is disabled. If left unspecified, the actual behaviour depends on enablement at the organization level and at the system level.
 * `elasticity` - (Optional, *v2.7+*, *VCD 9.7+*) Indicates if the Flex VDC should be elastic. Required with the Flex allocation model.
-* `include_vm_memory_overhead` - (Optional, *v2.7+*, *VCD 9.7+*) Indicates if the Flex VDC should include memory overhead into its accounting for admission control. Required with the Flex allocation model.
+* `include_vm_memory_overhead` - (Optional, *v2.7+*, *VCD 9.7+*) Indicates if the Flex VDC should include memory overhead into its accounting for admission control. Required with the Flex allocation model. `memory_guaranteed` must also be specified together with this parameter.
 * `delete_force` - (Optional, but recommended) When destroying use `delete_force=true` to remove a VDC and any objects it contains, regardless of their state. Default is `false`
 * `delete_recursive` - (Optional, but recommended) When destroying use `delete_recursive=true` to remove the VDC and any objects it contains that are in a state that normally allows removal. Default is `false`
 * `default_compute_policy_id` - (Optional, *v3.8+*, *VCD 10.2+*) ID of the default Compute Policy for this VDC. It can be a VM Sizing Policy, a VM Placement Policy or a vGPU Policy.

--- a/website/docs/r/vm_vgpu_policy.html.markdown
+++ b/website/docs/r/vm_vgpu_policy.html.markdown
@@ -77,7 +77,6 @@ resource "vcd_org_vdc" "example_org_vdc" {
     }
     memory {
       allocated             = 2048
-      reservation_guarantee = "1.0"
     }
   }
 
@@ -89,6 +88,7 @@ resource "vcd_org_vdc" "example_org_vdc" {
 
   elasticity                 = true
   include_vm_memory_overhead = true
+  memory_guaranteed          = 1.0
   default_compute_policy_id  = vcd_vm_vgpu_policy.example_vgpu_policy.id
   vm_vgpu_policy_ids         = [vcd_vm_vgpu_policy.example_vgpu_policy.id]
 }

--- a/website/docs/r/vm_vgpu_policy.html.markdown
+++ b/website/docs/r/vm_vgpu_policy.html.markdown
@@ -76,7 +76,7 @@ resource "vcd_org_vdc" "example_org_vdc" {
       allocated = 2048
     }
     memory {
-      allocated             = 2048
+      allocated = 2048
     }
   }
 

--- a/website/docs/r/vm_vgpu_policy.html.markdown
+++ b/website/docs/r/vm_vgpu_policy.html.markdown
@@ -76,7 +76,8 @@ resource "vcd_org_vdc" "example_org_vdc" {
       allocated = 2048
     }
     memory {
-      allocated = 2048
+      allocated             = 2048
+      reservation_guarantee = "1.0"
     }
   }
 


### PR DESCRIPTION
This PR specifies Specify 'memory_guaranteed' when 'include_vm_memory_overhead=true' in `vcd_org_vdc` tests.

Similar to what we have done in:
* https://github.com/vmware/go-vcloud-director/pull/684
* https://github.com/vmware/go-vcloud-director/pull/685