### PR TITLE
Complete PR 1303

### DIFF
--- a/.changes/v3.14.0/1303-bug-fixes.md
+++ b/.changes/v3.14.0/1303-bug-fixes.md
@@ -1,2 +1,2 @@
 * Fix [Issue 1243](https://github.com/vmware/terraform-provider-vcd/issues/1243):
-  Allow unlimited `limit_in_mhz` in `vcd_vm_sizing_policy` resource [GH-1303]
+  Allow unlimited `limit_in_mhz` in `vcd_vm_sizing_policy` resource [GH-1303, GH-1318]

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -356,3 +356,5 @@ vcd.ResourceSchema-vcd_ip_space_uplink.tf v3.13.0 "Added 'associated_interface_i
 vcd.ResourceSchema-vcd_org.tf v3.13.0 "Added account_lockout block"
 vcd.ResourceSchema-vcd_rde_interface_behavior.tf v3.13.0 "Changed fields to computed and added new arguments"
 vcd.ResourceSchema-vcd_rde_type_behavior.tf v3.13.0 "Changed fields to computed and added new arguments"
+vcd.ResourceSchema-vcd_vm_sizing_policy.tf v3.13.0 "Changed description"
+vcd.ResourceSchema-vcd_vm_vgpu_policy.tf v3.13.0 "Changed description"


### PR DESCRIPTION
This PR complements #1303 by ignoring Upgrade tests for the updated schemas.