### PR TITLE
Fix tests

### DIFF
--- a/.changes/v3.13.0/1283-bug-fixes.md
+++ b/.changes/v3.13.0/1283-bug-fixes.md
@@ -1,0 +1,1 @@
+* Fix resource `vcd_nsxt_alb_settings` so update operations don't fail in VCD 10.6+ [GH-1283]

--- a/.changes/v3.13.0/1283-notes.md
+++ b/.changes/v3.13.0/1283-notes.md
@@ -1,0 +1,2 @@
+* Amend `TestAccVcdCatalogSharedAccess`, it failed in VCD 10.6+ as the used VDC was missing the
+  `ResourceGuaranteedMemory` parameter (Flex allocation model) [GH-1283]

--- a/vcd/resource_vcd_catalog_test.go
+++ b/vcd/resource_vcd_catalog_test.go
@@ -834,6 +834,7 @@ func spawnTestOrgVdcSharedCatalog(client *VCDClient, name string) (govcd.AdminCa
 				},
 			},
 		},
+		ResourceGuaranteedMemory: addrOf(0.8),
 		VdcStorageProfile: []*types.VdcStorageProfileConfiguration{{
 			Enabled: addrOf(true),
 			Units:   "MB",


### PR DESCRIPTION
* Fixes `TestAccVcdCatalogSharedAccess`, it failed in 10.6+ due to VDC missing `ResourceGuaranteedMemory` parameter (flex allocation model)
* Fixes the root cause that makes `TestAccVcdNsxtAlbSettingsTransparentMode` fail in 10.6+