### PR TITLE
Improve failing tests

### DIFF
--- a/.changes/v3.14.0/1305-improvements.md
+++ b/.changes/v3.14.0/1305-improvements.md
@@ -1,0 +1,2 @@
+* Add IP Space locks for `vcd_ip_space_ip_allocation` to prevent concurrent modification error in
+  API [GH-1305]

--- a/vcd/resource_vcd_ip_space_ip_allocation.go
+++ b/vcd/resource_vcd_ip_space_ip_allocation.go
@@ -134,6 +134,9 @@ func resourceVcdIpAllocationCreate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error getting IP Space by ID '%s': %s", ipSpaceId, err)
 	}
 
+	vcdClient.lockById(ipSpace.IpSpace.ID)
+	defer vcdClient.unlockById(ipSpace.IpSpace.ID)
+
 	allocationConfig := types.IpSpaceIpAllocationRequest{
 		Type:     d.Get("type").(string),
 		Quantity: addrOf(1),
@@ -209,6 +212,9 @@ func resourceVcdIpAllocationUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("error getting Org by ID: %s", err)
 	}
 
+	vcdClient.lockById(ipSpaceId)
+	defer vcdClient.unlockById(ipSpaceId)
+
 	ipAllocation, err := org.GetIpSpaceAllocationById(ipSpaceId, d.Id())
 	if err != nil {
 		return diag.Errorf("error retrieving IP Allocation: %s", err)
@@ -282,6 +288,9 @@ func resourceVcdIpAllocationDelete(ctx context.Context, d *schema.ResourceData, 
 	vcdClient := meta.(*VCDClient)
 	orgId := d.Get("org_id").(string)
 	ipSpaceId := d.Get("ip_space_id").(string)
+
+	vcdClient.lockById(ipSpaceId)
+	defer vcdClient.unlockById(ipSpaceId)
 
 	org, err := vcdClient.GetOrgById(orgId)
 	if err != nil {

--- a/vcd/resource_vcd_vapp_vm_customization_test.go
+++ b/vcd/resource_vcd_vapp_vm_customization_test.go
@@ -463,9 +463,6 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 			},
 			// Step 2 - join org domain (does not fail because enabled=false even though OS is not windows)
 			{
-				Taint: []string{"vcd_vapp_vm.test-vm"},
-				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
-				// recreation of the VM
 				Config: configTextVMStep1,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVcdVAppVmExists(netVappName, netVmName1+"-step1", "vcd_vapp_vm.test-vm-step2", &vapp, &vm),
@@ -481,9 +478,6 @@ func TestAccVcdVAppVmCustomizationSettings(t *testing.T) {
 			},
 			// Step 3 - join org domain enabled
 			{
-				Taint: []string{"vcd_vapp_vm.test-vm-step2"},
-				// Taint does not work in SDK 2.1.0 therefore every test step has resource address changed to force
-				// recreation of the VM
 				Config: configTextVMStep2,
 				// Our testing suite does not have Windows OS to actually try domain join so the point of this test is
 				// to prove that values are actually set and try to be applied on vCD.

--- a/vcd/vdc_group_common_test.go
+++ b/vcd/vdc_group_common_test.go
@@ -34,7 +34,7 @@ resource "vcd_org_vdc" "newVdc" {
     }
 
     memory {
-      allocated = "1024"
+      allocated = "768"
       limit     = "1024"
     }
   }


### PR DESCRIPTION
* `TestAccVcdVAppVmCustomizationSettings` - shuffle names so that duplicate name is not hit
* `TestAccVcdExternalNetworkV2NsxtTopologyIntentionIntegration` - add per IP Space locks to `vcd_ip_space_ip_allocation` to avoid manipulating IP Allocations and reservations in parallel
* TestAccVcdDistributedFirewallVCD10_2_2 - decrease VDC allocation of memory 
* TestAccVcdNsxtEdgeGatewayVdcGroupMigration - decrease VDC allocation of memory 