### PR TITLE
Remove validation that causes issue #1216

### DIFF
--- a/.changes/v3.14.0/1313-bug-fixes.md
+++ b/.changes/v3.14.0/1313-bug-fixes.md
@@ -1,3 +1,3 @@
 * Fix [Issue 1216](https://github.com/vmware/terraform-provider-vcd/issues/1216) in `vcd_org_vdc`
-  that would fail on creation when `vm_placement_policy_ids` are set but one does not want to declare a `default_compute_policy_id`
-  (to use the System default instead) [GH-1313]
+  which failed on creation when `vm_placement_policy_ids` were set but `default_compute_policy_id`
+  was not declared (System default was used instead) [GH-1313]

--- a/.changes/v3.14.0/1313-bug-fixes.md
+++ b/.changes/v3.14.0/1313-bug-fixes.md
@@ -1,0 +1,3 @@
+* Fix [Issue 1216](https://github.com/vmware/terraform-provider-vcd/issues/1216) in `vcd_org_vdc`
+  that would fail on creation when `vm_placement_policy_ids` are set but one does not want to declare a `default_compute_policy_id`
+  (to use the System default instead) [GH-1313]

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -972,8 +972,8 @@ func changeComputePoliciesAndDefaultId(d *schema.ResourceData, vcdClient *VCDCli
 	for _, attribute := range computePolicyAttributes {
 		vmComputePolicyIds = append(vmComputePolicyIds, convertSchemaSetToSliceOfStrings(d.Get(attribute).(*schema.Set))...)
 	}
-	if !contains(vmComputePolicyIds, defaultPolicyId.(string)) {
-		return fmt.Errorf("`default_compute_policy_id` %s is not present in any of `%v`", defaultPolicyId.(string), computePolicyAttributes)
+	if defaultPolicyId.(string) != "" && !contains(vmComputePolicyIds, defaultPolicyId.(string)) {
+		return fmt.Errorf("`default_compute_policy_id` '%s' is not present in any of `%v`", defaultPolicyId.(string), computePolicyAttributes)
 	}
 
 	var vdcComputePolicyReferenceList []*types.Reference
@@ -1010,6 +1010,8 @@ func changeComputePoliciesAndDefaultId(d *schema.ResourceData, vcdClient *VCDCli
 	for _, policyId := range vmComputePolicyIds {
 		vdcComputePolicyReferenceList = append(vdcComputePolicyReferenceList, &types.Reference{HREF: vcdComputePolicyHref + policyId})
 	}
+	// The default policy may not be set in the Terraform arguments explicitly (can be Computed)
+	vdcComputePolicyReferenceList = append(vdcComputePolicyReferenceList, vdc.AdminVdc.DefaultComputePolicy)
 	policyReferences.VdcComputePolicyReference = vdcComputePolicyReferenceList
 
 	_, err = updatedVdc.SetAssignedComputePolicies(policyReferences)

--- a/vcd/resource_vcd_org_vdc.go
+++ b/vcd/resource_vcd_org_vdc.go
@@ -972,6 +972,9 @@ func changeComputePoliciesAndDefaultId(d *schema.ResourceData, vcdClient *VCDCli
 	for _, attribute := range computePolicyAttributes {
 		vmComputePolicyIds = append(vmComputePolicyIds, convertSchemaSetToSliceOfStrings(d.Get(attribute).(*schema.Set))...)
 	}
+	// Check that the 'default_compute_policy_id' is not empty to prevent issue 1216: https://github.com/vmware/terraform-provider-vcd/issues/1216
+	// Otherwise, we can't set some Compute policies (like VM Placement policies) without an explicit default one
+	// (so VCD takes the System Default VM Sizing Policy automatically), which should be allowed.
 	if defaultPolicyId.(string) != "" && !contains(vmComputePolicyIds, defaultPolicyId.(string)) {
 		return fmt.Errorf("`default_compute_policy_id` '%s' is not present in any of `%v`", defaultPolicyId.(string), computePolicyAttributes)
 	}

--- a/vcd/resource_vcd_org_vdc_with_all_compute_policies_test.go
+++ b/vcd/resource_vcd_org_vdc_with_all_compute_policies_test.go
@@ -124,13 +124,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 
   compute_capacity {
     cpu {
-      allocated = 1024
-      limit     = 1024
+      allocated = 512
+      limit     = 512
     }
 
     memory {
-      allocated = 1024
-      limit     = 1024
+      allocated = 512
+      limit     = 512
     }
   }
 
@@ -150,6 +150,42 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   default_compute_policy_id = vcd_vm_placement_policy.placement1.id
   vm_placement_policy_ids   = [vcd_vm_placement_policy.placement1.id]
   vm_sizing_policy_ids = [vcd_vm_sizing_policy.sizing1.id]
+}
+
+resource "vcd_org_vdc" "{{.VdcName}}2" {
+  name = "{{.VdcName}}2"
+  org  = "{{.OrgName}}"
+
+  allocation_model  = "ReservationPool"
+  network_pool_name = "{{.NetworkPool}}"
+  provider_vdc_name = data.vcd_provider_vdc.pvdc.name
+
+  compute_capacity {
+    cpu {
+      allocated = 512
+      limit     = 512
+    }
+
+    memory {
+      allocated = 512
+      limit     = 512
+    }
+  }
+
+  storage_profile {
+    name     = "{{.ProviderVdcStorageProfile}}"
+    enabled  = true
+    limit    = 10240
+    default  = true
+  }
+
+  enabled                    = true
+  enable_thin_provisioning   = true
+  enable_fast_provisioning   = true
+  delete_force               = true
+  delete_recursive           = true
+
+  vm_placement_policy_ids   = [vcd_vm_placement_policy.placement1.id]
 }
 `
 
@@ -207,13 +243,13 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
 
   compute_capacity {
     cpu {
-      allocated = 1024
-      limit     = 1024
+      allocated = 512
+      limit     = 512
     }
 
     memory {
-      allocated = 1024
-      limit     = 1024
+      allocated = 512
+      limit     = 512
     }
   }
 
@@ -233,5 +269,42 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   default_compute_policy_id = vcd_vm_placement_policy.placement1.id
   vm_placement_policy_ids   = [vcd_vm_placement_policy.placement1.id]
   vm_sizing_policy_ids = [vcd_vm_sizing_policy.sizing1.id, vcd_vm_sizing_policy.sizing2.id]
+}
+
+resource "vcd_org_vdc" "{{.VdcName}}2" {
+  name = "{{.VdcName}}2"
+  org  = "{{.OrgName}}"
+
+  allocation_model  = "ReservationPool"
+  network_pool_name = "{{.NetworkPool}}"
+  provider_vdc_name = data.vcd_provider_vdc.pvdc.name
+
+  compute_capacity {
+    cpu {
+      allocated = 512
+      limit     = 512
+    }
+
+    memory {
+      allocated = 512
+      limit     = 512
+    }
+  }
+
+  storage_profile {
+    name     = "{{.ProviderVdcStorageProfile}}"
+    enabled  = true
+    limit    = 10240
+    default  = true
+  }
+
+  enabled                    = true
+  enable_thin_provisioning   = true
+  enable_fast_provisioning   = true
+  delete_force               = true
+  delete_recursive           = true
+
+  default_compute_policy_id = vcd_vm_placement_policy.placement1.id
+  vm_placement_policy_ids   = [vcd_vm_placement_policy.placement1.id]
 }
 `


### PR DESCRIPTION
## Problem

As it is now, the VCD Provider requires that `default_compute_policy_id` is set when `vm_placement_policy_ids` or `vm_sizing_policy_ids` are specified.

This works for most of the cases, except one important one: When a VDC is created with several Placement policies assigned (`vm_placement_policy_ids`) but one wants to use the System default Sizing policy as default:

```hcl
resource "vcd_org_vdc" "TestAccVcdOrgVdcWithAllComputePolicies" {
  # ...omitted

  default_compute_policy_id = null # This will be computed to the System default policy, auto-generated from VCD
  vm_placement_policy_ids   = [
    vcd_vm_placement_policy.placement1.id,
    vcd_vm_placement_policy.placement2.id,
    vcd_vm_placement_policy.placement3.id,
    # ...
  ]
}
```

Applying a configuration like this will fail on runtime due to a validation the provider does in code:

```
!contains(vmComputePolicyIds, defaultPolicyId.(string))
```

## Fix

When there is no `default_compute_policy_id` set (or it is ""), ignore the validation:

```
defaultPolicyId.(string) != "" && !contains(vmComputePolicyIds, defaultPolicyId.(string))
```

## Tests

Added a new VDC definition that replicates this scenario in `TestAccVcdOrgVdcWithAllComputePolicies`

____

Closes #1216