### PR TITLE
Test adjusments in release/v3.x

### DIFF
--- a/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_standalone_vm_with_vm_sizing_test.go
@@ -42,7 +42,7 @@ func TestAccVcdStandaloneVmWithVmSizing(t *testing.T) {
 		"ProviderVdc":               testConfig.VCD.NsxtProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.NsxtProviderVdc.NetworkPool,
 		"Allocated":                 "10240",
-		"Reserved":                  "0",
+		"Reserved":                  "10240",
 		"Limit":                     "10240",
 		"ProviderVdcStorageProfile": testConfig.VCD.NsxtProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
@@ -287,15 +287,15 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   allocation_model  = "{{.AllocationModel}}"
   network_pool_name = "{{.NetworkPool}}"
   provider_vdc_name = "{{.ProviderVdc}}"
+  memory_guaranteed = 1
+  cpu_guaranteed    = 1
 
   compute_capacity {
     cpu {
-      allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
 
     memory {
-      allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
   }

--- a/vcd/resource_vcd_vapp_vm_4types_test.go
+++ b/vcd/resource_vcd_vapp_vm_4types_test.go
@@ -1497,15 +1497,15 @@ resource "vcd_org_vdc" "sizing-policy" {
   allocation_model  = "{{.AllocationModel}}"
   network_pool_name = "{{.NetworkPool}}"
   provider_vdc_name = "{{.ProviderVdc}}"
+  memory_guaranteed = 1
+  cpu_guaranteed    = 1
 
   compute_capacity {
     cpu {
-      allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
 
     memory {
-      allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
   }
@@ -1739,7 +1739,7 @@ func TestAccVcdVAppVm_4types_sizing_max(t *testing.T) {
 
 		"AllocationModel":           "Flex",
 		"Allocated":                 "40000",
-		"Reserved":                  "0",
+		"Reserved":                  "40000",
 		"Limit":                     "40000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
@@ -2053,7 +2053,7 @@ func TestAccVcdVAppVm_4types_sizing_cpu_only(t *testing.T) {
 
 		"AllocationModel":           "Flex",
 		"Allocated":                 "30000",
-		"Reserved":                  "0",
+		"Reserved":                  "30000",
 		"Limit":                     "32000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),

--- a/vcd/resource_vcd_vapp_vm_boot_options_test.go
+++ b/vcd/resource_vcd_vapp_vm_boot_options_test.go
@@ -91,43 +91,43 @@ func TestAccVcdVAppVmBootOptions(t *testing.T) {
 					resource.TestCheckResourceAttr(vmWithTemplate, "firmware", "efi"),
 
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "2"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "2"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "1200"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "12000"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 				),
 			},
@@ -135,43 +135,43 @@ func TestAccVcdVAppVmBootOptions(t *testing.T) {
 				Config: configText2,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "firmware", "bios"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "firmware", "bios"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "firmware", "bios"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_enabled", "true"),
 
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "firmware", "bios"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.efi_secure_boot", "false"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "1"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "1"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "1100"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "11000"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_enabled", "true"),
 				),
 			},
@@ -179,43 +179,43 @@ func TestAccVcdVAppVmBootOptions(t *testing.T) {
 				Config: configText3,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr(emptyVapp, "boot_options.0.boot_retry_enabled", "false"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr("data."+emptyVapp, "boot_options.0.boot_retry_enabled", "false"),
 
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr(vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "false"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr("data."+vappVmWithTemplate, "boot_options.0.boot_retry_enabled", "false"),
 
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr(emptyVM, "boot_options.0.boot_retry_enabled", "false"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr("data."+emptyVM, "boot_options.0.boot_retry_enabled", "false"),
 
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr(vmWithTemplate, "boot_options.0.boot_retry_enabled", "false"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "firmware", "efi"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.efi_secure_boot", "true"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "0"),
-					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "0"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_delay", "1000"),
+					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_delay", "10000"),
 					resource.TestCheckResourceAttr("data."+vmWithTemplate, "boot_options.0.boot_retry_enabled", "false"),
 				),
 			},
@@ -296,9 +296,9 @@ resource "vcd_vapp_vm" "{{.VappVMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot               = true
-    boot_retry_delay              = 2
+    boot_retry_delay              = 12000
     boot_retry_enabled            = true
-    boot_delay                    = 2
+    boot_delay                    = 1200
     enter_bios_setup_on_next_boot = true
   }
 }
@@ -322,9 +322,9 @@ resource "vcd_vapp_vm" "{{.VappVMName}}" {
 
   boot_options {
     efi_secure_boot               = true
-    boot_retry_delay              = 2
+    boot_retry_delay              = 12000
     boot_retry_enabled            = true
-    boot_delay                    = 2
+    boot_delay                    = 1200
     enter_bios_setup_on_next_boot = true
   }
 }
@@ -347,9 +347,9 @@ resource "vcd_vm" "{{.EmptyVMName}}" {
 
   boot_options {
     efi_secure_boot               = true
-    boot_retry_delay              = 2
+    boot_retry_delay              = 12000
     boot_retry_enabled            = true
-    boot_delay                    = 2
+    boot_delay                    = 1200
     enter_bios_setup_on_next_boot = true
   }
 }
@@ -368,9 +368,9 @@ resource "vcd_vm" "{{.VMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot               = true
-    boot_retry_delay              = 2
+    boot_retry_delay              = 12000
     boot_retry_enabled            = true
-    boot_delay                    = 2
+    boot_delay                    = 1200
     enter_bios_setup_on_next_boot = true
   }
 }
@@ -393,8 +393,8 @@ resource "vcd_vapp_vm" "{{.VappVMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot    = false
-    boot_retry_delay   = 1
-    boot_delay         = 1
+    boot_retry_delay   = 11000
+    boot_delay         = 1100
     boot_retry_enabled = true
   }
 }
@@ -418,8 +418,8 @@ resource "vcd_vapp_vm" "{{.VappVMName}}" {
 
   boot_options {
     efi_secure_boot    = false
-    boot_retry_delay   = 1
-    boot_delay         = 1
+    boot_retry_delay   = 11000
+    boot_delay         = 1100
     boot_retry_enabled = true
   }
 }
@@ -442,8 +442,8 @@ resource "vcd_vm" "{{.EmptyVMName}}" {
 
   boot_options {
     efi_secure_boot    = false
-    boot_retry_delay   = 1
-    boot_delay         = 1
+    boot_retry_delay   = 11000
+    boot_delay         = 1100
     boot_retry_enabled = true
   }
 }
@@ -462,8 +462,8 @@ resource "vcd_vm" "{{.VMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot    = false
-    boot_retry_delay   = 1
-    boot_delay         = 1
+    boot_retry_delay   = 11000
+    boot_delay         = 1100
     boot_retry_enabled = true
   }
 }
@@ -486,8 +486,8 @@ resource "vcd_vapp_vm" "{{.VappVMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot    = true
-    boot_retry_delay   = 0
-    boot_delay         = 0
+    boot_retry_delay   = 10000
+    boot_delay         = 1000
     boot_retry_enabled = false
   }
 }
@@ -511,8 +511,8 @@ resource "vcd_vapp_vm" "{{.VappVMName}}" {
 
   boot_options {
     efi_secure_boot    = true
-    boot_retry_delay   = 0
-    boot_delay         = 0
+    boot_retry_delay   = 10000
+    boot_delay         = 1000
     boot_retry_enabled = false
   }
 }
@@ -535,8 +535,8 @@ resource "vcd_vm" "{{.EmptyVMName}}" {
 
   boot_options {
     efi_secure_boot    = true
-    boot_retry_delay   = 0
-    boot_delay         = 0
+    boot_retry_delay   = 10000
+    boot_delay         = 1000
     boot_retry_enabled = false
   }
 }
@@ -555,8 +555,8 @@ resource "vcd_vm" "{{.VMWithTemplateName}}" {
 
   boot_options {
     efi_secure_boot    = true
-    boot_retry_delay   = 0
-    boot_delay         = 0
+    boot_retry_delay   = 10000
+    boot_delay         = 1000
     boot_retry_enabled = false
   }
 }

--- a/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
+++ b/vcd/resource_vcd_vapp_vm_with_vm_sizing_test.go
@@ -41,7 +41,7 @@ func TestAccVcdVAppVmWithVmSizing(t *testing.T) {
 		"ProviderVdc":               testConfig.VCD.ProviderVdc.Name,
 		"NetworkPool":               testConfig.VCD.ProviderVdc.NetworkPool,
 		"Allocated":                 "16000",
-		"Reserved":                  "0",
+		"Reserved":                  "16000",
 		"Limit":                     "16000",
 		"ProviderVdcStorageProfile": testConfig.VCD.ProviderVdc.StorageProfile,
 		"FuncName":                  t.Name(),
@@ -349,15 +349,17 @@ resource "vcd_org_vdc" "{{.VdcName}}" {
   allocation_model  = "{{.AllocationModel}}"
   network_pool_name = "{{.NetworkPool}}"
   provider_vdc_name = "{{.ProviderVdc}}"
+  memory_guaranteed = 1
+  cpu_guaranteed    = 1
 
   compute_capacity {
     cpu {
-      allocated = "{{.Allocated}}"
+      # allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
 
     memory {
-      allocated = "{{.Allocated}}"
+      # allocated = "{{.Allocated}}"
       limit     = "{{.Limit}}"
     }
   }

--- a/vcd/resource_vcd_vm_placement_policy_test.go
+++ b/vcd/resource_vcd_vm_placement_policy_test.go
@@ -360,7 +360,7 @@ func TestAccVcdVmPlacementPolicyWithoutDescription(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 	}
 	vmPlacementPolicyDescription := "This is a system generated default compute policy auto assigned to this vDC."
-	if vcdClient.Client.APIVCDMaxVersionIs("< 38.0") {
+	if vcdClient.Client.APIVCDMaxVersionIs("< 38.0") || vcdClient.Client.APIVCDMaxVersionIs("> 39.0") {
 		vmPlacementPolicyDescription = ""
 	}
 

--- a/vcd/resource_vcd_vm_placement_policy_test.go
+++ b/vcd/resource_vcd_vm_placement_policy_test.go
@@ -38,7 +38,7 @@ func TestAccVcdVmPlacementPolicy(t *testing.T) {
 		t.Skip(acceptanceTestsSkipped)
 	}
 	vmPlacementPolicyDescription := "This is a system generated default compute policy auto assigned to this vDC."
-	if vcdClient.Client.APIVCDMaxVersionIs("< 38.0") {
+	if vcdClient.Client.APIVCDMaxVersionIs("< 38.0") || vcdClient.Client.APIVCDMaxVersionIs("> 39.0") {
 		vmPlacementPolicyDescription = ""
 	}
 


### PR DESCRIPTION
Only **test** files have changes.

* Newly created policy `vcd_vm_placement_policy` does not get default `This is a system generated default compute policy auto assigned to this vDC.` when description is not specified. Tests `TestAccVcdVmPlacementPolicy`, `TestAccVcdVmPlacementPolicyWithoutDescription`
* Improve invalid VDC configuration for tests `TestAccVcdStandaloneVmWithVmSizing`, `TestAccVcdVAppVm_4types_sizing_max`, `TestAccVcdVAppVm_4types_sizing_cpu_only`, `TestAccVcdVAppVmWithVmSizing`
* Tune boot retry delay settings in vcd_vapp_vm test  `TestAccVcdVAppVmBootOptions`