### PR TITLE
Patch broken test checks

### DIFF
--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -1797,21 +1797,21 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.empty-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Standalone template VM checks
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vm.template-vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vm.template-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Standalone empty VM checks
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vm.empty-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// VM copy checks
@@ -1825,28 +1825,28 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm-copy", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Empty vApp VM checks
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.empty-vm-copy", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Standalone template VM checks
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vm.template-vm-copy", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Standalone empty VM checks
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "vm_type", "vcd_vm"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vm.empty-vm-copy", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm-copy", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 				),
 			},

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -1790,7 +1790,7 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "vm_type", "vcd_vapp_vm"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "cpus", "3"),
 					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "cpu_cores", "3"),
-					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "memory", "2048"),
+					resource.TestCheckResourceAttr("vcd_vapp_vm.template-vm", "memory", "512"),
 					resource.TestCheckResourceAttrPair("vcd_vapp_vm.template-vm", "sizing_policy_id", "vcd_vm_sizing_policy.size_full", "id"),
 
 					// Empty vApp VM checks


### PR DESCRIPTION
TestAccVcdVAppVm_4types_sizing_max
```
resource_vcd_vapp_vm_4types_test.go:1770: Step 1/1 error: Check failed: Check 8/48 error: vcd_vapp_vm.template-vm: Attribute 'memory' expected "2048", got "512"
Check 13/48 error: vcd_vapp_vm.empty-vm: Attribute 'memory' expected "2048", got "512"
Check 18/48 error: vcd_vm.template-vm: Attribute 'memory' expected "2048", got "512"
Check 23/48 error: vcd_vm.empty-vm: Attribute 'memory' expected "2048", got "512"
Check 32/48 error: vcd_vapp_vm.template-vm-copy: Attribute 'memory' expected "2048", got "512"
Check 37/48 error: vcd_vapp_vm.empty-vm-copy: Attribute 'memory' expected "2048", got "512"
Check 42/48 error: vcd_vm.template-vm-copy: Attribute 'memory' expected "2048", got "512"
Check 47/48 error: vcd_vm.empty-vm-copy: Attribute 'memory' expected "2048", got "512"
FAIL: TestAccVcdVAppVm_4types_sizing_max (294.30s)
```


Test:
```
=== RUN   TestAccVcdVAppVm_4types_sizing_max                                                                                        08:49:26 [20/3909]
--- PASS: TestAccVcdVAppVm_4types_sizing_max (503.72s)
```