### PR TITLE
Fixes

### DIFF
--- a/.changes/v3.14.0/1295-features.md
+++ b/.changes/v3.14.0/1295-features.md
@@ -1,4 +1,4 @@
-* **New Resource:** `vcd_external_endpoint` to manage External Endpoints [GH-1295]
-* **New Data Source:** `vcd_external_endpoint` to read External Endpoints [GH-1295]
-* **New Resource:** `vcd_api_filter` to manage API Filters [GH-1295]
-* **New Data Source:** `vcd_api_filter` to read API Filters [GH-1295]
+* **New Resource:** `vcd_external_endpoint` to manage External Endpoints [GH-1295, GH-1322]
+* **New Data Source:** `vcd_external_endpoint` to read External Endpoints [GH-1295, GH-1322]
+* **New Resource:** `vcd_api_filter` to manage API Filters [GH-1295, GH-1322]
+* **New Data Source:** `vcd_api_filter` to read API Filters [GH-1295, GH-1322]

--- a/.changes/v3.14.0/1296-improvements.md
+++ b/.changes/v3.14.0/1296-improvements.md
@@ -1,2 +1,2 @@
 * Add `vcd_nsxt_alb_edgegateway_service_engine_group` and `vcd_nsxt_alb_service_engine_group` resource types to
-  `vcd_resource_list` data source [GH-1296]
+  `vcd_resource_list` data source [GH-1296, GH-1322]

--- a/.changes/v3.14.0/1297-improvements.md
+++ b/.changes/v3.14.0/1297-improvements.md
@@ -1,3 +1,3 @@
 * Add support for NSX-T Non-distributed Org VDC networks via flags `non_distributed_routing_enabled`
   in `vcd_nsxt_edgegateway` and `interface_type=non_distributed` in `vcd_network_routed_v2`
-  [GH-1297]
+  [GH-1297, GH-1322]

--- a/.changes/v3.14.0/1322-notes.md
+++ b/.changes/v3.14.0/1322-notes.md
@@ -1,0 +1,1 @@
+* Corrected a malformed HCL snippet in the *"Connecting with a Service Account API token"* section of the documentation [GH-1322]

--- a/scripts/skip-upgrade-tests.txt
+++ b/scripts/skip-upgrade-tests.txt
@@ -358,3 +358,4 @@ vcd.ResourceSchema-vcd_rde_interface_behavior.tf v3.13.0 "Changed fields to comp
 vcd.ResourceSchema-vcd_rde_type_behavior.tf v3.13.0 "Changed fields to computed and added new arguments"
 vcd.ResourceSchema-vcd_vm_sizing_policy.tf v3.13.0 "Changed description"
 vcd.ResourceSchema-vcd_vm_vgpu_policy.tf v3.13.0 "Changed description"
+vcd.ResourceSchema-vcd_network_routed_v2.tf v3.13.0 "Changed description"

--- a/vcd/datasource_vcd_resource_list_test.go
+++ b/vcd/datasource_vcd_resource_list_test.go
@@ -34,7 +34,6 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 		{name: "global_role", resourceType: "vcd_global_role", knownItem: "vApp Author"},
 		{name: "rights_bundle", resourceType: "vcd_rights_bundle", knownItem: "Default Rights Bundle"},
 		{name: "right", resourceType: "vcd_right", knownItem: "Catalog: Change Owner"},
-		{name: "alb-service-engine-group", resourceType: "vcd_nsxt_alb_service_engine_group"},
 
 		// entities belonging to an Org don't require an explicit parent, as it is given from the Org passed in the provider
 		// For each resource, we test with and without and explicit parent
@@ -43,6 +42,7 @@ func TestAccVcdDatasourceResourceList(t *testing.T) {
 
 	if usingSysAdmin() {
 		lists = append(lists, listDef{name: "admin-vdc-template", resourceType: "vcd_org_vdc_template"})
+		lists = append(lists, listDef{name: "alb-service-engine-group", resourceType: "vcd_nsxt_alb_service_engine_group"})
 	}
 
 	knownNetworkPool1 := testConfig.VCD.ProviderVdc.NetworkPool

--- a/vcd/resource_vcd_api_filter_test.go
+++ b/vcd/resource_vcd_api_filter_test.go
@@ -15,6 +15,10 @@ func TestAccVcdApiFilter(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.3") {
+		t.Skipf("This test tests VCD 10.4.3+ (API V37.3+) features. Skipping.")
+	}
+
 	var params = StringMap{
 		"Vendor":            "vmware",
 		"Name":              t.Name(),

--- a/vcd/resource_vcd_api_filter_test.go
+++ b/vcd/resource_vcd_api_filter_test.go
@@ -15,8 +15,8 @@ func TestAccVcdApiFilter(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	if checkVersion(testConfig.Provider.ApiVersion, "< 37.3") {
-		t.Skipf("This test tests VCD 10.4.3+ (API V37.3+) features. Skipping.")
+	if checkVersion(testConfig.Provider.ApiVersion, "< 38.1") {
+		t.Skipf("This test tests VCD 10.5.1+ (API V38.1+) features. Skipping.")
 	}
 
 	var params = StringMap{

--- a/vcd/resource_vcd_external_endpoint_test.go
+++ b/vcd/resource_vcd_external_endpoint_test.go
@@ -14,8 +14,8 @@ func TestAccVcdExternalEndpoint(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
-	if checkVersion(testConfig.Provider.ApiVersion, "< 37.3") {
-		t.Skipf("This test tests VCD 10.4.3+ (API V37.3+) features. Skipping.")
+	if checkVersion(testConfig.Provider.ApiVersion, "< 38.1") {
+		t.Skipf("This test tests VCD 10.5.1+ (API V38.1+) features. Skipping.")
 	}
 
 	vendor := "vmware"

--- a/vcd/resource_vcd_external_endpoint_test.go
+++ b/vcd/resource_vcd_external_endpoint_test.go
@@ -14,6 +14,10 @@ func TestAccVcdExternalEndpoint(t *testing.T) {
 	preTestChecks(t)
 	skipIfNotSysAdmin(t)
 
+	if checkVersion(testConfig.Provider.ApiVersion, "< 37.3") {
+		t.Skipf("This test tests VCD 10.4.3+ (API V37.3+) features. Skipping.")
+	}
+
 	vendor := "vmware"
 	name := t.Name()
 	version := "1.0.0"

--- a/vcd/resource_vcd_network_routed_v2_nsxt_test.go
+++ b/vcd/resource_vcd_network_routed_v2_nsxt_test.go
@@ -1135,6 +1135,7 @@ func TestAccVcdRoutedNetworkV2MetadataIgnore(t *testing.T) {
 
 func TestAccVcdRoutedNetworkV2NonDistributed(t *testing.T) {
 	preTestChecks(t)
+	skipIfNotSysAdmin(t)
 
 	// String map to fill the template
 	var params = StringMap{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -233,7 +233,6 @@ and activating a VCD Service Account can be found in the
 provider "vcd" {
   auth_type                  = "service_account_token_file"
   service_account_token_file = "token.json"
-  sysorg                     = "System"
   org                        = var.vcd_org # Default for resources
   vdc                        = var.vcd_vdc # Default for resources
   url                        = var.vcd_url

--- a/website/docs/r/api_filter.html.markdown
+++ b/website/docs/r/api_filter.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # vcd\_api\_filter
 
-Supported in provider *v3.14+* and VCD 10.4.3+.
+Supported in provider *v3.14+* and VCD 10.5.1+.
 
 Provides a resource to manage API Filters in VMware Cloud Director. An API Filter allows to extend VCD API with customised URLs
 that can be redirected to an [`vcd_external_endpoint`](/providers/vmware/vcd/latest/docs/resources/external_endpoint).

--- a/website/docs/r/external_endpoint.html.markdown
+++ b/website/docs/r/external_endpoint.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # vcd\_external\_endpoint
 
-Supported in provider *v3.14+* and VCD 10.4.3+.
+Supported in provider *v3.14+* and VCD 10.5.1+.
 
 Provides a resource to manage External Endpoints in VMware Cloud Director. An External Endpoint holds information for the
 HTTPS endpoint which requests will be proxied to when using a [`vcd_api_filter`](/providers/vmware/vcd/latest/docs/resources/api_filter).


### PR DESCRIPTION
- Fixes `TestAccVcdDatasourceResourceList/alb-service-engine-group-vcd_nsxt_alb_service_engine_group` as it must not run as Org user.
- Added skip for Org user in test `TestAccVcdRoutedNetworkV2NonDistributed` as it can't find required elements as Org user.
- Fixes typo in docs. 