### PR TITLE
Fix issue #1262

### DIFF
--- a/.changes/v3.14.0/1312-bug-fixes.md
+++ b/.changes/v3.14.0/1312-bug-fixes.md
@@ -1,2 +1,2 @@
-* Fix [Issue 1262](https://github.com/vmware/terraform-provider-vcd/issues/1262) Panic when creating a VM when the VCD provider
-  is configured with a user without "Organization vDC Disk: View/Edit IOPS" rights [GH-1312]
+* Fix [Issue 1262](https://github.com/vmware/terraform-provider-vcd/issues/1262): Panic when creating a VM with `vcd_vm` and `vcd_vapp_vm`
+  when the VCD provider is configured with a user without "Organization vDC Disk: View/Edit IOPS" rights [GH-1312]

--- a/.changes/v3.14.0/1312-bug-fixes.md
+++ b/.changes/v3.14.0/1312-bug-fixes.md
@@ -1,0 +1,2 @@
+* Fix [Issue 1262](https://github.com/vmware/terraform-provider-vcd/issues/1262) Panic when creating a VM when the VCD provider
+  is configured with a user without "Organization vDC Disk: View/Edit IOPS" rights [GH-1312]

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -476,6 +476,7 @@ func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 	var params = StringMap{
 		"ProviderVcdOrg": providerVcdOrg1,
 		"Org":            testConfig.VCD.Org,
+		"Name":           t.Name(),
 		"Vdc":            testConfig.Nsxt.Vdc,
 		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
 		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -543,6 +543,7 @@ func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 					}
 				},
 				Check: resource.ComposeTestCheckFunc(
+					// Nothing to test here, we just want to assert that no panic is thrown anymore
 					resource.TestCheckResourceAttr("vcd_vm.my_vm", "name", t.Name()),
 				),
 			},

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -510,6 +510,7 @@ func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 	debugPrintf("#[DEBUG] CONFIGURATION: %s\n", configText)
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: buildMultipleProviders(),
+		CheckDestroy:      testAccCheckVcdStandaloneVmDestroy(t.Name(), params["Org"].(string), params["Vdc"].(string)),
 		Steps: []resource.TestStep{
 			{
 				Config: configText,
@@ -541,7 +542,9 @@ func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 						t.Fatal(err)
 					}
 				},
-				Check: resource.ComposeTestCheckFunc(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vcd_vm.my_vm", "name", t.Name()),
+				),
 			},
 		},
 	})

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -469,7 +469,7 @@ resource "vcd_vm" "boot-image-vm" {
 `
 
 // TestAccVcdVm_WithoutIopsRights tests VM creation with a user that does not have any View/edit IOPS rights.
-// This test will panic without fix made in <INSERT PR>.
+// This test will panic without fix made in https://github.com/vmware/terraform-provider-vcd/pull/1312
 func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 	preTestChecks(t)
 

--- a/vcd/resource_vcd_vapp_vm_test.go
+++ b/vcd/resource_vcd_vapp_vm_test.go
@@ -472,15 +472,17 @@ resource "vcd_vm" "boot-image-vm" {
 // This test will panic without fix made in https://github.com/vmware/terraform-provider-vcd/pull/1312
 func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 	preTestChecks(t)
+	skipIfNotSysAdmin(t)
 
 	var params = StringMap{
-		"ProviderVcdOrg": providerVcdOrg1,
-		"Org":            testConfig.VCD.Org,
-		"Name":           t.Name(),
-		"Vdc":            testConfig.Nsxt.Vdc,
-		"Catalog":        testConfig.VCD.Catalog.NsxtBackedCatalogName,
-		"CatalogItem":    testConfig.VCD.Catalog.NsxtCatalogItem,
-		"Tags":           "vapp vm",
+		"ProviderVcdSystem": providerVcdSystem,
+		"ProviderVcdOrg":    providerVcdOrg1,
+		"Org":               testConfig.VCD.Org,
+		"Name":              t.Name(),
+		"Vdc":               testConfig.Nsxt.Vdc,
+		"Catalog":           testConfig.VCD.Catalog.NsxtBackedCatalogName,
+		"CatalogItem":       testConfig.VCD.Catalog.NsxtCatalogItem,
+		"Tags":              "vapp vm",
 	}
 	testParamsNotEmpty(t, params)
 
@@ -554,6 +556,14 @@ func TestAccVcdVm_WithoutIopsRights(t *testing.T) {
 }
 
 const testAccCheckVcdVmWithoutIopsRights = `
+# Acceptance tests only:
+# This data source initializes the 'testAccProvider' variable and prevents a panic
+# in 'testAccCheckVcdStandaloneVmDestroy' when running acceptance tests
+# (check TESTING.md "Tests with multiple providers" for more info)
+data "vcd_version" "dummy" {
+  provider = {{.ProviderVcdSystem}}
+}
+
 data "vcd_catalog" "my-catalog" {
   provider = {{.ProviderVcdOrg}}
   org      = "{{.Org}}"

--- a/vcd/resource_vcd_vapp_vm_tools.go
+++ b/vcd/resource_vcd_vapp_vm_tools.go
@@ -695,7 +695,7 @@ func updateTemplateInternalDisks(d *schema.ResourceData, meta interface{}, vm go
 		}
 
 		// Update details of internal disk for disk existing in template
-		if value, ok := internalDiskProvidedConfig["iops"]; ok {
+		if value, ok := internalDiskProvidedConfig["iops"]; ok && diskCreatedByTemplate.IopsAllocation != nil {
 			iops := int64(value.(int))
 			diskCreatedByTemplate.IopsAllocation.Reservation = iops
 		}

--- a/vcd/resource_vcd_vapp_vm_tools.go
+++ b/vcd/resource_vcd_vapp_vm_tools.go
@@ -696,6 +696,9 @@ func updateTemplateInternalDisks(d *schema.ResourceData, meta interface{}, vm go
 
 		// Update details of internal disk for disk existing in template
 		if value := internalDiskProvidedConfig["iops"]; value.(int) != 0 || diskCreatedByTemplate.IopsAllocation != nil {
+			if diskCreatedByTemplate.IopsAllocation == nil {
+				diskCreatedByTemplate.IopsAllocation = &types.IopsResource{}
+			}
 			iops := int64(value.(int))
 			diskCreatedByTemplate.IopsAllocation.Reservation = iops
 		}

--- a/vcd/resource_vcd_vapp_vm_tools.go
+++ b/vcd/resource_vcd_vapp_vm_tools.go
@@ -695,7 +695,7 @@ func updateTemplateInternalDisks(d *schema.ResourceData, meta interface{}, vm go
 		}
 
 		// Update details of internal disk for disk existing in template
-		if value, ok := internalDiskProvidedConfig["iops"]; ok && diskCreatedByTemplate.IopsAllocation != nil {
+		if value := internalDiskProvidedConfig["iops"]; value.(int) != 0 || diskCreatedByTemplate.IopsAllocation != nil {
 			iops := int64(value.(int))
 			diskCreatedByTemplate.IopsAllocation.Reservation = iops
 		}


### PR DESCRIPTION
This PR closes #1262

## Problem

When a user creates a VM with a VM template, and she does not have the "Organization vDC Disk: View IOPS" right, the VCD Provider crashes with a panic:

```
goroutine 786 [running]:
github.com/vmware/terraform-provider-vcd/v3/vcd.updateTemplateInternalDisks(0xc000054680, {0xcd4e980, 0xc000c8e870}, {0xc0003902c0, 0xc00017f088})
	/Users/adambarreiro/terraform-provider-vcd/vcd/resource_vcd_vapp_vm_tools.go:700 +0x945
github.com/vmware/terraform-provider-vcd/v3/vcd.createVmFromImage(0xc000054680, {0xcd4e980, 0xc000c8e870}, {0xc6a4f44, 0x6}, {0xc6b662b, 0x10})
	/Users/adambarreiro/terraform-provider-vcd/vcd/resource_vcd_vapp_vm.go:1347 +0x3886
github.com/vmware/terraform-provider-vcd/v3/vcd.genericResourceVmCreate(0xc000054680, {0xcd4e980, 0xc000c8e870}, {0xc6a4f44, 0x6})
	/Users/adambarreiro/terraform-provider-vcd/vcd/resource_vcd_vapp_vm.go:893 +0x395
```

HCL to reproduce:

```hcl
provider "vcd" {
  user                 = "abarreiro-admin" # User without Organization vDC Disk: View IOPS right!!
  password             = "******"
  token                = ""
  api_token            = ""
  auth_type            = "integrated"
  saml_adfs_rpt_id     = ""
  url                  = "https://vcd-url/api"
  sysorg               = "abarreiro"
  org                  = "abarreiro"
  vdc                  = "nsxt-vdc-abarreiro"
  allow_unverified_ssl = "true"
  max_retry_timeout    = 600
  logging              = true
  logging_file         = "go-vcloud-director.log"
}

data "vcd_catalog" "my-catalog" {
  name = "cat-abarreiro-nsxt-backed"
}

data "vcd_catalog_vapp_template" "template" {
  catalog_id = data.vcd_catalog.my-catalog.id
  name       = "nsxt-photon-hw11"
}

resource "vcd_vm" "my_vm" {
  name             = "my_vm_test_01"
  vapp_template_id = data.vcd_catalog_vapp_template.template.id
  memory           = 512
  cpus             = 1

  override_template_disk {
    bus_type        = "paravirtual"
    size_in_mb      = "16384"
    bus_number      = 0
    unit_number     = 0
    storage_profile = "*"
  }
}
```

## Solution

In code, it was assumed that the IOPS information was always present. The fix consists of safely checking for `nil` pointers.

## Tests

A new test is provided: `TestAccVcdVm_WithoutOrganizationVdcDiskIopsRights`. This test will panic without this fix (hence will remove the `Organization vDC Disk: View IOPS` from your VCD testing org user, be careful and restore it afterwards).
With this patch, the test obviously should pass.

What it does, it removes the mentioned rights, applies the HCL, then restores the same rights.