### PR TITLE
Improve docs and validation wording for `vcd_tm_org` resource

### DIFF
--- a/.changes/v4.0.0/1345-features.md
+++ b/.changes/v4.0.0/1345-features.md
@@ -1,2 +1,2 @@
-* **New Resource:** `vcd_tm_org` to manage TM Organizations [GH-1345]
+* **New Resource:** `vcd_tm_org` to manage TM Organizations [GH-1345, GH-1351]
 * **New Data Source:** `vcd_tm_org` to read TM Organizations [GH-1345]

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ website/node_modules
 *.test
 *.iml
 
+# Ignore test coverage files
+*.cover
+
 vcd/vcd_test_config*.json
 vcd/go-vcloud-director.log
 vcd/test-artifacts

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -139,6 +139,10 @@ testextnetwork: fmtcheck
 # Runs the acceptance test for tm
 testtm: fmtcheck
 	@sh -c "'$(CURDIR)/scripts/runtest.sh' tm"
+# Runs the acceptance test for tm with coverage
+testtm-coverage: fmtcheck
+	@sh -c "'$(CURDIR)/scripts/runtest.sh' tm-coverage"
+
 
 testtm-binary-prepare: install
 	cd vcd && go test -tags tm -vcd-add-provider -vcd-short -v .

--- a/scripts/runtest.sh
+++ b/scripts/runtest.sh
@@ -406,6 +406,9 @@ case $wanted in
     tm)
         acceptance_test tm
         ;;
+    tm-coverage)
+        acceptance_test tm "-coverprofile=tm.cover"
+        ;;
     network)
         acceptance_test network
         ;;

--- a/vcd/resource_vcd_tm_org.go
+++ b/vcd/resource_vcd_tm_org.go
@@ -184,7 +184,7 @@ func validateRenameOrgDisabled(d *schema.ResourceData, oldCfg *govcd.TmOrg, newC
 	if d.HasChange("name") &&
 		// this condition is a negative xor - it will be matched if Org is not transitioning from or to disabled state
 		((!newCfg.IsEnabled && !oldCfg.TmOrg.IsEnabled) || newCfg.IsEnabled && oldCfg.TmOrg.IsEnabled) {
-		return fmt.Errorf("%s must be disabled (is_enabled=false) to change name", labelTmOrg)
+		return fmt.Errorf("%s must be disabled (is_enabled=false) to change name because it changes tenant login URL", labelTmOrg)
 	}
 
 	return nil

--- a/website/docs/r/tm_org.html.markdown
+++ b/website/docs/r/tm_org.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) A name for Organization with which users log in to it as it will be used in
   the URL. The Org must be disabled to or transition from previous disabled state
-  (`is_enabled=false`) to change a name because it changes tenant login URL.
+  (`is_enabled=false`) to change a name because it changes tenant login URL
 * `display_name` - (Required) A human readable name for Organization
 * `description` - (Optional) An optional description for Organization
 * `is_enabled` - (Optional) Defines if Organization is enabled. Default `true`. **Note:**

--- a/website/docs/r/tm_org.html.markdown
+++ b/website/docs/r/tm_org.html.markdown
@@ -38,7 +38,8 @@ resource "vcd_tm_org" "test" {
 The following arguments are supported:
 
 * `name` - (Required) A name for Organization with which users log in to it as it will be used in
-  the URL
+  the URL. The Org must be disabled to or transition from previous disabled state
+  (`is_enabled=false`) to change a name.
 * `display_name` - (Required) A human readable name for Organization
 * `description` - (Optional) An optional description for Organization
 * `is_enabled` - (Optional) Defines if Organization is enabled. Default `true`. **Note:**

--- a/website/docs/r/tm_org.html.markdown
+++ b/website/docs/r/tm_org.html.markdown
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) A name for Organization with which users log in to it as it will be used in
   the URL. The Org must be disabled to or transition from previous disabled state
-  (`is_enabled=false`) to change a name.
+  (`is_enabled=false`) to change a name because it changes tenant login URL.
 * `display_name` - (Required) A human readable name for Organization
 * `description` - (Optional) An optional description for Organization
 * `is_enabled` - (Optional) Defines if Organization is enabled. Default `true`. **Note:**


### PR DESCRIPTION
This PR does two things:
* Improves docs and validation message for when the `name` can be changed (requires the Org to transition from or to disabled state as was discussed in https://github.com/vmware/terraform-provider-vcd/pull/1345#discussion_r1812748530
* Adds `make testtm-coverage` command that would storage test coverage profile `tm.cover`