### PR TITLE
Fix updating vcd_external_network_v2 with edge gateway having `dedicate_external_network=true`

### DIFF
--- a/.changes/v3.14.0/1301-bug-fixes.md
+++ b/.changes/v3.14.0/1301-bug-fixes.md
@@ -1,0 +1,3 @@
+* Fix [Issue 1183](https://github.com/vmware/terraform-provider-vcd/issues/1183) where updates might
+  fail for vcd_external_network_v2 when NSX-T edge gateway has `dedicate_external_network=true`
+  [GH-1301]


### PR DESCRIPTION
Closes #1183 

## About the problem

There is a bug in runtime validation that is triggered when all of the following conditions are met:
* User has external network backed by T0 or T0 VRF (aka provider gateway) without IP Spaces
* User has NSX-T edge gateway provisioned with flag `dedicate_external_network = true`
* User tries to update external network (e.g. expand the `static_ip_pool`) [this is when the bug described in #1183 is hit]

## Fix

The fix is to ignore validation `!usingIpSpace && d.Get("dedicated_org_id").(string) != ""` during update because `d.Get("dedicated_org_id")` might return the value of computed field which automatically gets populated when edge gateway consumes this network (has `dedicate_external_network = true`).

### Sample hcl

```hcl

resource "vcd_external_network_v2" "ext-net-nsxt" {
  name        = "XXX"
  description = "Test External Network"

  nsxt_network {
    nsxt_manager_id      = data.vcd_nsxt_manager.main.id
    nsxt_tier0_router_id = data.vcd_nsxt_tier0_router.router.id
  }

  use_ip_spaces = false

  ip_scope {
    enabled       = true
    gateway       = "192.168.30.49"
    prefix_length = "24"

    static_ip_pool {
      start_address = "192.168.30.51"
      end_address   = "192.168.30.66" # Increment the end address for update to see the issue
    }
  }

}


resource "vcd_nsxt_edgegateway" "nsxt-edge" {
  # org         = "my-org"
  owner_id    = data.vcd_org_vdc.vdc1.id
  name        = "nsxt-edge"
  description = "Description"

  external_network_id       = vcd_external_network_v2.ext-net-nsxt.id
  dedicate_external_network = true

  subnet {
    gateway       = "192.168.30.49"
    prefix_length = "24"
    primary_ip = "192.168.30.51"
    allocated_ips {
      start_address = "192.168.30.51"
      end_address   = "192.168.30.60"
    }
  }
}
```

## Replicating 
commit da78097562fea10c0cfdb8a1e9f8876e91ac56df  has a test that hits the issue

