### PR TITLE
Adjust internal generic function signatures to include *VCDClient

### DIFF
--- a/.changes/v4.0.0/1370-notes.md
+++ b/.changes/v4.0.0/1370-notes.md
@@ -1,0 +1,1 @@
+* Add `*VCDClient` parameter to generic `crudConfig.stateStoreFunc` and `dsReadConfig.stateStoreFunc` [GH-1370]

--- a/.changes/v4.0.0/1370-notes.md
+++ b/.changes/v4.0.0/1370-notes.md
@@ -1,1 +1,2 @@
-* Add `*VCDClient` parameter to generic `crudConfig.stateStoreFunc` and `dsReadConfig.stateStoreFunc` [GH-1370]
+* Add `*VCDClient` parameter to generic methods `crudConfig.stateStoreFunc` and
+  `dsReadConfig.stateStoreFunc` [GH-1370]

--- a/vcd/datasource_vcd_tm_content_library_item.go
+++ b/vcd/datasource_vcd_tm_content_library_item.go
@@ -3,6 +3,7 @@ package vcd
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -83,7 +84,7 @@ func datasourceTmContentLibraryItemRead(_ context.Context, d *schema.ResourceDat
 		return diag.Errorf("error retrieving Content Library Item: %s", err)
 	}
 
-	err = setContentLibraryItemData(d, cli)
+	err = setContentLibraryItemData(vcdClient, d, cli)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/vcd/datasource_vcd_tm_region_zone.go
+++ b/vcd/datasource_vcd_tm_region_zone.go
@@ -79,7 +79,7 @@ func resourceVcdTmRegionZoneRead(ctx context.Context, d *schema.ResourceData, me
 	return readDatasource(ctx, d, meta, c)
 }
 
-func setZoneData(d *schema.ResourceData, z *govcd.Zone) error {
+func setZoneData(_ *VCDClient, d *schema.ResourceData, z *govcd.Zone) error {
 	if z == nil || z.Zone == nil {
 		return fmt.Errorf("nil %s", labelTmRegionZone)
 	}

--- a/vcd/resource_generic_crud.go
+++ b/vcd/resource_generic_crud.go
@@ -20,7 +20,7 @@ type crudConfig[O updateDeleter[O, I], I any] struct {
 	// getTypeFunc is responsible for converting schema fields to inner type
 	getTypeFunc func(*VCDClient, *schema.ResourceData) (*I, error)
 	// stateStoreFunc is responsible for storing state
-	stateStoreFunc func(d *schema.ResourceData, outerType O) error
+	stateStoreFunc func(vcdClient *VCDClient, d *schema.ResourceData, outerType O) error
 
 	// createFunc is the function that can create an outer entity based on inner entity config
 	// (which is created by 'getTypeFunc')
@@ -80,7 +80,7 @@ func createResource[O updateDeleter[O, I], I any](ctx context.Context, d *schema
 		return diag.Errorf("error creating %s: %s", c.entityLabel, err)
 	}
 
-	err = c.stateStoreFunc(d, createdEntity)
+	err = c.stateStoreFunc(vcdClient, d, createdEntity)
 	if err != nil {
 		return diag.Errorf("error storing %s to state during create: %s", c.entityLabel, err)
 	}
@@ -113,7 +113,7 @@ func updateResource[O updateDeleter[O, I], I any](ctx context.Context, d *schema
 	return c.resourceReadFunc(ctx, d, meta)
 }
 
-func readResource[O updateDeleter[O, I], I any](_ context.Context, d *schema.ResourceData, _ interface{}, c crudConfig[O, I]) diag.Diagnostics {
+func readResource[O updateDeleter[O, I], I any](_ context.Context, d *schema.ResourceData, meta interface{}, c crudConfig[O, I]) diag.Diagnostics {
 	retrievedEntity, err := c.getEntityFunc(d.Id())
 	if err != nil {
 		if govcd.ContainsNotFound(err) {
@@ -129,7 +129,8 @@ func readResource[O updateDeleter[O, I], I any](_ context.Context, d *schema.Res
 		return diag.Errorf("error executing read %s hooks: %s", c.entityLabel, err)
 	}
 
-	err = c.stateStoreFunc(d, retrievedEntity)
+	vcdClient := meta.(*VCDClient)
+	err = c.stateStoreFunc(vcdClient, d, retrievedEntity)
 	if err != nil {
 		return diag.Errorf("error storing %s to state during resource read: %s", c.entityLabel, err)
 	}
@@ -219,7 +220,7 @@ type dsReadConfig[O any, I any] struct {
 	entityLabel string
 
 	// stateStoreFunc is responsible for storing state
-	stateStoreFunc func(d *schema.ResourceData, outerType O) error
+	stateStoreFunc func(vcdClient *VCDClient, d *schema.ResourceData, outerType O) error
 
 	// getEntityFunc is a function that retrieves the entity
 	// It will use ID for resources and Name for data sources
@@ -227,14 +228,15 @@ type dsReadConfig[O any, I any] struct {
 }
 
 // readDatasource will read a data source by a 'name' field in Terraform schema
-func readDatasource[O any, I any](_ context.Context, d *schema.ResourceData, _ interface{}, c dsReadConfig[O, I]) diag.Diagnostics {
+func readDatasource[O any, I any](_ context.Context, d *schema.ResourceData, meta interface{}, c dsReadConfig[O, I]) diag.Diagnostics {
 	entityName := d.Get("name").(string)
 	retrievedEntity, err := c.getEntityFunc(entityName)
 	if err != nil {
 		return diag.Errorf("error getting %s by Name '%s': %s", c.entityLabel, entityName, err)
 	}
 
-	err = c.stateStoreFunc(d, retrievedEntity)
+	vcdClient := meta.(*VCDClient)
+	err = c.stateStoreFunc(vcdClient, d, retrievedEntity)
 	if err != nil {
 		return diag.Errorf("error storing %s to state during data source read: %s", c.entityLabel, err)
 	}

--- a/vcd/resource_vcd_tm_content_library_item.go
+++ b/vcd/resource_vcd_tm_content_library_item.go
@@ -214,7 +214,7 @@ func getContentLibraryItemType(_ *VCDClient, d *schema.ResourceData) (*types.Con
 	return t, nil
 }
 
-func setContentLibraryItemData(d *schema.ResourceData, cli *govcd.ContentLibraryItem) error {
+func setContentLibraryItemData(_ *VCDClient, d *schema.ResourceData, cli *govcd.ContentLibraryItem) error {
 	if cli == nil || cli.ContentLibraryItem == nil {
 		return fmt.Errorf("cannot save state for nil Content Library Item")
 	}

--- a/vcd/resource_vcd_tm_ip_space.go
+++ b/vcd/resource_vcd_tm_ip_space.go
@@ -214,7 +214,7 @@ func getTmIpSpaceType(vcdClient *VCDClient, d *schema.ResourceData) (*types.TmIp
 	return t, nil
 }
 
-func setTmIpSpaceData(d *schema.ResourceData, i *govcd.TmIpSpace) error {
+func setTmIpSpaceData(_ *VCDClient, d *schema.ResourceData, i *govcd.TmIpSpace) error {
 	if i == nil || i.TmIpSpace == nil {
 		return fmt.Errorf("nil %s received", labelTmIpSpace)
 	}

--- a/vcd/resource_vcd_tm_nsxt_manager.go
+++ b/vcd/resource_vcd_tm_nsxt_manager.go
@@ -144,7 +144,7 @@ func getNsxtManagerType(_ *VCDClient, d *schema.ResourceData) (*types.NsxtManage
 	return t, nil
 }
 
-func setNsxtManagerData(d *schema.ResourceData, t *govcd.NsxtManagerOpenApi) error {
+func setNsxtManagerData(_ *VCDClient, d *schema.ResourceData, t *govcd.NsxtManagerOpenApi) error {
 	if t == nil || t.NsxtManagerOpenApi == nil {
 		return fmt.Errorf("nil object for %s", labelNsxtManager)
 	}

--- a/vcd/resource_vcd_tm_org.go
+++ b/vcd/resource_vcd_tm_org.go
@@ -214,7 +214,7 @@ func getTmOrgType(_ *VCDClient, d *schema.ResourceData) (*types.TmOrg, error) {
 	return t, nil
 }
 
-func setTmOrgData(d *schema.ResourceData, org *govcd.TmOrg) error {
+func setTmOrgData(_ *VCDClient, d *schema.ResourceData, org *govcd.TmOrg) error {
 	if org == nil || org.TmOrg == nil {
 		return fmt.Errorf("cannot save state for nil Org")
 	}

--- a/vcd/resource_vcd_tm_org_vdc.go
+++ b/vcd/resource_vcd_tm_org_vdc.go
@@ -200,7 +200,7 @@ func getTmVdcType(_ *VCDClient, d *schema.ResourceData) (*types.TmVdc, error) {
 	return t, nil
 }
 
-func setTmVdcData(d *schema.ResourceData, vdc *govcd.TmVdc) error {
+func setTmVdcData(_ *VCDClient, d *schema.ResourceData, vdc *govcd.TmVdc) error {
 	if vdc == nil {
 		return fmt.Errorf("provided VDC is nil")
 	}

--- a/vcd/resource_vcd_tm_region.go
+++ b/vcd/resource_vcd_tm_region.go
@@ -184,7 +184,7 @@ func getRegionType(vcdClient *VCDClient, d *schema.ResourceData) (*types.Region,
 	return t, nil
 }
 
-func setRegionData(d *schema.ResourceData, r *govcd.Region) error {
+func setRegionData(_ *VCDClient, d *schema.ResourceData, r *govcd.Region) error {
 	if r == nil || r.Region == nil {
 		return fmt.Errorf("nil Region entity")
 	}

--- a/vcd/resource_vcd_tm_vcenter.go
+++ b/vcd/resource_vcd_tm_vcenter.go
@@ -136,7 +136,7 @@ func getTmVcenterType(_ *VCDClient, d *schema.ResourceData) (*types.VSphereVirtu
 	return t, nil
 }
 
-func setTmVcenterData(d *schema.ResourceData, v *govcd.VCenter) error {
+func setTmVcenterData(_ *VCDClient, d *schema.ResourceData, v *govcd.VCenter) error {
 	if v == nil || v.VSphereVCenter == nil {
 		return fmt.Errorf("nil object for %s", labelTmVirtualCenter)
 	}


### PR DESCRIPTION
Add `*VCDClient` parameter to `crudConfig.stateStoreFunc` and `dsReadConfig.stateStoreFunc`
It will be used #1361, but splitting it off so that #1361 is less crowded. 
