### PR TITLE
Fix tests

### DIFF
--- a/.changes/v3.13.0/1285-notes.md
+++ b/.changes/v3.13.0/1285-notes.md
@@ -1,0 +1,3 @@
+* Amend test `TestAccVcdSubscribedCatalog` to be compatible with VCD 10.6.0 [GH-1285]
+* Update `vcd_subscribed_catalog` resource documentation to state that `metadata` attribute is not available in
+VCD 10.6.0 [GH-1285]

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -252,7 +252,7 @@ func TestAccVcdSubscribedCatalog(t *testing.T) {
 							"sync_catalog", "sync_all", "sync_on_refresh", "subscription_password",
 							"cancel_failed_tasks", "store_tasks", "sync_all_vapp_templates",
 							"sync_vapp_templates", "sync_all_media_items", "tasks_file_name",
-							"sync_media_items",
+							"sync_media_items", "catalog_version",
 						},
 					},
 				},

--- a/vcd/resource_vcd_subscribed_catalog_test.go
+++ b/vcd/resource_vcd_subscribed_catalog_test.go
@@ -228,12 +228,13 @@ func TestAccVcdSubscribedCatalog(t *testing.T) {
 								resource.TestCheckResourceAttr(resourceSubscriber, "metadata.identity", "published catalog")),
 
 							// Subscribed catalog items also get their metadata from the corresponding published items
+							// Note: Skipping when API version is 39.0 (VCD 10.6.0) due to a bug.
 							checkWithTimeout(checkTimeout, checkDelay,
-								resource.TestCheckResourceAttr("data.vcd_catalog_vapp_template.test-vt-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog))),
+								testCheckResourceAttrWhenVersionMatches("data.vcd_catalog_vapp_template.test-vt-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog), "< 39.0")),
 							checkWithTimeout(checkTimeout, checkDelay,
-								resource.TestCheckResourceAttr("data.vcd_catalog_media.test-media-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog))),
+								testCheckResourceAttrWhenVersionMatches("data.vcd_catalog_media.test-media-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog), "< 39.0")),
 							checkWithTimeout(checkTimeout, checkDelay,
-								resource.TestCheckResourceAttr("data.vcd_catalog_item.test-vt-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog))),
+								testCheckResourceAttrWhenVersionMatches("data.vcd_catalog_item.test-vt-1", "metadata.ancestors", fmt.Sprintf("%s.%s", publisherOrg, publisherCatalog), "< 39.0")),
 
 							// If these VM exist, it means that the corresponding vApp template and Media items are fully functional
 							resource.TestCheckResourceAttr("vcd_vm."+testVm, "name", testVm),

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -83,7 +83,7 @@ The following arguments are supported:
 ## Attribute Reference
 
 * `description` - Description of catalog. This is inherited from the publishing catalog and updated on sync.
-* `metadata` - (*Not available in VCD 10.6.0*) Optional metadata of the catalog. This is inherited from the publishing catalog and updated on sync.
+* `metadata` - (*Available until VCD 10.5*) Optional metadata of the catalog. This is inherited from the publishing catalog and updated on sync.
 * `catalog_version` - Version number from this catalog. This is inherited from the publishing catalog and updated on sync.
 * `owner_name` - Owner of the catalog.
 * `number_of_vapp_templates` - Number of vApp templates available in this catalog.

--- a/website/docs/r/subscribed_catalog.html.markdown
+++ b/website/docs/r/subscribed_catalog.html.markdown
@@ -82,8 +82,8 @@ The following arguments are supported:
  
 ## Attribute Reference
 
-* `description` -  Description of catalog. This is inherited from the publishing catalog and updated on sync.
-* `metadata` -  Optional metadata of the catalog. This is inherited from the publishing catalog and updated on sync.
+* `description` - Description of catalog. This is inherited from the publishing catalog and updated on sync.
+* `metadata` - (*Not available in VCD 10.6.0*) Optional metadata of the catalog. This is inherited from the publishing catalog and updated on sync.
 * `catalog_version` - Version number from this catalog. This is inherited from the publishing catalog and updated on sync.
 * `owner_name` - Owner of the catalog.
 * `number_of_vapp_templates` - Number of vApp templates available in this catalog.


### PR DESCRIPTION
This PR amends the following tests:

- `TestAccVcdSubscribedCatalog`: Fails in VCD 10.6.0 due to a bug that prevents catalog items metadata get synchronised with the subscribed catalog. The fix is to ignore metadata when using this version and update documentation accordingly to warn users.
- [x] Passes in VCD 10.5.1.1
- [x] Passes in VCD 10.6.0

Also adjusts documentation where necessary.