### PR TITLE
Allow unlimited CPU limit in vcd_vm_sizing_policy resource

### DIFF
--- a/.changes/v3.14.0/1303-bug-fixes.md
+++ b/.changes/v3.14.0/1303-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fix [Issue 1243](https://github.com/vmware/terraform-provider-vcd/issues/1243):
+  Allow unlimited `limit_in_mhz` in `vcd_vm_sizing_policy` resource [GH-1303]

--- a/vcd/resource_vcd_vm_sizing_policy.go
+++ b/vcd/resource_vcd_vm_sizing_policy.go
@@ -95,7 +95,7 @@ var sizingPolicyCpu = &schema.Resource{
 			Type:         schema.TypeString,
 			ForceNew:     true,
 			Optional:     true,
-			Description:  "Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs.",
+			Description:  "Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs. -1 means unlimited",
 			ValidateFunc: IsIntAndAtLeast(-1),
 		},
 		"shares": {

--- a/vcd/resource_vcd_vm_sizing_policy.go
+++ b/vcd/resource_vcd_vm_sizing_policy.go
@@ -96,7 +96,7 @@ var sizingPolicyCpu = &schema.Resource{
 			ForceNew:     true,
 			Optional:     true,
 			Description:  "Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs.",
-			ValidateFunc: IsIntAndAtLeast(0),
+			ValidateFunc: IsIntAndAtLeast(-1),
 		},
 		"shares": {
 			Type:         schema.TypeString,

--- a/vcd/resource_vcd_vm_sizing_policy_test.go
+++ b/vcd/resource_vcd_vm_sizing_policy_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var TestVmPolicy = "TestVmPolicyBasic"
-
 func TestAccVcdVmSizingPolicy(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
@@ -25,7 +23,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 		"Description": "TestAccVcdVmSizingPolicyDescription",
 
 		"CpuShare":       "886",
-		"CpuLimit":       "12375",
+		"CpuLimit":       "-1",
 		"CpuCount":       "9",
 		"CpuSpeed":       "2500",
 		"CoresPerSocket": "3",
@@ -40,6 +38,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 
 	configText := templateFill(testAccCheckVmSizingPolicy_basic, params)
 	params["FuncName"] = t.Name() + "-Update"
+	params["CpuLimit"] = "12375"
 	updateText := templateFill(testAccCheckVmSizingPolicy_update, params)
 	params["FuncName"] = t.Name() + "-DataSource"
 	dataSourceText := templateFill(testAccCheckVmSizingPolicy_update+testAccVmSizingPolicyDataSource, params)
@@ -76,7 +75,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resource2, "description", params["Description"].(string)+"_2"),
 
 					resource.TestCheckResourceAttr(resource2, "cpu.0.shares", params["CpuShare"].(string)),
-					resource.TestCheckResourceAttr(resource2, "cpu.0.limit_in_mhz", params["CpuLimit"].(string)),
+					resource.TestCheckResourceAttr(resource2, "cpu.0.limit_in_mhz", "-1"),
 					resource.TestCheckResourceAttr(resource2, "cpu.0.count", params["CpuCount"].(string)),
 					resource.TestCheckResourceAttr(resource2, "cpu.0.speed_in_mhz", params["CpuSpeed"].(string)),
 					resource.TestCheckResourceAttr(resource2, "cpu.0.cores_per_socket", params["CoresPerSocket"].(string)),
@@ -96,7 +95,7 @@ func TestAccVcdVmSizingPolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resource4, "description", params["Description"].(string)+"_4"),
 
 					resource.TestCheckResourceAttr(resource4, "cpu.0.shares", params["CpuShare"].(string)),
-					resource.TestCheckResourceAttr(resource4, "cpu.0.limit_in_mhz", params["CpuLimit"].(string)),
+					resource.TestCheckResourceAttr(resource4, "cpu.0.limit_in_mhz", "-1"),
 					resource.TestCheckResourceAttr(resource4, "cpu.0.count", params["CpuCount"].(string)),
 					resource.TestCheckResourceAttr(resource4, "cpu.0.speed_in_mhz", params["CpuSpeed"].(string)),
 					resource.TestCheckResourceAttr(resource4, "cpu.0.cores_per_socket", params["CoresPerSocket"].(string)),

--- a/website/docs/r/vm_sizing_policy.html.markdown
+++ b/website/docs/r/vm_sizing_policy.html.markdown
@@ -62,7 +62,7 @@ To preserve compatibility until the next release, though, the parameter is still
  Each VM sizing policy supports the following attributes:
  
  * `shares` - (Optional) Defines the number of CPU shares for a VM. Shares specify the relative importance of a VM within a virtual data center. If a VM has twice as many shares of CPU as another VM, it is entitled to consume twice as much CPU when these two virtual machines are competing for resources. If not defined in the VDC compute policy, normal shares are applied to the VM.
- * `limit_in_mhz` - (Optional) Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs.
+ * `limit_in_mhz` - (Optional) Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs. Since *v3.14+*, `-1` means unlimited.
  * `count` - (Required) Defines the number of vCPUs configured for a VM. This is a VM hardware configuration. When a tenant assigns the VM sizing policy to a VM, this count becomes the configured number of vCPUs for the VM.
  * `speed_in_mhz` - (Optional) Defines the vCPU speed of a core in MHz.
  * `cores_per_socket` - (Optional) The number of cores per socket for a VM. This is a VM hardware configuration. The number of vCPUs that is defined in the VM sizing policy must be divisible by the number of cores per socket. If the number of vCPUs is not divisible by the number of cores per socket, the number of cores per socket becomes invalid.

--- a/website/docs/r/vm_sizing_policy.html.markdown
+++ b/website/docs/r/vm_sizing_policy.html.markdown
@@ -62,7 +62,7 @@ To preserve compatibility until the next release, though, the parameter is still
  Each VM sizing policy supports the following attributes:
  
  * `shares` - (Optional) Defines the number of CPU shares for a VM. Shares specify the relative importance of a VM within a virtual data center. If a VM has twice as many shares of CPU as another VM, it is entitled to consume twice as much CPU when these two virtual machines are competing for resources. If not defined in the VDC compute policy, normal shares are applied to the VM.
- * `limit_in_mhz` - (Optional) Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs. Since *v3.14+*, `-1` means unlimited.
+ * `limit_in_mhz` - (Optional) Defines the CPU limit in MHz for a VM. If not defined in the VDC compute policy, CPU limit is equal to the vCPU speed multiplied by the number of vCPUs. Since *v3.14*, `-1` means unlimited.
  * `count` - (Required) Defines the number of vCPUs configured for a VM. This is a VM hardware configuration. When a tenant assigns the VM sizing policy to a VM, this count becomes the configured number of vCPUs for the VM.
  * `speed_in_mhz` - (Optional) Defines the vCPU speed of a core in MHz.
  * `cores_per_socket` - (Optional) The number of cores per socket for a VM. This is a VM hardware configuration. The number of vCPUs that is defined in the VM sizing policy must be divisible by the number of cores per socket. If the number of vCPUs is not divisible by the number of cores per socket, the number of cores per socket becomes invalid.


### PR DESCRIPTION
This PR amends `vcd_vm_sizing_policy` resource to allow the value -1 in the `limit_in_mhz` argument of the `cpu` block, which means **Unlimited** (or **No limit**).

Before this change, the resource would output an error as the minimum allowed value was 0.

Closes #1243

## Tests

- `TestAccVcdVmSizingPolicy` in VCD 10.6.0 passed
- `vcd.ResourceSchema-vcd_vm_sizing_policy.tf` Upgrade test passed (no need to skip)