### PR TITLE
Add vcd_catalog_access_control data source

### DIFF
--- a/.changes/v3.14.0/XXXX-features.md
+++ b/.changes/v3.14.0/XXXX-features.md
@@ -1,0 +1,1 @@
+* **New Data Source:** `vcd_catalog_access_control` to read Catalog access controls [GH-XXXX]

--- a/vcd/datasource_vcd_catalog_access_control.go
+++ b/vcd/datasource_vcd_catalog_access_control.go
@@ -1,0 +1,78 @@
+package vcd
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func datasourceVcdCatalogAccessControl() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: datasourceVcdCatalogAccessControlRead,
+		Schema: map[string]*schema.Schema{
+			"org": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The name of organization to use, optional if defined at provider " +
+					"level. Useful when connected as sysadmin working across different organizations",
+			},
+			"catalog_id": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The ID of Catalog to use",
+			},
+			"shared_with_everyone": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the Catalog is shared with everyone",
+			},
+			"everyone_access_level": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Access level when the catalog is shared with everyone (only ReadOnly is available). Required when shared_with_everyone is set",
+			},
+			"read_only_shared_with_all_orgs": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If true, the catalog is shared as read-only with all organizations",
+			},
+			"shared_with": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"org_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID of the Org to which we are sharing. Required if user_id or group_id is not set",
+						},
+						"user_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID of the user to which we are sharing. Required if group_id or org_id is not set",
+						},
+						"group_id": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "ID of the group to which we are sharing. Required if user_id or org_id is not set",
+						},
+						"subject_name": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Name of the subject (org, group, or user) with which we are sharing",
+						},
+						"access_level": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "The access level for the org, user, or group to which we are sharing. One of [ReadOnly, Change, FullControl] for users and groups, but just ReadOnly for Organizations",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func datasourceVcdCatalogAccessControlRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	return genericVcdCatalogAccessControlRead(ctx, d, meta, "datasource")
+}

--- a/vcd/provider.go
+++ b/vcd/provider.go
@@ -170,6 +170,7 @@ var globalDataSourceMap = map[string]*schema.Resource{
 	"vcd_org_vdc_template":                             datasourceVcdOrgVdcTemplate(),                          // 3.13
 	"vcd_external_endpoint":                            datasourceVcdExternalEndpoint(),                        // 3.14
 	"vcd_api_filter":                                   datasourceVcdApiFilter(),                               // 3.14
+	"vcd_catalog_access_control":                       datasourceVcdCatalogAccessControl(),                    // 3.14
 }
 
 var globalResourceMap = map[string]*schema.Resource{

--- a/website/docs/d/catalog_access_control.html.markdown
+++ b/website/docs/d/catalog_access_control.html.markdown
@@ -22,7 +22,7 @@ data "vcd_catalog" "catalog" {
   name = "my-catalog"
 }
 
-resource "vcd_catalog_access_control" "ac" {
+data "vcd_catalog_access_control" "ac" {
   catalog_id = data.vcd_catalog.catalog.id
 }
 

--- a/website/docs/d/catalog_access_control.html.markdown
+++ b/website/docs/d/catalog_access_control.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "vcd"
+page_title: "VMware Cloud Director: vcd_catalog_access_control"
+sidebar_current: "docs-vcd-data-source-catalog-access-control"
+description: |-
+  Provides a data source to read Access Control details from a Catalog in VMware Cloud Director.
+---
+
+# vcd\_catalog\_access\_control
+
+Provides a data source to read Access Control details from a Catalog in VMware Cloud Director.
+
+-> **Note:** Access control reads run in tenant context, meaning that, even if the user is a system administrator,
+in every request it uses headers items that define the tenant context as restricted to the organization to which the Catalog belongs.
+
+Supported in provider *v3.14+*
+
+## Example Usage
+
+```hcl
+data "vcd_catalog" "catalog" {
+  name = "my-catalog"
+}
+
+resource "vcd_catalog_access_control" "ac" {
+  catalog_id = data.vcd_catalog.catalog.id
+}
+
+output "shared_with" {
+  value = data.vcd_catalog_access_control.ac.shared_with
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `org` - (Optional) The name of organization to which the Catalog belongs. Optional if defined at provider level.
+* `catalog_id` - (Required) A unique identifier for the Catalog.
+
+## Attribute Reference
+
+All the arguments from [the `vcd_catalog_access_control` resource](/providers/vmware/vcd/latest/docs/resources/catalog_access_control)
+are available as read-only.

--- a/website/vcd.erb
+++ b/website/vcd.erb
@@ -73,6 +73,9 @@
             <li<%= sidebar_current("docs-vcd-data-source-catalog") %>>
               <a href="/docs/providers/vcd/d/catalog.html">vcd_catalog</a>
             </li>
+            <li<%= sidebar_current("docs-vcd-data-source-catalog-access-control") %>>
+              <a href="/docs/providers/vcd/d/catalog_access_control.html">vcd_catalog_access_control</a>
+            </li>
             <li<%= sidebar_current("docs-vcd-data-source-subscribed-catalog") %>>
               <a href="/docs/providers/vcd/d/subscribed_catalog.html">vcd_subscribed_catalog</a>
             </li>


### PR DESCRIPTION
Closes #1209 

Adds a `vcd_catalog_access_control` data source to be able to read its properties from an existing Catalog.